### PR TITLE
Use absolute path for project_dir context object

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -65,12 +65,14 @@ def create_new_project_skeleton(project_name, profile=None):
 @click.pass_context
 def cli(ctx, project_dir, debug=False):
     # type: (click.Context, str, bool) -> None
-    if project_dir is None:
-        project_dir = os.getcwd()
-    ctx.obj['project_dir'] = project_dir
+    abs_project_dir = os.path.join(
+        os.getenv('PWD'), project_dir
+    ) if project_dir else os.getcwd()
+
+    ctx.obj['project_dir'] = abs_project_dir
     ctx.obj['debug'] = debug
-    ctx.obj['factory'] = CLIFactory(project_dir, debug)
-    os.chdir(project_dir)
+    ctx.obj['factory'] = CLIFactory(abs_project_dir, debug)
+    os.chdir(abs_project_dir)
 
 
 @cli.command()


### PR DESCRIPTION
The --project-dir option was not correctly calculating the path to open up the
config file. This would result in valid `project_dir` values raising an OSError
and presenting this error message to the user:

```
$ ls
drwxr-xr-x  6 chris  staff   204B Jul 12 17:24 sample/
...
...
$ chalice --project-dir sample deploy
Unable to load the project config file. Are you sure this is a chalice project?
```