### PR TITLE
Add lambda context to app properties

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -558,6 +558,7 @@ class Chalice(object):
         view_function = route_entry.view_function
         function_args = [event['pathParameters'][name]
                          for name in route_entry.view_args]
+        self.lambda_context = context
         self.current_request = Request(event['queryStringParameters'],
                                        event['headers'],
                                        event['pathParameters'],


### PR DESCRIPTION
An application may need access to the variables inside the lambda context such as any of these things:
```
{
    "aws_request_id": "0ff8542d-6a2b-11e7-b421-xxxxxxxxxxxx",
    "log_stream_name": "2017/07/16/[$LATEST]xxxcccxxxxxxxxxxxxxcccxxxxxxxxxx",
    "invoked_function_arn": "arn:aws:lambda:us-west-1:nnnnnnnnn:function:xxxxxx",
    "client_context": null,
    "log_group_name": "/aws/lambda/xxxxxxx",
    "function_name": "xxxxxxx",
    "function_version": "$LATEST",
    "memory_limit_in_mb": "256"
}
```
This provides a barebones minimum way of doing so.