### PR TITLE
Fix log level out of sync with debug mode

### DIFF
--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1185,3 +1185,32 @@ def test_can_use_out_of_order_args():
     response = demo(event, context=None)
     response = json_response_body(response)
     assert response == {'a': 'first', 'b': 'second'}
+
+
+def test_ensure_debug_mode_is_false_by_default():
+    # These logger tests need to each have a unique name because the Chalice
+    # app creates a logger with it's name. If these tests are run in a batch
+    # the logger names will overlap in the logging module and cause test
+    # failures.
+    test_app = app.Chalice('logger-test-1')
+    assert test_app.debug is False
+    assert test_app.log.getEffectiveLevel() == logging.ERROR
+
+
+def test_can_explicitly_set_debug_false_in_initializer():
+    test_app = app.Chalice('logger-test-2', debug=False)
+    assert test_app.debug is False
+    assert test_app.log.getEffectiveLevel() == logging.ERROR
+
+
+def test_can_set_debug_mode_in_initialzier():
+    test_app = app.Chalice('logger-test-3', debug=True)
+    assert test_app.debug is True
+    assert test_app.log.getEffectiveLevel() == logging.DEBUG
+
+
+def test_debug_mode_changes_log_level():
+    test_app = app.Chalice('logger-test-4', debug=False)
+    test_app.debug = True
+    assert test_app.debug is True
+    assert test_app.log.getEffectiveLevel() == logging.DEBUG


### PR DESCRIPTION
Debug mode can be set with `app.debug = True` which does not update
the logger level from ERROR to DEBUG. This is has been replaced with a
setter that reconfigures the log level after debug is reset. The
initialization method on the Chalice class had some logic that checked
what the debug value was and configured the logger to match; however,
debug was hardcoded to be False so this never did anything useful. A
debug parameter has been added to the the __init__ method to make this
more useful, it defaults to False.

fixes #386 
cc @jamesls @kyleknap 