### PR TITLE
Add support for wildcard routes and methods

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -749,11 +749,16 @@ class AuthResponse(object):
             if isinstance(route, AuthRoute):
                 methods = route.methods
                 path = route.path
+            elif route == '*':
+                # A string route of '*' means that all paths and
+                # all HTTP methods are now allowed.
+                methods = ['*']
+                path = '*'
             else:
                 # If 'route' is just a string, then they've
                 # opted not to use the AuthRoute(), so we'll
                 # generate a policy that allows all HTTP methods.
-                methods = self.ALL_HTTP_METHODS
+                methods = ['*']
                 path = route
             for method in methods:
                 allowed_resources.append(
@@ -775,11 +780,12 @@ class AuthResponse(object):
         # '/'.join(...)'d properly.
         base.extend([method, route[1:]])
         last_arn_segment = '/'.join(base)
-        if route == '/':
+        if route == '/' or route == '*':
             # We have to special case the '/' case.  For whatever
             # reason, API gateway adds an extra '/' to the method_arn
             # of the auth request, so we need to do the same thing.
-            last_arn_segment += '/'
+            # We also have to handle the '*' case which is for wildcards
+            last_arn_segment += route
         final_arn = '%s:%s' % (parts[0], last_arn_segment)
         return final_arn
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -368,7 +368,9 @@ These classes are used when defining built-in authoriers in Chalice.
       an instance of ``AuthRoute``.  If you specify the URL as
       a string, then all supported HTTP methods will be authorized.
       If you want to specify which HTTP methods are allowed, you
-      can use ``AuthRoute``.
+      can use ``AuthRoute``.  If you want to specify that all
+      routes and HTTP methods are supported you can use the
+      wildcard value of ``"*"``: ``AuthResponse(routes=['*'], ...)``
 
    .. attribute:: principal_id
 


### PR DESCRIPTION
Fixes #403.

As part of this change, I switched the static list of HTTP
methods to use '*'.  This cuts down on the verbosity of the
policy and makes the string routes and the AuthRoutes() more
consistent in the policies they generate.