### PR TITLE
Issue #450: Chalice generate-pipeline can create  incompatible yaml

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -2,6 +2,7 @@ import os
 import copy
 import json
 import hashlib
+import re
 
 from typing import Any, Dict  # noqa
 
@@ -150,7 +151,7 @@ class SAMTemplateGenerator(object):
         events = {}
         for methods in app.routes.values():
             for http_method, view in methods.items():
-                mod_view_name = filter(str.isalnum, view.view_name)
+                mod_view_name = re.sub(r'[^A-Za-z0-9]+', '', view.view_name)
                 key_name = ''.join([
                     mod_view_name, http_method.lower(),
                     hashlib.md5(

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -150,8 +150,9 @@ class SAMTemplateGenerator(object):
         events = {}
         for methods in app.routes.values():
             for http_method, view in methods.items():
+                mod_view_name = filter(str.isalnum, view.view_name)
                 key_name = ''.join([
-                    view.view_name, http_method.lower(),
+                    mod_view_name, http_method.lower(),
                     hashlib.md5(
                         view.view_name.encode('utf-8')).hexdigest()[:4],
                 ])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,3 +32,14 @@ def sample_app_with_auth():
         return {}
 
     return app
+
+
+@fixture
+def sample_app_incompatible_with_cf():
+    app = Chalice('sample_invalid_cf')
+
+    @app.route('/')
+    def foo_invalid():
+        return {}
+
+    return app

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1,6 +1,7 @@
 import mock
 
 import pytest
+import re
 from chalice.config import Config
 from chalice import package
 from chalice import __version__ as chalice_version
@@ -273,3 +274,21 @@ def test_fails_with_custom_auth(sample_app_with_auth,
         app_name='myapp', manage_iam_role=False, iam_role_arn='role-arn')
     with pytest.raises(package.UnsupportedFeatureError):
         p.generate_sam_template(config)
+
+
+def test_app_incompatible_with_cf(sample_app_incompatible_with_cf,
+                                  mock_swagger_generator,
+                                  mock_policy_generator):
+    p = package.SAMTemplateGenerator(
+        mock_swagger_generator, mock_policy_generator)
+    mock_swagger_generator.generate_swagger.return_value = {
+        'swagger': 'document'
+    }
+    config = Config.create(chalice_app=sample_app_incompatible_with_cf,
+                           api_gateway_stage='dev',
+                           app_name='sample_invalid_cf')
+    template = p.generate_sam_template(config)
+    check_exp = re.compile(r'[^A-Za-z0-9]+')
+    events = template['Resources']['APIHandler']['Properties']['Events']
+    for k in events.keys():
+        assert not check_exp.search(k)


### PR DESCRIPTION
If function name in `app.py` contains '_' or special characters,  invalid cloudformation template is created.  We need to remove the special characters before generating cloudformation template. 


 