### PR TITLE
Show user friendly error message if config.json is invalid

### DIFF
--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -96,6 +96,10 @@ class CLIFactory(object):
         except (OSError, IOError):
             raise RuntimeError("Unable to load the project config file. "
                                "Are you sure this is a chalice project?")
+        except ValueError as err:
+            raise RuntimeError("Unable to load the project config file. "
+                               "Cause: %s. " % repr(err))
+
         self._validate_config_from_disk(config_from_disk)
         app_obj = self.load_chalice_app()
         user_provided_params['chalice_app'] = app_obj

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -155,7 +155,5 @@ def test_error_raised_on_invalid_config_json(clifactory):
     with open(filename, 'w') as f:
         f.write("INVALID_JSON")
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(RuntimeError):
         clifactory.create_config_obj()
-
-    assert 'ValueError' in str(excinfo.value), "Expecting ValueError in error message"

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -147,3 +147,15 @@ def test_can_import_vendor_package(clifactory):
     app = clifactory.load_chalice_app()
     assert app.imported_value == 'foo bar'
     assert sys.path[-1] == vendor_lib
+
+
+def test_error_raised_on_invalid_config_json(clifactory):
+    filename = os.path.join(
+        clifactory.project_dir, '.chalice', 'config.json')
+    with open(filename, 'w') as f:
+        f.write("INVALID_JSON")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        clifactory.create_config_obj()
+
+    assert 'ValueError' in str(excinfo.value), "Expecting ValueError in error message"


### PR DESCRIPTION


If my config.json is invalid json, I see this error message in chalice package.
```
$ chalice package .
Expecting property name: line 5 column 5 (char 67) 
```

This is not a very friendly error message and took me a while to figure out my config.json was invalid. It would help if we print a proper error message.