### PR TITLE
Auto Generate policy not working for pure lambda function and schedule. 

### DIFF
--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -618,6 +618,12 @@ class AppViewTransformer(ast.NodeTransformer):
                 if decorator.func.attr == 'route' and \
                         decorator.args:
                     return True
+
+                # For lambda_function and schedule decorator.args
+                # not present.
+                if decorator.func.attr in ('lambda_function', 'schedule'):
+                    return True
+
         return False
 
     def _auto_invoke_view(self, node):

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -150,8 +150,9 @@ class SAMTemplateGenerator(object):
         events = {}
         for methods in app.routes.values():
             for http_method, view in methods.items():
+                mod_view_name = filter(str.isalnum, view.view_name)
                 key_name = ''.join([
-                    view.view_name, http_method.lower(),
+                    mod_view_name, http_method.lower(),
                     hashlib.md5(
                         view.view_name.encode('utf-8')).hexdigest()[:4],
                 ])


### PR DESCRIPTION
### Problem
Auto gen policy feature not working for ```lambda_function``` and ```schedule```

###  Steps to reproduce

1. Create a sample app as follows : 

```
from chalice import Chalice
import boto3
s3cli = boto3.client('s3')

app = Chalice(app_name='autogen_test')

@app.route('/')
def index():
    s3cli.put_object()
    return {'hello': 'world'}


@app.lambda_function(name="myPureLambda")
def lam1(event, context):
    s3cli.list_buckets()
    return {'hello': 'world'}


@app.schedule('rate(1 hour)')
def every_hour(event):
    s3cli.create_bucket()
    return {'hello': 'world'}
```

2. Generate policy 

```
$ chalice gen-policy
```
```
{
  "Version": "2012-10-17", 
  "Statement": [
    {
      "Action": [
        "s3:PutObject"
      ], 
      "Resource": [
        "*"
      ], 
      "Effect": "Allow", 
      "Sid": "f7e7ae79eca44676b9b8ac4941e3e4af"
    }
  ]
}
```

From the output it is clear that policy for ```lambda_function``` and ```schedule```  not getting generated. Because of this function invocation failed with  permission denied error 

```
ClientError: An error occurred (AccessDenied) when calling the ListBuckets operation: Access Denied
```  

