### PR TITLE
Enable auto policy generation for lamdba_function and schedule events

### DIFF
--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -618,6 +618,10 @@ class AppViewTransformer(ast.NodeTransformer):
                 if decorator.func.attr == 'route' and \
                         decorator.args:
                     return True
+                # For lambda_function and schedule decorator.args
+                # not present.
+                if decorator.func.attr in ('lambda_function', 'schedule'):
+                    return True
         return False
 
     def _auto_invoke_view(self, node):

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -509,10 +509,16 @@ def test_can_analyze_combination():
         def index_sc():
             s3.list_buckets()
             return {}
+
         @app.lambda_function(name='lambda1')
         def index_lm():
             ec.describe_instances()
             return {}
+
+        @random
+        def foo():
+            return {}
+
     """) == {'s3': set(['list_buckets']),
              'ec2': set(['describe_instances'])}
 

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -468,6 +468,54 @@ def test_can_handle_multiple_listcomps():
     """) == {}
 
 
+def test_can_analyze_lambda_function():
+    assert chalice_aws_calls("""\
+        from chalice import Chalice
+        import boto3
+        app = Chalice(app_name='james1')
+        ec2 = boto3.client('ec2')
+        @app.lambda_function(name='lambda1')
+        def index():
+            ec2.describe_instances()
+            return {}
+    """) == {'ec2': set(['describe_instances'])}
+
+
+def test_can_analyze_schedule():
+    assert chalice_aws_calls("""\
+        from chalice import Chalice
+        import boto3
+        app = Chalice(app_name='james1')
+        s3cli = boto3.client('s3')
+        @app.schedule('rate(1 hour)')
+        def index():
+            s3cli.list_buckets()
+            return {}
+    """) == {'s3': set(['list_buckets'])}
+
+
+def test_can_analyze_combination():
+    assert chalice_aws_calls("""\
+        from chalice import Chalice
+        import boto3
+        app = Chalice(app_name='james1')
+        s3 = boto3.client('s3')
+        ec = boto3.client('ec2')
+        @app.route('/')
+        def index():
+            ec2.describe_instances()
+            return {}
+        @app.schedule('rate(1 hour)')
+        def index_sc():
+            s3.list_buckets()
+            return {}
+        @app.lambda_function(name='lambda1')
+        def index_lm():
+            ec.describe_instances()
+            return {}
+    """) == {'s3': set(['list_buckets']),
+             'ec2': set(['describe_instances'])}
+
 # def test_can_handle_dict_comp():
 #     assert aws_calls("""\
 #         import boto3


### PR DESCRIPTION
### Problem
Auto gen policy feature not working for ```lambda_function``` and ```schedule```

###  Steps to reproduce

1. Create a sample app as follows : 

```
from chalice import Chalice
import boto3
s3cli = boto3.client('s3')

app = Chalice(app_name='autogen_test')

@app.route('/')
def index():
    s3cli.put_object()
    return {'hello': 'world'}


@app.lambda_function(name="myPureLambda")
def lam1(event, context):
    s3cli.list_buckets()
    return {'hello': 'world'}


@app.schedule('rate(1 hour)')
def every_hour(event):
    s3cli.create_bucket()
    return {'hello': 'world'}
```

2. Generate policy 

```
$ chalice gen-policy
```
```
{
  "Version": "2012-10-17", 
  "Statement": [
    {
      "Action": [
        "s3:PutObject"
      ], 
      "Resource": [
        "*"
      ], 
      "Effect": "Allow", 
      "Sid": "f7e7ae79eca44676b9b8ac4941e3e4af"
    }
  ]
}
```

From the output it is clear that policy for ```lambda_function``` and ```schedule```  not getting generated. Because of this function invocation failed with  permission denied error 

```
ClientError: An error occurred (AccessDenied) when calling the ListBuckets operation: Access Denied
```  

### Fix

Enhanced analyzer.py to support policy generation for both types. 
