### PR TITLE
Improve output for 'chalice deploy'

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -24,7 +24,7 @@ from chalice.utils import create_zip_file
 from chalice.utils import record_deployed_values
 from chalice.utils import remove_stage_from_deployed_values
 from chalice.deploy.deployer import validate_python_version
-from chalice.utils import getting_started_prompt
+from chalice.utils import getting_started_prompt, UI
 from chalice.constants import CONFIG_VERSION, TEMPLATE_APP, GITIGNORE
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
@@ -124,7 +124,7 @@ def deploy(ctx, autogen_policy, profile, api_gateway_stage, stage):
         api_gateway_stage=api_gateway_stage,
     )
     session = factory.create_botocore_session()
-    d = factory.create_default_deployer(session=session, prompter=click)
+    d = factory.create_default_deployer(session=session, ui=UI())
     deployed_values = d.deploy(config, chalice_stage_name=stage)
     record_deployed_values(deployed_values, os.path.join(
         config.project_dir, '.chalice', 'deployed.json'))
@@ -141,7 +141,7 @@ def delete(ctx, profile, stage):
     factory.profile = profile
     config = factory.create_config_obj(chalice_stage_name=stage)
     session = factory.create_botocore_session()
-    d = factory.create_default_deployer(session=session, prompter=click)
+    d = factory.create_default_deployer(session=session, ui=UI())
     d.delete(config, chalice_stage_name=stage)
     remove_stage_from_deployed_values(stage, os.path.join(
         config.project_dir, '.chalice', 'deployed.json'))

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -17,6 +17,7 @@ from chalice.package import AppPackager  # noqa
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.logs import LogRetriever
 from chalice import local
+from chalice.utils import UI  # noqa
 
 
 def create_botocore_session(profile=None, debug=False):
@@ -80,10 +81,10 @@ class CLIFactory(object):
         return create_botocore_session(profile=self.profile,
                                        debug=self.debug)
 
-    def create_default_deployer(self, session, prompter):
-        # type: (Session, deployer.NoPrompt) -> deployer.Deployer
+    def create_default_deployer(self, session, ui):
+        # type: (Session, UI) -> deployer.Deployer
         return deployer.create_default_deployer(
-            session=session, prompter=prompter)
+            session=session, ui=ui)
 
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None, api_gateway_stage=None):

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -201,4 +201,5 @@ the chalice vendor folder.
 Your deployment will continue but may not work correctly
 if missing dependencies are not present. For more information:
 http://chalice.readthedocs.io/en/latest/topics/packaging.html
+
 """

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -688,7 +688,6 @@ class LambdaDeployer(object):
         # Creates a lambda function and returns the
         # function arn.
         # First we need to create a deployment package.
-        self._ui.write("Initial creation of lambda function.\n")
         role_arn = self._get_or_create_lambda_role_arn(config, function_name)
         zip_filename = self._packager.create_deployment_package(
             config.project_dir, config.lambda_python_version)
@@ -789,7 +788,7 @@ class APIGatewayDeployer(object):
             rest_api_id = existing_resources.rest_api_id
             return self._create_resources_for_api(
                 config, rest_api_id, deployed_resources)
-        self._ui.write("Initiating first time deployment...\n")
+        self._ui.write("Initiating first time deployment.\n")
         return self._first_time_deploy(config, deployed_resources)
 
     def _first_time_deploy(self, config, deployed_resources):

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -722,7 +722,6 @@ class LambdaDeployer(object):
 
     def _update_lambda_function(self, config, lambda_name, stage_name):
         # type: (Config, str, str) -> Dict[str, Any]
-        self._ui.write("Updating lambda function...\n")
         project_dir = config.project_dir
         packager = self._packager
         deployment_package_filename = packager.deployment_package_filename(

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -324,12 +324,6 @@ class ChaliceDeploymentError(Exception):
         return '%.1f MB' % (float(value) / (1024 ** 2))
 
 
-class NoPrompt(object):
-    def confirm(self, text, default=False, abort=False):
-        # type: (str, bool, bool) -> bool
-        return default
-
-
 class Deployer(object):
 
     BACKEND_NAME = 'api'

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -209,7 +209,7 @@ class LambdaDeploymentPackager(object):
         # a way to do this efficiently so we need to create a new
         # zip file that has all the same stuff except for the new
         # app file.
-        self._ui.write("Regen deployment package...\n")
+        self._ui.write("Regen deployment package.\n")
         tmpzip = deployment_package_filename + '.tmp.zip'
 
         with self._osutils.open_zip(deployment_package_filename, 'r') as inzip:

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -8,10 +8,11 @@ from typing import Any, Dict  # noqa
 from chalice.deploy.swagger import CFNSwaggerGenerator
 from chalice.deploy.swagger import SwaggerGenerator  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
+from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.deployer import ApplicationPolicyHandler
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
-from chalice.utils import OSUtils
+from chalice.utils import OSUtils, UI
 from chalice.config import Config  # noqa
 from chalice.app import Chalice  # noqa
 from chalice.policy import AppPolicyGenerator
@@ -20,6 +21,7 @@ from chalice.policy import AppPolicyGenerator
 def create_app_packager(config):
     # type: (Config) -> AppPackager
     osutils = OSUtils()
+    ui = UI()
     # The config object does not handle a default value
     # for autogen'ing a policy so we need to handle this here.
     return AppPackager(
@@ -31,7 +33,11 @@ def create_app_packager(config):
                 config,
                 ApplicationPolicyHandler(
                     osutils, AppPolicyGenerator(osutils)))),
-        LambdaDeploymentPackager()
+        LambdaDeploymentPackager(
+            osutils=osutils,
+            dependency_builder=DependencyBuilder(osutils),
+            ui=ui,
+        )
     )
 
 

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -35,6 +35,7 @@ from chalice.deploy.deployer import validate_route_content_types
 from chalice.deploy.deployer import validate_python_version
 from chalice.deploy.deployer import validate_unique_function_names
 from chalice.deploy.packager import LambdaDeploymentPackager
+from chalice.utils import UI
 
 
 _SESSION = None
@@ -59,17 +60,6 @@ class InMemoryOSUtils(object):
 
     def set_file_contents(self, filename, contents, binary=True):
         self.filemap[filename] = contents
-
-
-class CustomConfirmPrompt():
-    def __init__(self, confirm_response=False):
-        self._confirm_response = confirm_response
-
-    def confirm(self, text, default=False, abort=False):
-        return self._confirm_response
-
-    def Abort(self):
-        return Exception('Aborted!')
 
 
 @fixture
@@ -113,7 +103,12 @@ def config_obj(sample_app):
     return config
 
 
-def test_api_gateway_deployer_initial_deploy(config_obj):
+@fixture
+def ui():
+    return mock.Mock(spec=UI)
+
+
+def test_api_gateway_deployer_initial_deploy(config_obj, ui):
     aws_client = mock.Mock(spec=TypedAWSClient, region_name='us-west-2')
 
     # The rest_api_id does not exist which will trigger
@@ -122,7 +117,7 @@ def test_api_gateway_deployer_initial_deploy(config_obj):
     aws_client.import_rest_api.return_value = 'rest-api-id'
     lambda_arn = 'arn:aws:lambda:us-west-2:account-id:function:func-name'
 
-    d = APIGatewayDeployer(aws_client)
+    d = APIGatewayDeployer(aws_client, ui)
     d.deploy(config_obj, None, {'api_handler_arn': lambda_arn})
 
     # mock.ANY because we don't want to test the contents of the swagger
@@ -140,7 +135,7 @@ def test_api_gateway_deployer_initial_deploy(config_obj):
     )
 
 
-def test_api_gateway_deployer_redeploy_api(config_obj):
+def test_api_gateway_deployer_redeploy_api(config_obj, ui):
     aws_client = mock.Mock(spec=TypedAWSClient, region_name='us-west-2')
 
     # The rest_api_id does not exist which will trigger
@@ -150,7 +145,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj):
     aws_client.rest_api_exists.return_value = True
     lambda_arn = 'arn:aws:lambda:us-west-2:account-id:function:func-name'
 
-    d = APIGatewayDeployer(aws_client)
+    d = APIGatewayDeployer(aws_client, ui)
     d.deploy(config_obj, deployed, {'api_handler_arn': lambda_arn})
 
     aws_client.update_api_from_swagger.assert_called_with('existing-id',
@@ -165,7 +160,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj):
     )
 
 
-def test_api_gateway_deployer_delete(config_obj):
+def test_api_gateway_deployer_delete(config_obj, ui):
     aws_client = mock.Mock(spec=TypedAWSClient, region_name='us-west-2')
 
     rest_api_id = 'abcdef1234'
@@ -173,12 +168,12 @@ def test_api_gateway_deployer_delete(config_obj):
         None, None, None, rest_api_id, 'dev', None, None, {})
     aws_client.rest_api_exists.return_value = True
 
-    d = APIGatewayDeployer(aws_client)
+    d = APIGatewayDeployer(aws_client, ui)
     d.delete(deployed)
     aws_client.delete_rest_api.assert_called_with(rest_api_id)
 
 
-def test_api_gateway_deployer_delete_already_deleted(capsys):
+def test_api_gateway_deployer_delete_already_deleted(ui):
     rest_api_id = 'abcdef1234'
     aws_client = mock.Mock(spec=TypedAWSClient, region_name='us-west-2')
     aws_client.delete_rest_api.side_effect = ResourceDoesNotExistError(
@@ -186,12 +181,11 @@ def test_api_gateway_deployer_delete_already_deleted(capsys):
     deployed = DeployedResources(
         None, None, None, rest_api_id, 'dev', None, None, {})
     aws_client.rest_api_exists.return_value = True
-    d = APIGatewayDeployer(aws_client)
+    d = APIGatewayDeployer(aws_client, ui)
     d.delete(deployed)
 
-    # Check that we printed out that no rest api with that id was found
-    out, _ = capsys.readouterr()
-    assert "No rest API with id %s found." % rest_api_id in out
+    output = [call[0][0] for call in ui.write.call_args_list]
+    assert "No rest API with id %s found.\n" % rest_api_id in output
     aws_client.delete_rest_api.assert_called_with(rest_api_id)
 
 
@@ -534,7 +528,7 @@ class TestChaliceDeploymentError(object):
 
 
 class TestDeployer(object):
-    def test_can_deploy_apig_and_lambda(self, sample_app):
+    def test_can_deploy_apig_and_lambda(self, sample_app, ui):
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
 
@@ -544,7 +538,7 @@ class TestDeployer(object):
         }
         apig_deploy.deploy.return_value = ('api_id', 'region', 'stage')
 
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         cfg = Config.create(
             chalice_stage='dev',
             chalice_app=sample_app,
@@ -560,7 +554,7 @@ class TestDeployer(object):
             'api_handler_arn': 'my_lambda_arn', 'backend': 'api'
         })
 
-    def test_deployer_returns_deployed_resources(self, sample_app):
+    def test_deployer_returns_deployed_resources(self, sample_app, ui):
         cfg = Config.create(
             chalice_stage='dev',
             chalice_app=sample_app,
@@ -575,7 +569,7 @@ class TestDeployer(object):
             'api_handler_arn': 'my_lambda_arn',
         }
 
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         deployed_values = d.deploy(cfg)
         assert deployed_values == {
             'dev': {
@@ -589,7 +583,7 @@ class TestDeployer(object):
             }
         }
 
-    def test_deployer_delete_calls_deletes(self):
+    def test_deployer_delete_calls_deletes(self, ui):
         # Check that the deployer class calls other deployer classes delete
         # methods.
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
@@ -607,29 +601,30 @@ class TestDeployer(object):
         })
         cfg.deployed_resources.return_value = deployed_resources
 
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         d.delete(cfg)
 
         lambda_deploy.delete.assert_called_with(deployed_resources)
         apig_deploy.delete.assert_called_with(deployed_resources)
 
-    def test_deployer_does_not_call_delete_when_no_resources(self, capsys):
+    def test_deployer_does_not_call_delete_when_no_resources(self, ui):
         # If there is nothing to clean up the deployer should not call delete.
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
         cfg = mock.Mock(spec=Config)
         deployed_resources = None
         cfg.deployed_resources.return_value = deployed_resources
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         d.delete(cfg)
 
-        out, _ = capsys.readouterr()
-        assert 'No existing resources found for stage dev' in out
+        output = [call[0][0] for call in ui.write.call_args_list]
+        assert 'No existing resources found for stage dev.\n' in output
         lambda_deploy.delete.assert_not_called()
         apig_deploy.delete.assert_not_called()
 
     def test_raises_deployment_error_for_botcore_client_error(self,
-                                                              sample_app):
+                                                              sample_app,
+                                                              ui):
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
         lambda_deploy.deploy.side_effect = ClientError(
@@ -641,7 +636,7 @@ class TestDeployer(object):
             },
             'CreateFunction'
         )
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         cfg = Config.create(
             chalice_stage='dev',
             chalice_app=sample_app,
@@ -652,7 +647,9 @@ class TestDeployer(object):
         assert excinfo.match('ERROR - While deploying')
         assert excinfo.match('Denied')
 
-    def test_raises_deployment_error_for_lambda_client_error(self, sample_app):
+    def test_raises_deployment_error_for_lambda_client_error(self,
+                                                             sample_app,
+                                                             ui):
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
         lambda_deploy.deploy.side_effect = LambdaClientError(
@@ -663,7 +660,7 @@ class TestDeployer(object):
                 deployment_size=1024 ** 2
             )
         )
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         cfg = Config.create(
             chalice_stage='dev',
             chalice_app=sample_app,
@@ -674,7 +671,7 @@ class TestDeployer(object):
         assert excinfo.match('ERROR - While sending')
         assert excinfo.match('my error')
 
-    def test_raises_deployment_error_for_apig_error(self, sample_app):
+    def test_raises_deployment_error_for_apig_error(self, sample_app, ui):
         lambda_deploy = mock.Mock(spec=LambdaDeployer)
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
         lambda_deploy.deploy.return_value = {
@@ -690,7 +687,7 @@ class TestDeployer(object):
             },
             'CreateStage'
         )
-        d = Deployer(apig_deploy, lambda_deploy)
+        d = Deployer(apig_deploy, lambda_deploy, ui)
         cfg = Config.create(
             chalice_stage='dev',
             chalice_app=sample_app,
@@ -738,7 +735,7 @@ def test_deployer_does_not_reuse_pacakge_on_python_version_change(
     aws_client.get_function_configuration.return_value = {
         'Runtime': 'python1.0',
     }
-    prompter = mock.Mock(spec=NoPrompt)
+    prompter = mock.Mock(spec=UI)
     prompter.confirm.return_value = True
 
     d = LambdaDeployer(aws_client, packager, prompter, osutils, app_policy)
@@ -790,7 +787,7 @@ def test_lambda_deployer_repeated_deploy(app_policy, sample_app):
     aws_client.get_function_configuration.return_value = {
         'Runtime': cfg.lambda_python_version,
     }
-    prompter = mock.Mock(spec=NoPrompt)
+    prompter = mock.Mock(spec=UI)
     prompter.confirm.return_value = True
 
     d = LambdaDeployer(aws_client, packager, prompter, osutils, app_policy)
@@ -821,15 +818,16 @@ def test_lambda_deployer_repeated_deploy(app_policy, sample_app):
     )
 
 
-def test_lambda_deployer_delete():
+def test_lambda_deployer_delete(ui):
     aws_client = mock.Mock(spec=TypedAWSClient)
     aws_client.get_role_arn_for_name.return_value = 'arn_prefix/role_name'
     lambda_function_name = 'api-handler'
     deployed = DeployedResources(
         'api', 'api_handler_arn/lambda_name', lambda_function_name,
         None, 'dev', None, None, {'name': {'arn': 'auth-arn'}})
+    ui.confirm.return_value = True
     d = LambdaDeployer(
-        aws_client, None, CustomConfirmPrompt(True), None, None)
+        aws_client, None, ui, None, None)
     d.delete(deployed)
 
     aws_client.get_role_arn_for_name.assert_called_with(lambda_function_name)
@@ -840,7 +838,7 @@ def test_lambda_deployer_delete():
     aws_client.delete_role.assert_called_with('role_name')
 
 
-def test_lambda_deployer_delete_already_deleted(capsys):
+def test_lambda_deployer_delete_already_deleted(ui):
     lambda_function_name = 'lambda_name'
     aws_client = mock.Mock(spec=TypedAWSClient)
     aws_client.get_role_arn_for_name.return_value = 'arn_prefix/role_name'
@@ -850,12 +848,13 @@ def test_lambda_deployer_delete_already_deleted(capsys):
         'api', 'api_handler_arn/lambda_name', lambda_function_name,
         None, 'dev', None, None, {})
     d = LambdaDeployer(
-        aws_client, None, NoPrompt(), None, None)
+        aws_client, None, ui, None, None)
     d.delete(deployed)
 
     # check that we printed that no lambda function with that name was found
-    out, _ = capsys.readouterr()
-    assert "No lambda function named %s found." % lambda_function_name in out
+    output = [call[0][0] for call in ui.write.call_args_list]
+    assert ("No lambda function named %s found.\n" %
+            lambda_function_name in output)
     aws_client.delete_function.assert_called_with(lambda_function_name)
 
 
@@ -897,7 +896,7 @@ def test_prompted_on_runtime_change_can_reject_change(app_policy, sample_app):
     assert 'runtime will change' in message
 
 
-def test_lambda_deployer_initial_deploy(app_policy, sample_app):
+def test_lambda_deployer_initial_deploy(app_policy, sample_app, ui):
     osutils = InMemoryOSUtils({'packages.zip': b'package contents'})
     aws_client = mock.Mock(spec=TypedAWSClient)
     aws_client.create_function.return_value = 'lambda-arn'
@@ -916,7 +915,7 @@ def test_lambda_deployer_initial_deploy(app_policy, sample_app):
         tags={'mykey': 'myvalue'}
     )
 
-    d = LambdaDeployer(aws_client, packager, None, osutils, app_policy)
+    d = LambdaDeployer(aws_client, packager, ui, osutils, app_policy)
     deployed = d.deploy(cfg, None, 'dev')
     assert deployed == {
         'api_handler_arn': 'lambda-arn',
@@ -1061,7 +1060,8 @@ def test_can_validate_updated_custom_binary_types(sample_app):
 
 
 class TestAuthHandlersAreAuthorized(object):
-    def tests_apigateway_adds_auth_handler_policy(self, sample_app_with_auth):
+    def tests_apigateway_adds_auth_handler_policy(self, sample_app_with_auth,
+                                                  ui):
         # When we create authorizers in API gateway, we also need to
         # give the authorizers permission to invoke the lambda functions
         # we've created.
@@ -1072,7 +1072,7 @@ class TestAuthHandlersAreAuthorized(object):
             manage_iam_role=False, iam_role_arn='role-arn',
             project_dir='.'
         )
-        d = APIGatewayDeployer(aws_client)
+        d = APIGatewayDeployer(aws_client, ui)
         deployed_resources = {
             'api_handler_arn': (
                 'arn:aws:lambda:us-west-2:1:function:myapp-dev'
@@ -1093,7 +1093,7 @@ class TestAuthHandlersAreAuthorized(object):
 
 class TestLambdaInitialDeploymentWithConfigurations(object):
     @fixture(autouse=True)
-    def setup_deployer_dependencies(self, app_policy):
+    def setup_deployer_dependencies(self, app_policy, ui):
         # This autouse fixture is used instead of ``setup_method`` because it:
         # * Is ran for every test
         # * Allows additional fixtures to be passed in to reduce the number
@@ -1119,6 +1119,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
         self.packager.deployment_package_filename.return_value =\
             self.package_name
         self.app_policy = app_policy
+        self.ui = ui
 
     def create_config_obj(self, sample_app):
         cfg = Config.create(
@@ -1131,7 +1132,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
     def test_can_create_auth_handlers(self, sample_app_with_auth):
         config = self.create_config_obj(sample_app_with_auth)
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         self.aws_client.lambda_function_exists.return_value = False
         self.aws_client.create_function.side_effect = [
@@ -1163,7 +1164,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
 
         config = self.create_config_obj(sample_app)
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         self.aws_client.lambda_function_exists.return_value = False
         self.aws_client.get_or_create_rule_arn.return_value = 'rule-arn'
@@ -1205,7 +1206,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
         self.aws_client.create_function.side_effect = [
             self.lambda_arn, 'arn:event-function']
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         deployer.deploy(config, None, stage_name='dev')
 
@@ -1221,7 +1222,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
 
         config = self.create_config_obj(sample_app)
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         self.aws_client.lambda_function_exists.return_value = False
         self.aws_client.create_function.side_effect = [
@@ -1249,7 +1250,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
     def test_can_update_auth_handlers(self, sample_app_with_auth):
         config = self.create_config_obj(sample_app_with_auth)
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         self.aws_client.lambda_function_exists.return_value = True
         self.aws_client.update_function.return_value = {
@@ -1301,7 +1302,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                                   'project_dir': '.'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         self.aws_client.lambda_function_exists.return_value = False
         self.aws_client.create_function.side_effect = [
@@ -1355,7 +1356,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             'Runtime': config.lambda_python_version,
         }
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
         deployed = deployer.deploy(config, existing, stage_name='dev')
         # Because the "old-function" was not referenced in the update
@@ -1373,7 +1374,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
     def test_lambda_deployer_defaults(self, sample_app):
         cfg = self.create_config_obj(sample_app)
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, None, 'dev')
@@ -1397,7 +1398,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             project_dir='.', environment_variables={'FOO': 'BAR'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, None, 'dev')
@@ -1421,7 +1422,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             project_dir='.', lambda_timeout=120
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, None, 'dev')
@@ -1445,7 +1446,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             project_dir='.', lambda_memory_size=256
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, None, 'dev')
@@ -1469,7 +1470,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             project_dir='.', tags={'mykey': 'myvalue'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, None, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, None, 'dev')
@@ -1490,7 +1491,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
 
 class TestLambdaUpdateDeploymentWithConfigurations(object):
     @fixture(autouse=True)
-    def setup_deployer_dependencies(self, app_policy):
+    def setup_deployer_dependencies(self, app_policy, ui):
         # This autouse fixture is used instead of ``setup_method`` because it:
         # * Is ran for every test
         # * Allows additional fixtures to be passed in to reduce the number
@@ -1514,8 +1515,8 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             'Runtime': 'python2.7',
         }
 
-        self.prompter = mock.Mock(spec=NoPrompt)
-        self.prompter.confirm.return_value = True
+        self.ui = ui
+        self.ui.confirm.return_value = True
 
         self.packager = mock.Mock(spec=LambdaDeploymentPackager)
         self.packager.create_deployment_package.return_value =\
@@ -1534,7 +1535,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.',
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, self.deployed_resources, 'dev')
@@ -1558,7 +1559,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.', environment_variables={'FOO': 'BAR'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, self.deployed_resources, 'dev')
@@ -1582,7 +1583,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.', lambda_timeout=120
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, self.deployed_resources, 'dev')
@@ -1606,7 +1607,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.', lambda_memory_size=256
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, self.deployed_resources, 'dev')
@@ -1630,7 +1631,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.', tags={'mykey': 'myvalue'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         deployer.deploy(cfg, self.deployed_resources, 'dev')
@@ -1655,7 +1656,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             project_dir='.', tags={'mykey': 'myvalue'}
         )
         deployer = LambdaDeployer(
-            self.aws_client, self.packager, self.prompter, self.osutils,
+            self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
         self.aws_client.get_role_arn_for_name.return_value = 'role-arn'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,37 @@
+import mock
+import click
+import pytest
+from six import StringIO
+
+from chalice import utils
+
+
+class TestUI(object):
+    def setup(self):
+        self.out = StringIO()
+        self.err = StringIO()
+        self.ui = utils.UI(self.out, self.err)
+
+    def test_write_goes_to_out_obj(self):
+        self.ui.write("Foo")
+        assert self.out.getvalue() == 'Foo'
+        assert self.err.getvalue() == ''
+
+    def test_error_goes_to_err_obj(self):
+        self.ui.error("Foo")
+        assert self.err.getvalue() == 'Foo'
+        assert self.out.getvalue() == ''
+
+    def test_confirm_raises_own_exception(self):
+        confirm = mock.Mock(spec=click.confirm)
+        confirm.side_effect = click.Abort()
+        ui = utils.UI(self.out, self.err, confirm)
+        with pytest.raises(utils.AbortedError):
+            ui.confirm("Confirm?")
+
+    def test_confirm_returns_value(self):
+        confirm = mock.Mock(spec=click.confirm)
+        confirm.return_value = 'foo'
+        ui = utils.UI(self.out, self.err, confirm)
+        return_value = ui.confirm("Confirm?")
+        assert return_value == 'foo'


### PR DESCRIPTION
This adds more detail to the output of `chalice deploy`, including:

* Add resource names where possible (lambda function names, rest api IDs, etc)
* Print when we're deleting unreferenced lambda functions

I've also introduced a module level logger that includes debug messages for the parts of the deployer.  This is more intended for us to help troubleshoot any deployment issues.

I've also restructured the internals to remove bare print calls.  A `UI` object is now passed through the deployer objects.  This makes testing easier as well as makes it easier to add more UI capabilities in the future.  Right now it just has writing to stdout/stderr, and prompting.  I've also moved the `NoPrompt` interface into the `UI` interface.