### PR TITLE
Add support for local custom authorizers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Next Release (TBD)
 * Fix bug where ``raw_body`` would raise an exception if no HTTP
   body was provided
   (`#503 <https://github.com/aws/chalice/issues/503>`__)
+* Fix bug where exit codes were not properly being propagated during packaging
+  (`#500 <https://github.com/aws/chalice/issues/500>`__)
+* Add support for Builtin Authorizers in local mode
+  (`#404 <https://github.com/aws/chalice/issues/404>`__)
 
 
 1.0.1

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -1,4 +1,5 @@
 from typing import Dict, List, Any, Callable, Union, Optional
+from chalice.local import LambdaContext
 
 __version__ = ... # type: str
 
@@ -109,9 +110,7 @@ class Chalice(object):
     api = ... # type: APIGateway
     routes = ... # type: Dict[str, Dict[str, RouteEntry]]
     current_request = ... # type: Request
-    # TODO: Change lambda_context to a real type once we have one for local
-    # API Gateway
-    lambda_context = ... # type: Any
+    lambda_context = ... # type: LambdaContext
     debug = ... # type: bool
     authorizers = ... # type: Dict[str, Dict[str, Any]]
     builtin_auth_handlers = ... # type: List[BuiltinAuthConfig]

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -99,7 +99,7 @@ def run_local_server(factory, port, env):
     # The app-specific logger (app.log) will still continue
     # to work.
     logging.basicConfig(stream=sys.stdout)
-    server = factory.create_local_server(app_obj, port)
+    server = factory.create_local_server(app_obj, config, port)
     server.serve_forever()
 
 

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -186,6 +186,6 @@ class CLIFactory(object):
         with open(config_file) as f:
             return json.loads(f.read())
 
-    def create_local_server(self, app_obj, port):
-        # type: (Chalice, int) -> local.LocalDevServer
-        return local.create_local_server(app_obj, port)
+    def create_local_server(self, app_obj, config, port):
+        # type: (Chalice, Config, int) -> local.LocalDevServer
+        return local.create_local_server(app_obj, config, port)

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -4,27 +4,99 @@ This is intended only for local development purposes.
 
 """
 from __future__ import print_function
+import re
+import time
+import uuid
 import base64
 import functools
+import warnings
 from collections import namedtuple
 
 from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
-from typing import List, Any, Dict, Tuple, Callable  # noqa
+from typing import List, Any, Dict, Tuple, Callable, Optional, Union  # noqa
 
-from chalice.app import Chalice, CORSConfig  # noqa
+from chalice.app import Chalice  # noqa
+from chalice.app import CORSConfig  # noqa
+from chalice.app import ChaliceAuthorizer  # noqa
+from chalice.app import RouteEntry  # noqa
+from chalice.app import Request  # noqa
+from chalice.app import AuthResponse  # noqa
+from chalice.app import BuiltinAuthConfig  # noqa
+from chalice.config import Config  # noqa
+
 from chalice.compat import urlparse, parse_qs
 
 
 MatchResult = namedtuple('MatchResult', ['route', 'captured', 'query_params'])
 EventType = Dict[str, Any]
+ContextType = Dict[str, Any]
+HeaderType = Dict[str, Any]
+ResponseType = Dict[str, Any]
 HandlerCls = Callable[..., 'ChaliceRequestHandler']
 ServerCls = Callable[..., 'HTTPServer']
 
 
-def create_local_server(app_obj, port):
-    # type: (Chalice, int) -> LocalDevServer
-    return LocalDevServer(app_obj, port)
+class Clock(object):
+    def time(self):
+        # type: () -> float
+        return time.time()
+
+
+def create_local_server(app_obj, config, port):
+    # type: (Chalice, Config, int) -> LocalDevServer
+    return LocalDevServer(app_obj, config, port)
+
+
+class LocalARNBuilder(object):
+    ARN_FORMAT = ('arn:aws:execute-api:{region}:{account_id}'
+                  ':{api_id}/{stage}/{method}/{resource_path}')
+    LOCAL_REGION = 'mars-west-1'
+    LOCAL_ACCOUNT_ID = '123456789012'
+    LOCAL_API_ID = 'ymy8tbxw7b'
+    LOCAL_STAGE = 'api'
+
+    def build_arn(self, method, path):
+        # type: (str, str) -> str
+        # In API Gateway the method and URI are separated by a / so typically
+        # the uri portion omits the leading /. In the case where the entire
+        # url is just '/' API Gateway adds a / to the end so that the arn end
+        # with a '//'.
+        if path != '/':
+            path = path[1:]
+        return self.ARN_FORMAT.format(
+            region=self.LOCAL_REGION,
+            account_id=self.LOCAL_ACCOUNT_ID,
+            api_id=self.LOCAL_API_ID,
+            stage=self.LOCAL_STAGE,
+            method=method,
+            resource_path=path
+        )
+
+
+class ARNMatcher(object):
+    def __init__(self, target_arn):
+        # type: (str) -> None
+        self._arn = target_arn
+
+    def _resource_match(self, resource):
+        # type: (str) -> bool
+        # Arn matching supports two special case characetrs that are not
+        # escapable. * represents a glob which translates to a non-greedy
+        # match of any number of characters. ? which is any single character.
+        # These are easy to translate to a regex using .*? and . respectivly.
+        escaped_resource = re.escape(resource)
+        resource_regex = escaped_resource.replace(r'\?', '.').replace(
+            r'\*', '.*?')
+        resource_regex = '^%s$' % resource_regex
+        return re.match(resource_regex, self._arn) is not None
+
+    def does_any_resource_match(self, resources):
+        # type: (List[str]) -> bool
+        for resource in resources:
+            if self._resource_match(resource):
+                return True
+        return False
 
 
 class RouteMatcher(object):
@@ -94,7 +166,7 @@ class LambdaEventConverter(object):
                     'sourceIp': self.LOCAL_SOURCE_IP
                 },
             },
-            'headers': dict(headers),
+            'headers': {k.lower(): v for k, v in headers.items()},
             'queryStringParameters': view_route.query_params,
             'pathParameters': view_route.captured,
             'stageVariables': {},
@@ -107,98 +179,300 @@ class LambdaEventConverter(object):
         return event
 
 
-class ChaliceRequestHandler(BaseHTTPRequestHandler):
+class LocalGatewayException(Exception):
+    CODE = 0
 
-    protocol = 'HTTP/1.1'
+    def __init__(self, headers, body=None):
+        # type: (HeaderType, Optional[bytes]) -> None
+        self.headers = headers
+        self.body = body
 
-    def __init__(self, request, client_address, server, app_object):
-        # type: (bytes, Tuple[str, int], HTTPServer, Chalice) -> None
-        self.app_object = app_object
+
+class InvalidAuthorizerError(LocalGatewayException):
+    CODE = 500
+
+
+class ForbiddenError(LocalGatewayException):
+    CODE = 403
+
+
+class NotAuthorizedError(LocalGatewayException):
+    CODE = 401
+
+
+class NoOptionsRouteDefined(LocalGatewayException):
+    CODE = 403
+
+
+class LambdaContext(object):
+    def __init__(self, function_name, memory_size,
+                 max_runtime_ms=3000, time_source=None):
+        # type: (str, int, int, Optional[Clock]) -> None
+        if time_source is None:
+            time_source = Clock()
+        self._time_source = time_source
+        self._start_time = self._current_time_millis()
+        self._max_runtime = max_runtime_ms
+
+        # Below are properties that are found on the real LambdaContext passed
+        # by lambda and their associated documentation.
+
+        # Name of the Lambda function that is executing.
+        self.function_name = function_name
+
+        # The Lambda function version that is executing. If an alias is used
+        # to invoke the function, then function_version will be the version
+        # the alias points to.
+        # Chalice local obviously does not support versioning so it will always
+        # be set to $LATEST.
+        self.function_version = '$LATEST'
+
+        # The ARN used to invoke this function. It can be function ARN or
+        # alias ARN. An unqualified ARN executes the $LATEST version and
+        # aliases execute the function version it is pointing to.
+        self.invoked_function_arn = ''
+
+        # Memory limit, in MB, you configured for the Lambda function. You set
+        # the memory limit at the time you create a Lambda function and you
+        # can change it later.
+        self.memory_limit_in_mb = memory_size
+
+        # AWS request ID associated with the request. This is the ID returned
+        # to the client that called the invoke method.
+        self.aws_request_id = str(uuid.uuid4())
+
+        # The name of the CloudWatch log group where you can find logs written
+        # by your Lambda function.
+        self.log_group_name = ''
+
+        # The name of the CloudWatch log stream where you can find logs
+        # written by your Lambda function. The log stream may or may not
+        # change for each invocation of the Lambda function.
+        #
+        # The value is null if your Lambda function is unable to create a log
+        # stream, which can happen if the execution role that grants necessary
+        # permissions to the Lambda function does not include permissions for
+        # the CloudWatch Logs actions.
+        self.log_stream_name = ''
+
+        # The last two attributes have the following comment in the
+        # documentation:
+        # Information about the client application and device when invoked
+        # through the AWS Mobile SDK, it can be null.
+        # Chalice local doens't need to set these since they are specifically
+        # for the mobile SDK.
+        self.identity = None
+        self.client_context = None
+
+    def _current_time_millis(self):
+        # type: () -> float
+        return self._time_source.time() * 1000
+
+    def get_remaining_time_in_millis(self):
+        # type: () -> float
+        runtime = self._current_time_millis() - self._start_time
+        return self._max_runtime - runtime
+
+
+LocalAuthPair = Tuple[EventType, LambdaContext]
+
+
+class LocalGatewayAuthorizer(object):
+    """A class for running user defined authorizers in local mode."""
+    def __init__(self, app_object):
+        # type: (Chalice) -> None
+        self._app_object = app_object
+        self._arn_builder = LocalARNBuilder()
+
+    def authorize(self, raw_path, lambda_event, lambda_context):
+        # type: (str, EventType, LambdaContext) -> LocalAuthPair
+        method = lambda_event['requestContext']['httpMethod']
+        route_entry = self._route_for_event(lambda_event)
+        if not route_entry:
+            return lambda_event, lambda_context
+        authorizer = route_entry.authorizer
+        if not authorizer:
+            return lambda_event, lambda_context
+        if not isinstance(authorizer, ChaliceAuthorizer):
+            # Currently the only supported local authorizer is the
+            # BuiltinAuthConfig type. Anything else we will err on the side of
+            # allowing local testing by simply admiting the request. Otherwise
+            # there is no way for users to test their code in local mode.
+            warnings.warn(
+                '%s is not a supported in local mode. All requests made '
+                'against a route will be authorized to allow local testing.'
+                % authorizer.__class__.__name__
+            )
+            return lambda_event, lambda_context
+        arn = self._arn_builder.build_arn(method, raw_path)
+        auth_event = self._prepare_authorizer_event(arn, lambda_event,
+                                                    lambda_context)
+        auth_result = authorizer(auth_event, lambda_context)
+        if auth_result is None:
+            raise InvalidAuthorizerError(
+                {'x-amzn-RequestId': lambda_context.aws_request_id,
+                 'x-amzn-ErrorType': 'AuthorizerConfigurationException'},
+                b'{"message":null}'
+            )
+        authed = self._check_can_invoke_view_function(arn, auth_result)
+        if authed:
+            lambda_event = self._update_lambda_event(lambda_event, auth_result)
+        else:
+            raise ForbiddenError(
+                {'x-amzn-RequestId': lambda_context.aws_request_id,
+                 'x-amzn-ErrorType': 'AccessDeniedException'},
+                (b'{"Message": '
+                 b'"User is not authorized to access this resource"}'))
+        return lambda_event, lambda_context
+
+    def _check_can_invoke_view_function(self, arn, auth_result):
+        # type: (str, ResponseType) -> bool
+        policy = auth_result.get('policyDocument', {})
+        statements = policy.get('Statement', [])
+        allow_resource_statements = []
+        for statement in statements:
+            if statement.get('Effect') == 'Allow' and \
+               statement.get('Action') == 'execute-api:Invoke':
+                for resource in statement.get('Resource'):
+                    allow_resource_statements.append(resource)
+
+        arn_matcher = ARNMatcher(arn)
+        return arn_matcher.does_any_resource_match(allow_resource_statements)
+
+    def _route_for_event(self, lambda_event):
+        # type: (EventType) -> Optional[RouteEntry]
+        # Authorizer had to be made into an Any type since mypy couldn't
+        # detect that app.ChaliceAuthorizer was callable.
+        resource_path = lambda_event.get(
+            'requestContext', {}).get('resourcePath')
+        http_method = lambda_event['requestContext']['httpMethod']
+        try:
+            route_entry = self._app_object.routes[resource_path][http_method]
+        except KeyError:
+            # If a key error is raised when trying to get the route entry
+            # then this route does not support this method. A method error
+            # will be raised by the chalice handler method. We can ignore it
+            # here by returning no authorizer to avoid duplicating the logic.
+            return None
+        return route_entry
+
+    def _update_lambda_event(self, lambda_event, auth_result):
+        # type: (EventType, ResponseType) -> EventType
+        auth_context = auth_result['context']
+        auth_context.update({
+            'principalId': auth_result['principalId']
+        })
+        lambda_event['requestContext']['authorizer'] = auth_context
+        return lambda_event
+
+    def _prepare_authorizer_event(self, arn, lambda_event, lambda_context):
+        # type: (str, EventType, LambdaContext) -> EventType
+        """Translate event for an authorizer input."""
+        authorizer_event = lambda_event.copy()
+        authorizer_event['type'] = 'TOKEN'
+        try:
+            authorizer_event['authorizationToken'] = authorizer_event.get(
+                'headers', {})['authorization']
+        except KeyError:
+            raise NotAuthorizedError(
+                {'x-amzn-RequestId': lambda_context.aws_request_id,
+                 'x-amzn-ErrorType': 'UnauthorizedException'},
+                b'{"message":"Unauthorized"}')
+        authorizer_event['methodArn'] = arn
+        return authorizer_event
+
+
+class LocalGateway(object):
+    """A class for faking the behavior of API Gateway."""
+    def __init__(self, app_object, config):
+        # type: (Chalice, Config) -> None
+        self._app_object = app_object
+        self._config = config
         self.event_converter = LambdaEventConverter(
             RouteMatcher(list(app_object.routes)),
-            self.app_object.api.binary_types
+            self._app_object.api.binary_types
         )
-        BaseHTTPRequestHandler.__init__(
-            self, request, client_address, server)  # type: ignore
-        # Force BaseHTTPRequestHandler to use HTTP/1.1
-        # Chrome ignores many headers from HTTP/1.0 servers.
-        BaseHTTPRequestHandler.protocol_version = "HTTP/1.1"
+        self._authorizer = LocalGatewayAuthorizer(app_object)
 
-    def _generic_handle(self):
-        # type: () -> None
-        lambda_event = self._generate_lambda_event()
-        self._do_invoke_view_function(lambda_event)
+    def _generate_lambda_context(self):
+        # type: () -> LambdaContext
+        return LambdaContext(
+            function_name=self._config.function_name,
+            memory_size=self._config.lambda_memory_size,
+            max_runtime_ms=self._config.lambda_timeout
+        )
 
-    def _handle_binary(self, response):
-        # type: (Dict[str,Any]) -> Dict[str,Any]
-        if response.get('isBase64Encoded'):
-            body = base64.b64decode(response['body'])
-            response['body'] = body
-        return response
-
-    def _do_invoke_view_function(self, lambda_event):
-        # type: (EventType) -> None
-        lambda_context = None
-        response = self.app_object(lambda_event, lambda_context)
-        response = self._handle_binary(response)
-        self._send_http_response(lambda_event, response)
-
-    def _send_http_response(self, lambda_event, response):
-        # type: (EventType, Dict[str, Any]) -> None
-        self.send_response(response['statusCode'])
-        self.send_header('Content-Length', str(len(response['body'])))
-        content_type = response['headers'].pop(
-            'Content-Type', 'application/json')
-        self.send_header('Content-Type', content_type)
-        headers = response['headers']
-        for header in headers:
-            self.send_header(header, headers[header])
-        self.end_headers()
-        body = response['body']
-        if not isinstance(body, bytes):
-            body = body.encode('utf-8')
-        self.wfile.write(body)
-
-    def _generate_lambda_event(self):
-        # type: () -> EventType
-        content_length = int(self.headers.get('content-length', '0'))
-        body = None
-        if content_length > 0:
-            body = self.rfile.read(content_length)
-        # mypy doesn't like dict(self.headers) so I had to use a
-        # dictcomp instead to make it happy.
-        converted_headers = {key: value for key, value in self.headers.items()}
+    def _generate_lambda_event(self, method, path, headers, body):
+        # type: (str, str, HeaderType, str) -> EventType
         lambda_event = self.event_converter.create_lambda_event(
-            method=self.command, path=self.path, headers=converted_headers,
+            method=method, path=path, headers=headers,
             body=body,
         )
         return lambda_event
 
-    do_GET = do_PUT = do_POST = do_HEAD = do_DELETE = do_PATCH = \
-        _generic_handle
-
-    def do_OPTIONS(self):
-        # type: () -> None
-        # This can either be because the user's provided an OPTIONS method
-        # *or* this is a preflight request, which chalice automatically
-        # sets up for you.
-        lambda_event = self._generate_lambda_event()
-        if self._has_user_defined_options_method(lambda_event):
-            self._do_invoke_view_function(lambda_event)
-        else:
-            # Otherwise this is a preflight request which we automatically
-            # generate.
-            self._send_autogen_options_response(lambda_event)
-
     def _has_user_defined_options_method(self, lambda_event):
         # type: (EventType) -> bool
         route_key = lambda_event['requestContext']['resourcePath']
-        return 'OPTIONS' in self.app_object.routes[route_key]
+        return 'OPTIONS' in self._app_object.routes[route_key]
 
-    def _send_autogen_options_response(self, lambda_event):
-        # type:(EventType) -> None
+    def handle_request(self, method, path, headers, body):
+        # type: (str, str, HeaderType, str) -> ResponseType
+        lambda_context = self._generate_lambda_context()
+        try:
+            lambda_event = self._generate_lambda_event(
+                method, path, headers, body)
+        except ValueError:
+            # API Gateway will return a different error on route not found
+            # depending on whether or not we have an authorization token in our
+            # request. Since we do not do that check until we actually find
+            # the authorizer that we will call we do not have that information
+            # available at this point. Instead we just check to see if that
+            # header is present and change our response if it is. This will
+            # need to be refactored later if we decide to more closely mirror
+            # how API Gateway does their auth and routing.
+            error_headers = {'x-amzn-RequestId': lambda_context.aws_request_id,
+                             'x-amzn-ErrorType': 'UnauthorizedException'}
+            auth_header = headers.get('authorization')
+            if auth_header is None:
+                auth_header = headers.get('Authorization')
+            if auth_header is not None:
+                raise ForbiddenError(
+                    error_headers,
+                    (b'{"message": "Authorization header requires '
+                     b'\'Credential\''
+                     b' parameter. Authorization header requires \'Signature\''
+                     b' parameter. Authorization header requires '
+                     b'\'SignedHeaders\' parameter. Authorization header '
+                     b'requires existence of either a \'X-Amz-Date\' or a'
+                     b' \'Date\' header. Authorization=%s"}'
+                     % auth_header.encode('ascii')))
+            raise ForbiddenError(
+                error_headers,
+                b'{"message": "Missing Authentication Token"}')
+
+        # This can either be because the user's provided an OPTIONS method
+        # *or* this is a preflight request, which chalice automatically
+        # responds to without invoking a user defined route.
+        if method == 'OPTIONS' and \
+           not self._has_user_defined_options_method(lambda_event):
+            # No options route was defined for this path. API Gateway should
+            # automatically generate our CORS headers.
+            options_headers = self._autogen_options_headers(lambda_event)
+            raise NoOptionsRouteDefined(options_headers)
+        # The authorizer call will be a noop if there is no authorizer method
+        # defined for route. Otherwise it will raise a ForbiddenError
+        # which will be caught by the handler that called this and a 403 or
+        # 401 will be sent back over the wire.
+        lambda_event, lambda_context = self._authorizer.authorize(
+            path, lambda_event, lambda_context)
+        response = self._app_object(lambda_event, lambda_context)
+        response = self._handle_binary(response)
+        return response
+
+    def _autogen_options_headers(self, lambda_event):
+        # type:(EventType) -> HeaderType
         route_key = lambda_event['requestContext']['resourcePath']
-        route_dict = self.app_object.routes[route_key]
+        route_dict = self._app_object.routes[route_key]
         route_methods = list(route_dict.keys())
 
         # Chalice ensures that routes with multiple views have the same
@@ -212,7 +486,6 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
         # So our local version needs to add this manually to our set of allowed
         # headers.
         route_methods.append('OPTIONS')
-        route_methods = route_methods
 
         # The Access-Control-Allow-Methods header is not added by the
         # CORSConfig object it is added to the API Gateway route during
@@ -220,21 +493,101 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
         cors_headers.update({
             'Access-Control-Allow-Methods': '%s' % ','.join(route_methods)
         })
+        return cors_headers
 
-        self.send_response(200)
-        for k, v in cors_headers.items():
+    def _handle_binary(self, response):
+        # type: (Dict[str,Any]) -> Dict[str,Any]
+        if response.get('isBase64Encoded'):
+            body = base64.b64decode(response['body'])
+            response['body'] = body
+        return response
+
+
+class ChaliceRequestHandler(BaseHTTPRequestHandler):
+    """A class for mapping raw HTTP events to and from LocalGateway."""
+    protocol_version = 'HTTP/1.1'
+
+    def __init__(self, request, client_address, server, app_object, config):
+        # type: (bytes, Tuple[str, int], HTTPServer, Chalice, Config) -> None
+        self.local_gateway = LocalGateway(app_object, config)
+        BaseHTTPRequestHandler.__init__(
+            self, request, client_address, server)  # type: ignore
+
+    def _parse_payload(self):
+        # type: () -> Tuple[HeaderType, str]
+        body = None
+        content_length = int(self.headers.get('content-length', '0'))
+        if content_length > 0:
+            body = self.rfile.read(content_length)
+        # mypy doesn't like dict(self.headers) so I had to use a
+        # dictcomp instead to make it happy.
+        converted_headers = {key: value for key, value in self.headers.items()}
+        return converted_headers, body
+
+    def _generic_handle(self):
+        # type: () -> None
+        headers, body = self._parse_payload()
+        try:
+            response = self.local_gateway.handle_request(
+                method=self.command,
+                path=self.path,
+                headers=headers,
+                body=body
+            )
+            status_code = response['statusCode']
+            headers = response['headers']
+            body = response['body']
+            self._send_http_response(status_code, headers, body)
+        except LocalGatewayException as e:
+            self._send_error_response(e)
+
+    def _send_error_response(self, error):
+        # type: (LocalGatewayException) -> None
+        code = error.CODE
+        headers = error.headers
+        body = error.body
+        self._send_http_response(code, headers, body)
+
+    def _send_http_response(self, code, headers, body):
+        # type: (int, HeaderType, Optional[Union[str,bytes]]) -> None
+        if body is None:
+            self._send_http_response_no_body(code, headers)
+        else:
+            self._send_http_response_with_body(code, headers, body)
+
+    def _send_http_response_with_body(self, code, headers, body):
+        # type: (int, HeaderType, Union[str,bytes]) -> None
+        self.send_response(code)
+        self.send_header('Content-Length', str(len(body)))
+        content_type = headers.pop(
+            'Content-Type', 'application/json')
+        self.send_header('Content-Type', content_type)
+        for header_name, header_value in headers.items():
+            self.send_header(header_name, header_value)
+        self.end_headers()
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
+        self.wfile.write(body)
+
+    do_GET = do_PUT = do_POST = do_HEAD = do_DELETE = do_PATCH = do_OPTIONS = \
+        _generic_handle
+
+    def _send_http_response_no_body(self, code, headers):
+        # type: (int, HeaderType) -> None
+        self.send_response(code)
+        for k, v in headers.items():
             self.send_header(k, v)
         self.end_headers()
 
 
 class LocalDevServer(object):
-    def __init__(self, app_object, port, handler_cls=ChaliceRequestHandler,
-                 server_cls=HTTPServer):
-        # type: (Chalice, int, HandlerCls, ServerCls) -> None
+    def __init__(self, app_object, config, port,
+                 handler_cls=ChaliceRequestHandler, server_cls=HTTPServer):
+        # type: (Chalice, Config, int, HandlerCls, ServerCls) -> None
         self.app_object = app_object
         self.port = port
         self._wrapped_handler = functools.partial(
-            handler_cls, app_object=app_object)
+            handler_cls, app_object=app_object, config=config)
         self.server = server_cls(('', port), self._wrapped_handler)
 
     def handle_single_request(self):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pytest import fixture
 
 from chalice.app import Chalice
@@ -32,3 +33,52 @@ def sample_app_with_auth():
         return {}
 
     return app
+
+
+@fixture
+def create_event():
+    def create_event_inner(uri, method, path, content_type='application/json'):
+        return {
+            'requestContext': {
+                'httpMethod': method,
+                'resourcePath': uri,
+            },
+            'headers': {
+                'Content-Type': content_type,
+            },
+            'pathParameters': path,
+            'queryStringParameters': {},
+            'body': "",
+            'stageVariables': {},
+        }
+    return create_event_inner
+
+
+@fixture
+def create_empty_header_event():
+    def create_empty_header_event_inner(uri, method, path,
+                                        content_type='application/json'):
+        return {
+            'requestContext': {
+                'httpMethod': method,
+                'resourcePath': uri,
+            },
+            'headers': None,
+            'pathParameters': path,
+            'queryStringParameters': {},
+            'body': "",
+            'stageVariables': {},
+        }
+    return create_empty_header_event_inner
+
+
+@fixture
+def create_event_with_body():
+    def create_event_with_body_inner(body, uri='/', method='POST',
+                                     content_type='application/json'):
+        event = create_event()(uri, method, {}, content_type)
+        if content_type == 'application/json':
+            body = json.dumps(body)
+        event['body'] = body
+        return event
+    return create_event_with_body_inner


### PR DESCRIPTION
BuiltinAuthorizer will now work in local mode. Authorizer types that
cannot be run locally will now simply allow the requests to proceed as
if there were no authorizer to allow for local testing.

closes #404 