### PR TITLE
Issue #470 : Stage feature not functioning as expected

### DIFF
--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -35,7 +35,9 @@ from chalice.constants import DEFAULT_STAGE_NAME, LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
 from chalice.constants import MAX_LAMBDA_DEPLOYMENT_SIZE
+from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.policy import AppPolicyGenerator
+
 
 
 NULLARY = Callable[[], str]
@@ -804,7 +806,8 @@ class APIGatewayDeployer(object):
         # for each rest API, but that would require injecting chalice stage
         # information into the swagger generator.
         rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or DEFAULT_STAGE_NAME
+        api_gateway_stage = config.api_gateway_stage or \
+                            DEFAULT_APIGATEWAY_STAGE_NAME
         self._deploy_api_to_stage(rest_api_id, api_gateway_stage,
                                   deployed_resources)
         return rest_api_id, self._aws_client.region_name, api_gateway_stage
@@ -817,7 +820,8 @@ class APIGatewayDeployer(object):
         LOGGER.debug("Generating swagger document for rest API.")
         swagger_doc = generator.generate_swagger(config.chalice_app)
         self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or DEFAULT_STAGE_NAME
+        api_gateway_stage = config.api_gateway_stage or \
+                            DEFAULT_APIGATEWAY_STAGE_NAME
         self._deploy_api_to_stage(
             rest_api_id, api_gateway_stage,
             deployed_resources)

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -39,7 +39,6 @@ from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.policy import AppPolicyGenerator
 
 
-
 NULLARY = Callable[[], str]
 OPT_RESOURCES = Optional[DeployedResources]
 OPT_STR = Optional[str]
@@ -806,8 +805,8 @@ class APIGatewayDeployer(object):
         # for each rest API, but that would require injecting chalice stage
         # information into the swagger generator.
         rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or \
-                            DEFAULT_APIGATEWAY_STAGE_NAME
+        api_gateway_stage = (config.api_gateway_stage or
+                             DEFAULT_APIGATEWAY_STAGE_NAME)
         self._deploy_api_to_stage(rest_api_id, api_gateway_stage,
                                   deployed_resources)
         return rest_api_id, self._aws_client.region_name, api_gateway_stage
@@ -820,8 +819,8 @@ class APIGatewayDeployer(object):
         LOGGER.debug("Generating swagger document for rest API.")
         swagger_doc = generator.generate_swagger(config.chalice_app)
         self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or \
-                            DEFAULT_APIGATEWAY_STAGE_NAME
+        api_gateway_stage = (config.api_gateway_stage or
+                             DEFAULT_APIGATEWAY_STAGE_NAME)
         self._deploy_api_to_stage(
             rest_api_id, api_gateway_stage,
             deployed_resources)

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -128,7 +128,7 @@ def test_api_gateway_deployer_initial_deploy(config_obj, ui):
     assert isinstance(first_arg, dict)
     assert 'swagger' in first_arg
 
-    aws_client.deploy_rest_api.assert_called_with('rest-api-id', 'dev')
+    aws_client.deploy_rest_api.assert_called_with('rest-api-id', 'api')
     aws_client.add_permission_for_apigateway_if_needed.assert_called_with(
         'func-name', 'us-west-2', 'account-id', 'rest-api-id', mock.ANY
     )
@@ -153,7 +153,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj, ui):
     assert isinstance(second_arg, dict)
     assert 'swagger' in second_arg
 
-    aws_client.deploy_rest_api.assert_called_with('existing-id', 'dev')
+    aws_client.deploy_rest_api.assert_called_with('existing-id', 'api')
     aws_client.add_permission_for_apigateway_if_needed.assert_called_with(
         'func-name', 'us-west-2', 'account-id', 'existing-id', mock.ANY
     )


### PR DESCRIPTION
When configuration for stage is not defined in ```config.json```,  we need to take default APIGateway stage as ```api```. 