### PR TITLE
Fix API Gateway stage not being set correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Next Release (TBD)
   (`#450 <https://github.com/aws/chalice/issues/450>`__)
 * Print useful error message when config.json is invalid
   (`#458 <https://github.com/aws/chalice/pull/458>`__)
+* Fix api gateway stage being set incorrectly in non-default chalice stage
+ (`#$70 <https://github.com/aws/chalice/issues/470>`__)
 
 
 1.0.0

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -108,7 +108,7 @@ def run_local_server(factory, port, env):
               default=None,
               help='Automatically generate IAM policy for app code.')
 @click.option('--profile', help='Override profile at deploy time.')
-@click.option('--api-gateway-stage',
+@click.option('--api-gateway-stage', default=DEFAULT_APIGATEWAY_STAGE_NAME,
               help='Name of the API gateway stage to deploy to.')
 @click.option('--stage', default=DEFAULT_STAGE_NAME,
               help=('Name of the Chalice stage to deploy to. '

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -15,6 +15,7 @@ from chalice.deploy import deployer
 from chalice.package import create_app_packager
 from chalice.package import AppPackager  # noqa
 from chalice.constants import DEFAULT_STAGE_NAME
+from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.logs import LogRetriever
 from chalice import local
 from chalice.utils import UI  # noqa
@@ -87,8 +88,9 @@ class CLIFactory(object):
             session=session, ui=ui)
 
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
-                          autogen_policy=None, api_gateway_stage=None):
-        # type: (str, Optional[bool], Optional[str]) -> Config
+                          autogen_policy=None,
+                          api_gateway_stage=DEFAULT_APIGATEWAY_STAGE_NAME):
+        # type: (str, Optional[bool], str) -> Config
         user_provided_params = {}  # type: Dict[str, Any]
         default_params = {'project_dir': self.project_dir,
                           'autogen_policy': True}

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -35,7 +35,6 @@ from chalice.constants import DEFAULT_STAGE_NAME, LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
 from chalice.constants import MAX_LAMBDA_DEPLOYMENT_SIZE
-from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.policy import AppPolicyGenerator
 
 
@@ -805,8 +804,7 @@ class APIGatewayDeployer(object):
         # for each rest API, but that would require injecting chalice stage
         # information into the swagger generator.
         rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        api_gateway_stage = (config.api_gateway_stage or
-                             DEFAULT_APIGATEWAY_STAGE_NAME)
+        api_gateway_stage = config.api_gateway_stage
         self._deploy_api_to_stage(rest_api_id, api_gateway_stage,
                                   deployed_resources)
         return rest_api_id, self._aws_client.region_name, api_gateway_stage
@@ -819,8 +817,7 @@ class APIGatewayDeployer(object):
         LOGGER.debug("Generating swagger document for rest API.")
         swagger_doc = generator.generate_swagger(config.chalice_app)
         self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        api_gateway_stage = (config.api_gateway_stage or
-                             DEFAULT_APIGATEWAY_STAGE_NAME)
+        api_gateway_stage = config.api_gateway_stage
         self._deploy_api_to_stage(
             rest_api_id, api_gateway_stage,
             deployed_resources)

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -35,7 +35,9 @@ from chalice.constants import DEFAULT_STAGE_NAME, LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
 from chalice.constants import MAX_LAMBDA_DEPLOYMENT_SIZE
+from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.policy import AppPolicyGenerator
+
 
 
 NULLARY = Callable[[], str]
@@ -804,7 +806,8 @@ class APIGatewayDeployer(object):
         # for each rest API, but that would require injecting chalice stage
         # information into the swagger generator.
         rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or DEFAULT_STAGE_NAME
+        api_gateway_stage = config.api_gateway_stage or \
+                            DEFAULT_APIGATEWAY_STAGE_NAME
         self._deploy_api_to_stage(rest_api_id, api_gateway_stage,
                                   deployed_resources)
         return rest_api_id, self._aws_client.region_name, api_gateway_stage
@@ -817,7 +820,8 @@ class APIGatewayDeployer(object):
         LOGGER.debug("Generating swagger document for rest API.")
         swagger_doc = generator.generate_swagger(config.chalice_app)
         self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or DEFAULT_STAGE_NAME
+        api_gateway_stage = config.api_gateway_stage or \
+                            DEFAULT_APIGATEWAY_STAGE_NAME
         self._deploy_api_to_stage(
             rest_api_id, api_gateway_stage,
             deployed_resources)

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -39,7 +39,6 @@ from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.policy import AppPolicyGenerator
 
 
-
 NULLARY = Callable[[], str]
 OPT_RESOURCES = Optional[DeployedResources]
 OPT_STR = Optional[str]
@@ -806,8 +805,8 @@ class APIGatewayDeployer(object):
         # for each rest API, but that would require injecting chalice stage
         # information into the swagger generator.
         rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or \
-                            DEFAULT_APIGATEWAY_STAGE_NAME
+        api_gateway_stage = (config.api_gateway_stage or
+                             DEFAULT_APIGATEWAY_STAGE_NAME)
         self._deploy_api_to_stage(rest_api_id, api_gateway_stage,
                                   deployed_resources)
         return rest_api_id, self._aws_client.region_name, api_gateway_stage
@@ -820,8 +819,8 @@ class APIGatewayDeployer(object):
         LOGGER.debug("Generating swagger document for rest API.")
         swagger_doc = generator.generate_swagger(config.chalice_app)
         self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        api_gateway_stage = config.api_gateway_stage or \
-                            DEFAULT_APIGATEWAY_STAGE_NAME
+        api_gateway_stage = (config.api_gateway_stage or
+                             DEFAULT_APIGATEWAY_STAGE_NAME)
         self._deploy_api_to_stage(
             rest_api_id, api_gateway_stage,
             deployed_resources)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -169,6 +169,21 @@ def test_can_deploy(runner, mock_cli_factory, mock_deployer):
             assert data == deployed_values
 
 
+def test_does_deploy_with_default_api_gateway_stage_name(
+        runner, mock_cli_factory, mock_deployer):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        _run_cli_command(runner, cli.deploy, [], cli_factory=mock_cli_factory)
+        call = mock_cli_factory.create_config_obj.call_args
+        expected_call = mock.call(
+            api_gateway_stage='api',
+            autogen_policy=None,
+            chalice_stage_name='dev'
+        )
+        assert call == expected_call
+
+
 def test_can_delete(runner, mock_cli_factory, mock_deployer):
     deployed_values = {
         'dev': {

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -101,6 +101,11 @@ def test_can_create_config_obj_with_api_gateway_stage(clifactory):
     assert config.api_gateway_stage == 'custom-stage'
 
 
+def test_can_create_config_obj_with_default_api_gateway_stage(clifactory):
+    config = clifactory.create_config_obj()
+    assert config.api_gateway_stage == 'api'
+
+
 def test_cant_load_config_obj_with_bad_project(clifactory):
     clifactory.project_dir = 'nowhere-asdfasdfasdfas'
     with pytest.raises(RuntimeError):

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -128,7 +128,7 @@ def test_api_gateway_deployer_initial_deploy(config_obj, ui):
     assert isinstance(first_arg, dict)
     assert 'swagger' in first_arg
 
-    aws_client.deploy_rest_api.assert_called_with('rest-api-id', 'dev')
+    aws_client.deploy_rest_api.assert_called_with('rest-api-id', 'api')
     aws_client.add_permission_for_apigateway_if_needed.assert_called_with(
         'func-name', 'us-west-2', 'account-id', 'rest-api-id', mock.ANY
     )
@@ -153,7 +153,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj, ui):
     assert isinstance(second_arg, dict)
     assert 'swagger' in second_arg
 
-    aws_client.deploy_rest_api.assert_called_with('existing-id', 'dev')
+    aws_client.deploy_rest_api.assert_called_with('existing-id', 'api')
     aws_client.add_permission_for_apigateway_if_needed.assert_called_with(
         'func-name', 'us-west-2', 'account-id', 'existing-id', mock.ANY
     )

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -98,6 +98,7 @@ def config_obj(sample_app):
     config = Config.create(
         chalice_app=sample_app,
         stage='dev',
+        api_gateway_stage='api',
     )
     return config
 
@@ -140,7 +141,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj, ui):
     # The rest_api_id does not exist which will trigger
     # the initial import
     deployed = DeployedResources(
-        None, None, None, 'existing-id', 'dev', None, None, {})
+        None, None, None, 'existing-id', 'api', None, None, {})
     aws_client.rest_api_exists.return_value = True
     lambda_arn = 'arn:aws:lambda:us-west-2:account-id:function:func-name'
 
@@ -164,7 +165,7 @@ def test_api_gateway_deployer_delete(config_obj, ui):
 
     rest_api_id = 'abcdef1234'
     deployed = DeployedResources(
-        None, None, None, rest_api_id, 'dev', None, None, {})
+        None, None, None, rest_api_id, 'api', None, None, {})
     aws_client.rest_api_exists.return_value = True
 
     d = APIGatewayDeployer(aws_client, ui)
@@ -178,7 +179,7 @@ def test_api_gateway_deployer_delete_already_deleted(ui):
     aws_client.delete_rest_api.side_effect = ResourceDoesNotExistError(
         rest_api_id)
     deployed = DeployedResources(
-        None, None, None, rest_api_id, 'dev', None, None, {})
+        None, None, None, rest_api_id, 'api', None, None, {})
     aws_client.rest_api_exists.return_value = True
     d = APIGatewayDeployer(aws_client, ui)
     d.delete(deployed)


### PR DESCRIPTION
The API Gateway stage is not set correctly since it was renamed from dev
to api. This change enforces the 'api' default all the way through the
config layer and CLI layer rather than making the end code that consumes
the configuration manually enforce a default everywhere the api gateway
stage name is used.

fixes #470


@achautha Thanks for the contribution. I added a few more tests and more strict defaults in the Config object itself.

closes #474