### PR TITLE
Parse the accept header fully and return success if response matches …

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -8,6 +8,7 @@ import traceback
 import decimal
 import base64
 from collections import defaultdict, Mapping
+from mime import AcceptableType
 
 __version__ = '1.0.0'
 
@@ -634,11 +635,13 @@ class Chalice(object):
             'content-type', 'application/json')
         response_is_binary = _matches_content_type(response_content_type,
                                                    self.api.binary_types)
-        expects_binary_response = False
+        matches_accepted = False
         if request_accept_header is not None:
-            expects_binary_response = _matches_content_type(
-                request_accept_header, self.api.binary_types)
-        if response_is_binary and not expects_binary_response:
+            accept_types = AcceptableType.parse_header(request_accept_header)
+            for accept_type in accept_types:
+                matches_accepted = matches_accepted or\
+                                   accept_type.matches(response_content_type)
+        if response_is_binary and not matches_accepted:
             return False
         return True
 

--- a/chalice/mime.py
+++ b/chalice/mime.py
@@ -1,0 +1,42 @@
+import re
+
+valid_mime_type = re.compile(r'^(\*|[a-zA-Z0-9._-]+)(/(\*|[a-zA-Z0-9._-]+))?$')
+
+
+class AcceptableType:
+    mime_type = None
+    pattern = None
+
+    def __init__(self, raw_mime_type):
+        bits = raw_mime_type.split(';', 1)
+
+        mime_type = bits[0]
+        if not valid_mime_type.match(mime_type):
+            raise ValueError('"%s" is not a valid mime type' % mime_type)
+
+        self.mime_type = mime_type
+        self.pattern = re.compile('^' + mime_type.replace('*', '[a-zA-Z0-9_.$#!%^*-]+') + '$')
+
+    @staticmethod
+    def parse_header(header):
+        raw_mime_types = header.split(',')
+        mime_types = []
+        for raw_mime_type in raw_mime_types:
+            try:
+                mime_types.append(AcceptableType(raw_mime_type.strip()))
+            except ValueError:
+                pass
+
+        return mime_types
+
+    def matches(self, mime_type):
+        return self.pattern.match(mime_type)
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.mime_type
+
+    def __repr__(self):
+        return '<AcceptableType {0}>'.format(self)


### PR DESCRIPTION
…any of accept

Let me explain why I'm making this change. I have an endpoint that I want to return an image like so:
```
@app.route('/sp', methods=['GET'], cors=cors_config)
def pixel():
    return Response(PNG_PIXEL_DATA, headers={
        'Content-Type': 'image/png'
    })
```
This will be embedded in a webpage like `<img src='http://localhost:8000/sp' \>`. However, a browser (like Chrome) won't send the Accept header "image/png", it will send something like `Accept:image/webp,image/apng,image/*,*/*;q=0.8`. Chalice doesn't call this a match and throws out a 400. This is my attempt to fix this so that `Accept: image/*` will match `Content-Type: image/png`. I know this PR has no tests, but I wanted to see if this was an acceptable solution before writing any tests. Please gimme feedback (especially if this behavior exists due to some API Gateway behavior as I've only tested this via chalice local)!