### PR TITLE
Move 'parameters' key in swagger up one level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Fix issue where requestParameters were not being mapped
+  correctly resulting in invalid generated javascript SDKs
+  (`#498 <https://github.com/aws/chalice/issues/498>`__)
+
+
 1.0.1
 =====
 

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -128,6 +128,8 @@ class SwaggerGenerator(object):
             current['security'] = [{'api_key': []}]
         if view.authorizer:
             current['security'] = [{view.authorizer.name: []}]
+        if view.view_args:
+            self._add_view_args(current, view.view_args)
         return current
 
     def _generate_precanned_responses(self):
@@ -164,13 +166,11 @@ class SwaggerGenerator(object):
             'contentHandling': 'CONVERT_TO_TEXT',
             'type': 'aws_proxy',
         }
-        if view.view_args:
-            self._add_view_args(apig_integ, view.view_args)
         return apig_integ
 
-    def _add_view_args(self, apig_integ, view_args):
+    def _add_view_args(self, single_method, view_args):
         # type: (Dict[str, Any], List[str]) -> None
-        apig_integ['parameters'] = [
+        single_method['parameters'] = [
             {'name': name, 'in': 'path', 'required': True, 'type': 'string'}
             for name in view_args
         ]

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -64,9 +64,8 @@ def test_can_add_url_captures_to_params(sample_app, swagger_gen):
 
     doc = swagger_gen.generate_swagger(sample_app)
     single_method = doc['paths']['/path/{capture}']['get']
-    apig_integ = single_method['x-amazon-apigateway-integration']
-    assert 'parameters' in apig_integ
-    assert apig_integ['parameters'] == [
+    assert 'parameters' in single_method
+    assert single_method['parameters'] == [
         {'name': "capture", "in": "path", "required": True, "type": "string"}
     ]
 


### PR DESCRIPTION
This should not be in the x-amazon-apigateway-integration
key but instead in the key for the http method which is up
one level.

Fixes #498