### PR TITLE
Allow api_gateway_stage to be set from config.json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Fix issue where ``api_gateway_stage`` was being
+  ignored when set in the ``config.json`` file
+  (`#495 <https://github.com/aws/chalice/issues/495>`__)
+
+
 1.0.1
 =====
 

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -108,7 +108,7 @@ def run_local_server(factory, port, env):
               default=None,
               help='Automatically generate IAM policy for app code.')
 @click.option('--profile', help='Override profile at deploy time.')
-@click.option('--api-gateway-stage', default=DEFAULT_APIGATEWAY_STAGE_NAME,
+@click.option('--api-gateway-stage',
               help='Name of the API gateway stage to deploy to.')
 @click.option('--stage', default=DEFAULT_STAGE_NAME,
               help=('Name of the Chalice stage to deploy to. '

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -89,10 +89,11 @@ class CLIFactory(object):
 
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None,
-                          api_gateway_stage=DEFAULT_APIGATEWAY_STAGE_NAME):
+                          api_gateway_stage=None):
         # type: (str, Optional[bool], str) -> Config
         user_provided_params = {}  # type: Dict[str, Any]
         default_params = {'project_dir': self.project_dir,
+                          'api_gateway_stage': DEFAULT_APIGATEWAY_STAGE_NAME,
                           'autogen_policy': True}
         try:
             config_from_disk = self.load_project_config()

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -174,14 +174,17 @@ def test_does_deploy_with_default_api_gateway_stage_name(
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')
         os.chdir('testproject')
-        _run_cli_command(runner, cli.deploy, [], cli_factory=mock_cli_factory)
-        call = mock_cli_factory.create_config_obj.call_args
-        expected_call = mock.call(
-            api_gateway_stage='api',
+        # This isn't perfect as we're assuming we know how to
+        # create the config_obj like the deploy() command does,
+        # it should give us more confidence that the api gateway
+        # stage defaults are still working.
+        cli_factory = factory.CLIFactory('.')
+        config = cli_factory.create_config_obj(
+            chalice_stage_name='dev',
             autogen_policy=None,
-            chalice_stage_name='dev'
+            api_gateway_stage=None
         )
-        assert call == expected_call
+        assert config.api_gateway_stage == DEFAULT_APIGATEWAY_STAGE_NAME
 
 
 def test_can_delete(runner, mock_cli_factory, mock_deployer):


### PR DESCRIPTION
Anything that has chained precedence can't be defaulted at
the CLI layer because you can't differentiate between
a default value vs. not set.  In this case, `None` is used
as the sentinel to indicate not set.

The defaulting still happens in the CLI factory layer, it's just
that it needs to do in the "defaults" dict that is the final
fallback if no other value for a config key was found in the
various search dicts.

This is how `autogen_policy` is handled, so this change uses
that same approach but for `api_gateway_stage`.

Fixes #495