### PR TITLE
Fix error code propagation from subprocess pip

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -584,7 +584,7 @@ class SubprocessPip(object):
             shim = ''
         env_vars.update(subprocess_python_base_environ)
         python_exe = sys.executable
-        run_pip = 'import pip; pip.main(%s)' % args
+        run_pip = 'import pip, sys; sys.exit(pip.main(%s))' % args
         exec_string = '%s%s' % (shim, run_pip)
         invoke_pip = [python_exe, '-c', exec_string]
         p = subprocess.Popen(invoke_pip,

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,0 +1,60 @@
+import os
+import uuid
+from contextlib import contextmanager
+
+from click.testing import CliRunner
+import pytest
+
+from chalice import cli
+from chalice.cli import factory
+from chalice.cli import create_new_project_skeleton
+from chalice.deploy.packager import NoSuchPackageError
+
+
+@contextmanager
+def cd(path):
+    try:
+        original_dir = os.getcwd()
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original_dir)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def app_skeleton(tmpdir, runner):
+    project_name = 'deployment-integ-test'
+    with cd(tmpdir):
+        create_new_project_skeleton(project_name, None)
+    return str(os.path.join(tmpdir, project_name))
+
+
+def _get_random_package_name():
+    return 'foobar-%s' % str(uuid.uuid4())[:8]
+
+
+class TestPackage(object):
+    def test_does_not_package_bad_requirements_file(
+            self, runner, app_skeleton):
+        req = os.path.join(app_skeleton, 'requirements.txt')
+        package = _get_random_package_name()
+        with open(req, 'w') as f:
+            f.write('%s\n' % package)
+        cli_factory = factory.CLIFactory(app_skeleton)
+
+        # Try to build a deployment package from the bad requirements file.
+        # It should fail with a NoSuchPackageError error since the package
+        # should not exist.
+        result = runner.invoke(
+            cli.package, ['package'], obj={'project_dir': app_skeleton,
+                                           'debug': False,
+                                           'factory': cli_factory})
+        assert result.exception is not None
+        ex = result.exception
+        assert isinstance(ex, NoSuchPackageError)
+        assert str(ex) == 'Could not satisfy the requirement: %s' % package

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -118,6 +118,15 @@ class TestSubprocessPip(object):
         assert rc == 0
         assert err == b''
 
+    def test_does_error_code_propagate(self):
+        pip = SubprocessPip()
+        rc, err = pip.main(['badcommand'])
+        assert rc != 0
+        # Don't want to depend on a particular error message from pip since it
+        # may change if we pin a differnet version to Chalice at some point.
+        # But there should be a non-empty error message of some kind.
+        assert err != b''
+
 
 class TestPipRunner(object):
     def test_build_wheel(self, pip_runner):


### PR DESCRIPTION
Error codes were not returned which would result in pip failures not
cancelling the Chalice deploy process when they should. For example if
you provided a bad package name that pip failed to find the error would
be ignored and all the partial package would be deployed anyway.

Fixes #500