### PR TITLE
Don't assume the response attr always exist

### DIFF
--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -128,11 +128,18 @@ def _deploy_with_retries(deployer, config, max_attempts=10):
             # API Gateway aggressively throttles deployments.
             # If we run into this case, we just wait and try
             # again.
-            error_code = e.original_error.response['Error']['Code']
+            error_code = _get_error_code_from_exception(e)
             if error_code != 'TooManyRequestsException':
                 raise
             time.sleep(20)
     raise RuntimeError("Failed to deploy app after %s attempts" % max_attempts)
+
+
+def _get_error_code_from_exception(exception):
+    error_response = getattr(exception.original_error, 'response', None)
+    if error_response is None:
+        return None
+    return error_response.get('Error', {}).get('Code')
 
 
 def _delete_app(application):


### PR DESCRIPTION
The ChaliceDeploymentError wraps an exception but it's
not always a botocore error.  It can also wrap a
requests.ConnectionError in which case there will be no
`.response` attribute.  This was triggering an "AttributeError"
in some of the failure cases which obscures the original error.