### PR TITLE
Use a random app name on integ tests

### DIFF
--- a/tests/integration/testapp/.chalice/config.json
+++ b/tests/integration/testapp/.chalice/config.json
@@ -1,9 +1,12 @@
 {
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "environment_variables": {
+        "APP_NAME": "replaceme"
+      }
     }
   },
   "version": "2.0",
-  "app_name": "smoketestapp"
+  "app_name": "replaceme"
 }

--- a/tests/integration/testapp/app-redeploy.py
+++ b/tests/integration/testapp/app-redeploy.py
@@ -4,10 +4,12 @@ This file is copied over to app.py during the integration
 tests to test behavior on redeploys.
 
 """
+import os
+
 from chalice import Chalice
 
 
-app = Chalice(app_name='smoketestapp')
+app = Chalice(app_name=os.environ['APP_NAME'])
 
 
 # Test an unchanged view, this is the exact

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,16 +1,19 @@
-from chalice import Chalice, BadRequestError, NotFoundError, Response,\
-    CORSConfig, UnauthorizedError, AuthResponse, AuthRoute
-
+import os
 try:
     from urllib.parse import parse_qs
 except:
     from urlparse import parse_qs
 
+
+from chalice import Chalice, BadRequestError, NotFoundError, Response,\
+    CORSConfig, UnauthorizedError, AuthResponse, AuthRoute
+
+
 # This is a test app that is used by integration tests.
 # This app exercises all the major features of chalice
 # and helps prevent regressions.
 
-app = Chalice(app_name='smoketestapp')
+app = Chalice(app_name=os.environ['APP_NAME'])
 app.api.binary_types.append('application/binary')
 
 


### PR DESCRIPTION
Hard coded app names is problematic if multiple CI systems
are running the same integ tests within the same AWS account.

This also ensures that any failure to cleanup state from a previous
run won't affect subsequent test runs.