### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,26 @@
+DEPLOY_TEST_BASENAME = 'test_features.py'
+
+
 def pytest_collection_modifyitems(session, config, items):
     # Ensure that all tests with require a redeploy are run after
     # tests that don't need a redeploy.
-    final_list = []
-    on_redeploy_tests = []
-    for item in items:
+    start, end = _get_start_end_index(DEPLOY_TEST_BASENAME, items)
+    marked = []
+    unmarked = []
+    for item in items[start:end]:
         if item.get_marker('on_redeploy') is not None:
-            on_redeploy_tests.append(item)
+            marked.append(item)
         else:
-            final_list.append(item)
-    final_list.extend(on_redeploy_tests)
-    items[:] = final_list
+            unmarked.append(item)
+    items[start:end] = unmarked + marked
+
+
+def _get_start_end_index(basename, items):
+    # precondition: all the tests for test_features.py are
+    # in a contiguous range.  This is the case because pytest
+    # will group all tests in a module together.
+    matched = [item.fspath.basename == basename for item in items]
+    return (
+        matched.index(True),
+        len(matched) - list(reversed(matched)).index(True)
+    )

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -29,9 +29,9 @@ def runner():
 @pytest.fixture
 def app_skeleton(tmpdir, runner):
     project_name = 'deployment-integ-test'
-    with cd(tmpdir):
+    with cd(str(tmpdir)):
         create_new_project_skeleton(project_name, None)
-    return str(os.path.join(tmpdir, project_name))
+    return str(tmpdir.join(project_name))
 
 
 def _get_random_package_name():


### PR DESCRIPTION
Two issues:

1. The test_package.py tests don't work on py27.
2. With the addition of test_package.py, the logic in the test reordering for redeploys was wrong.  It made the assumption that test_features.py was the only integration test.  We now need to make sure we only reorder tests within test_features.py.

In other order, for point 2 above, when test_package.py was added we had:

```
<Module 'tests/integration/test_features.py'>
  <Function 'test_returns_simple_response'>
  <Function 'test_can_have_nested_routes'>
  <Function 'test_supports_path_params'>
  <Function 'test_path_params_mapped_in_api'>
  <Function 'test_supports_post'>
  <Function 'test_supports_put'>
  <Function 'test_supports_shared_routes'>
  <Function 'test_can_read_json_body_on_post'>
  <Function 'test_can_raise_bad_request'>
  <Function 'test_can_raise_not_found'>
  <Function 'test_unexpected_error_raises_500_in_prod_mode'>
  <Function 'test_can_route_multiple_methods_in_one_view'>
  <Function 'test_form_encoded_content_type'>
  <Function 'test_can_round_trip_binary'>
  <Function 'test_can_round_trip_binary_custom_content_type'>
  <Function 'test_can_support_cors'>
  <Function 'test_can_support_custom_cors'>
  <Function 'test_to_dict_is_also_json_serializable'>
  <Function 'test_multfile_support'>
  <Function 'test_custom_response'>
  <Function 'test_api_key_required_fails_with_no_key'>
  <Function 'test_can_handle_charset'>
  <Function 'test_can_use_builtin_custom_auth'>
  <Function 'test_can_use_shared_auth'>
  <Function 'test_empty_raw_body'>
<Module 'tests/integration/test_package.py'>
  <Class 'TestPackage'>
    <Instance '()'>
      <Function 'test_does_not_package_bad_requirements_file'>
<Module 'tests/integration/test_features.py'>
  <Function 'test_redeploy_no_change_view'>
  <Function 'test_redeploy_changed_function'>
  <Function 'test_redeploy_new_function'>
  <Function 'test_redeploy_change_route_info'>
  <Function 'test_redeploy_view_deleted'>
```

Which screwed up the module fixtures used for deploying apps.  Looks like the module was re-imported because a new uuid was generated.

With this change, we now have the desired behavior:

```
<Module 'tests/integration/test_features.py'>
  <Function 'test_returns_simple_response'>
  <Function 'test_can_have_nested_routes'>
  <Function 'test_supports_path_params'>
  <Function 'test_path_params_mapped_in_api'>
  <Function 'test_supports_post'>
  <Function 'test_supports_put'>
  <Function 'test_supports_shared_routes'>
  <Function 'test_can_read_json_body_on_post'>
  <Function 'test_can_raise_bad_request'>
  <Function 'test_can_raise_not_found'>
  <Function 'test_unexpected_error_raises_500_in_prod_mode'>
  <Function 'test_can_route_multiple_methods_in_one_view'>
  <Function 'test_form_encoded_content_type'>
  <Function 'test_can_round_trip_binary'>
  <Function 'test_can_round_trip_binary_custom_content_type'>
  <Function 'test_can_support_cors'>
  <Function 'test_can_support_custom_cors'>
  <Function 'test_to_dict_is_also_json_serializable'>
  <Function 'test_multfile_support'>
  <Function 'test_custom_response'>
  <Function 'test_api_key_required_fails_with_no_key'>
  <Function 'test_can_handle_charset'>
  <Function 'test_can_use_builtin_custom_auth'>
  <Function 'test_can_use_shared_auth'>
  <Function 'test_empty_raw_body'>
  <Function 'test_redeploy_no_change_view'>
  <Function 'test_redeploy_changed_function'>
  <Function 'test_redeploy_new_function'>
  <Function 'test_redeploy_change_route_info'>
  <Function 'test_redeploy_view_deleted'>
<Module 'tests/integration/test_package.py'>
  <Class 'TestPackage'>
    <Instance '()'>
      <Function 'test_does_not_package_bad_requirements_file'>
```