### PR TITLE
Make integ tests more robust

### DIFF
--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -330,6 +330,7 @@ def test_can_round_trip_binary(smoke_test_app):
                                  'Accept': 'application/octet-stream',
                              },
                              data=bin_data)
+    response.raise_for_status()
     assert response.content == bin_data
 
 


### PR DESCRIPTION
1. Poll for resource id retrieval, it can take a while to propagate
2. Add missing `raise_for_status()` call to get better error messages on failure.