### PR TITLE
Only rearrange integ tests if we see test_features tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,8 @@ def _get_start_end_index(basename, items):
     # in a contiguous range.  This is the case because pytest
     # will group all tests in a module together.
     matched = [item.fspath.basename == basename for item in items]
+    if not any(matched):
+        return 0, len(items)
     return (
         matched.index(True),
         len(matched) - list(reversed(matched)).index(True)


### PR DESCRIPTION
You can now run individual tests:

```
$ py.test tests/integration/test_package.py
platform darwin -- Python 2.7.12, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/jamessar/Source/chalice, inifile:
plugins: cov-2.4.0, hypothesis-3.8.2
collected 1 items

tests/integration/test_package.py .

=== 1 passed in 1.13 seconds ===