### PR TITLE
Initial POC of new deployer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ sample/
 venv
 docs/build/
 .idea
-*.py?
 __pycache__/
 .coverage
 chalice.egg-info/

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -130,6 +130,36 @@ def deploy(ctx, autogen_policy, profile, api_gateway_stage, stage):
         config.project_dir, '.chalice', 'deployed.json'))
 
 
+@cli.command('deploy-new')
+@click.option('--autogen-policy/--no-autogen-policy',
+              default=None,
+              help='Automatically generate IAM policy for app code.')
+@click.option('--profile', help='Override profile at deploy time.')
+@click.option('--api-gateway-stage',
+              help='Name of the API gateway stage to deploy to.')
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+              help=('Name of the Chalice stage to deploy to. '
+                    'Specifying a new chalice stage will create '
+                    'an entirely new set of AWS resources.'))
+@click.pass_context
+def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
+    # type: (click.Context, Optional[bool], str, str, str) -> None
+    # This is just a temporary command so that both deployers
+    # can be used simultaneously.  This will eventually just
+    # become the 'deploy' command and the old one will be removed.
+    factory = ctx.obj['factory']  # type: CLIFactory
+    factory.profile = profile
+    config = factory.create_config_obj(
+        chalice_stage_name=stage, autogen_policy=autogen_policy,
+        api_gateway_stage=api_gateway_stage,
+    )
+    session = factory.create_botocore_session()
+    d = factory.create_new_default_deployer(session=session)
+    deployed_values = d.deploy(config, chalice_stage_name=stage)
+    record_deployed_values(deployed_values, os.path.join(
+        config.project_dir, '.chalice', 'deployed.json'))
+
+
 @cli.command('delete')
 @click.option('--profile', help='Override profile at deploy time.')
 @click.option('--stage', default=DEFAULT_STAGE_NAME,

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -19,6 +19,7 @@ from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.logs import LogRetriever
 from chalice import local
 from chalice.utils import UI  # noqa
+from chalice.deploy import newdeployer
 
 
 def create_botocore_session(profile=None, debug=False):
@@ -86,6 +87,10 @@ class CLIFactory(object):
         # type: (Session, UI) -> deployer.Deployer
         return deployer.create_default_deployer(
             session=session, ui=ui)
+
+    def create_new_default_deployer(self, session):
+        # type: (Session) -> newdeployer.Deployer
+        return newdeployer.create_default_deployer(session)
 
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None,

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -1,0 +1,87 @@
+import enum
+from attr import attrs, attrib
+
+
+class DeployPhase(enum.Enum):
+    BUILD = 'build'
+    DEPLOY = 'deploy'
+
+
+class Model(object):
+    def dependencies(self):
+        return []
+
+
+@attrs
+class ManagedModel(Model):
+    resource_name = attrib()
+    # Subclasses must fill in this attribute.
+    resource_type = ''
+
+
+@attrs
+class Application(Model):
+    stage = attrib()
+    resources = attrib()
+
+    def dependencies(self):
+        return self.resources
+
+
+@attrs
+class DeploymentPackage(Model):
+    filename = attrib()
+
+
+@attrs
+class IAMPolicy(Model):
+    pass
+
+
+@attrs
+class FileBasedIAMPolicy(IAMPolicy):
+    filename = attrib()
+
+
+@attrs
+class AutoGenIAMPolicy(IAMPolicy):
+    document = attrib()
+
+
+@attrs
+class IAMRole(Model):
+    pass
+
+
+@attrs
+class PreCreatedIAMRole(IAMRole):
+    role_arn = attrib()
+
+
+@attrs
+class ManagedIAMRole(IAMRole, ManagedModel):
+    resource_type = 'iam_role'
+    role_arn = attrib()
+    role_name = attrib()
+    trust_policy = attrib()
+    policy = attrib()
+
+    def dependencies(self):
+        return [self.policy]
+
+
+@attrs
+class LambdaFunction(ManagedModel):
+    resource_type = 'lambda_function'
+    function_name = attrib()
+    deployment_package = attrib()
+    environment_variables = attrib()
+    runtime = attrib()
+    handler = attrib()
+    tags = attrib()
+    timeout = attrib()
+    memory_size = attrib()
+    role = attrib()
+
+    def dependencies(self):
+        return [self.role, self.deployment_package]

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -2,9 +2,9 @@ import enum
 from attr import attrs, attrib
 
 
-class DeployPhase(enum.Enum):
-    BUILD = 'build'
-    DEPLOY = 'deploy'
+class Placeholder(enum.Enum):
+    BUILD_STAGE = 'build_stage'
+    DEPLOY_STAGE = 'deploy_stage'
 
 
 class Model(object):

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -1,0 +1,124 @@
+from typing import List, Dict, Any, TypeVar, Union
+import enum
+
+class DeployPhase(enum.Enum):
+    BUILD = 'build'
+    DEPLOY = 'deploy'
+
+
+T = TypeVar('T')
+DV = Union[DeployPhase, T]
+STR_MAP = Dict[str, str]
+
+
+class Model:
+    def dependencies(self) -> List[Model]: ...
+
+
+class ManagedModel(Model):
+    resource_name = ...  # type: str
+    resource_type = ...  # type: str
+
+
+class Application(Model):
+    stage = ...  # type: str
+    resources = ... # type: List[Model]
+
+    def __init__(self,
+                 stage,       # type: str
+                 resources,   # type: List[Model]
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class DeploymentPackage(Model):
+    filename = ...  # type: str
+
+    def __init__(self,
+                 filename,   # type: DV[str]
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class IAMPolicy(Model):
+    pass
+
+
+class FileBasedIAMPolicy(IAMPolicy):
+    filename = ...  # type: str
+
+    def __init__(self,
+                 filename,   # type: str
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class AutoGenIAMPolicy(IAMPolicy):
+    document = ...  # type: DV[Dict[str, Any]]
+
+    def __init__(self,
+                 document,   # type: DV[Dict[str, Any]]
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class IAMRole(Model):
+    pass
+
+
+class PreCreatedIAMRole(IAMRole):
+    role_arn = ... # type: str
+
+    def __init__(self,
+                 role_arn,   # type: str
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class ManagedIAMRole(IAMRole, ManagedModel):
+    role_arn = ... # type: DV[str]
+    role_name = ... # type: str
+    trust_policy = ... # type: Dict[str, Any]
+    policy = ... # type: IAMPolicy
+
+    def __init__(self,
+                 resource_name,  # type: str
+                 role_arn,       # type: DV[str]
+                 role_name,      # type: str
+                 trust_policy,   # type: Dict[str, Any]
+                 policy,         # type: IAMPolicy
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class LambdaFunction(ManagedModel):
+    function_name = ... # type: str
+    deployment_package = ... # type: DeploymentPackage
+    environment_variables = ... # type: STR_MAP
+    runtime = ... # type: str
+    handler = ... # type: str
+    tags = ... # type: STR_MAP
+    timeout = ... # type: int
+    memory_size = ... # type: int
+    role = ... # type: IAMRole
+
+    def __init__(self,
+                 resource_name,           # type: str
+                 function_name,           # type: str
+                 deployment_package,      # type: DeploymentPackage
+                 environment_variables,   # type: STR_MAP
+                 runtime,                 # type: str
+                 handler,                 # type: str
+                 tags,                    # type: STR_MAP
+                 timeout,                 # type: int
+                 memory_size,             # type: int
+                 role,                    # type: IAMRole
+                 ):
+        # type: (...) -> None
+        ...

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -1,13 +1,13 @@
 from typing import List, Dict, Any, TypeVar, Union
 import enum
 
-class DeployPhase(enum.Enum):
-    BUILD = 'build'
-    DEPLOY = 'deploy'
+class Placeholder(enum.Enum):
+    BUILD_STAGE = 'build_stage'
+    DEPLOY_STAGE = 'deploy_stage'
 
 
 T = TypeVar('T')
-DV = Union[DeployPhase, T]
+DV = Union[Placeholder, T]
 STR_MAP = Dict[str, str]
 
 

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -363,7 +363,7 @@ class PlanStage(object):
              'tags': resource.tags,
              'timeout': resource.timeout,
              'memory_size': resource.memory_size},
-            '%s_arn' % resource.resource_name,
+            '%s_lambda_arn' % resource.resource_name,
             resource,
         )
 

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -144,6 +144,7 @@ class UnresolvedValueError(Exception):
     )
 
     def __init__(self, key, value, method_name):
+        # type: (str, models.Placeholder, str) -> None
         msg = self.MSG % (key, value, method_name)
         super(UnresolvedValueError, self).__init__(msg)
         self.key = key

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -111,7 +111,7 @@ def create_default_deployer(session):
         pip_runner=pip_runner
     )
     return Deployer(
-        resource_builder=ApplicationGraphBuilder(),
+        application_builder=ApplicationGraphBuilder(),
         deps_builder=DependencyBuilder(),
         build_stage=BuildStage(
             steps=[
@@ -154,14 +154,14 @@ class UnresolvedValueError(Exception):
 
 class Deployer(object):
     def __init__(self,
-                 resource_builder,  # type: ApplicationGraphBuilder
-                 deps_builder,      # type: DependencyBuilder
-                 build_stage,       # type: BuildStage
-                 plan_stage,        # type: PlanStage
-                 executor,          # type: Executor
+                 application_builder,  # type: ApplicationGraphBuilder
+                 deps_builder,         # type: DependencyBuilder
+                 build_stage,          # type: BuildStage
+                 plan_stage,           # type: PlanStage
+                 executor,             # type: Executor
                  ):
         # type: (...) -> None
-        self._resource_builder = resource_builder
+        self._application_builder = application_builder
         self._deps_builder = deps_builder
         self._build_stage = build_stage
         self._plan_stage = plan_stage
@@ -169,7 +169,8 @@ class Deployer(object):
 
     def deploy(self, config, chalice_stage_name):
         # type: (Config, str) -> Dict[str, Any]
-        application = self._resource_builder.build(config, chalice_stage_name)
+        application = self._application_builder.build(
+            config, chalice_stage_name)
         resources = self._deps_builder.build_dependencies(application)
         self._build_stage.execute(config, resources)
         plan = self._plan_stage.execute(config, resources)

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -1,6 +1,6 @@
 """Chalice deployer module.
 
-The deployment system in chalice is broken down into  a pipeline of multiple
+The deployment system in chalice is broken down into a pipeline of multiple
 stages.  Each stage takes the input and transforms it to some other form.  The
 reason for this is so that each stage can stay simple and focused on only a
 single part of the deployment process.  This makes the code easier to follow
@@ -11,8 +11,8 @@ extract out into higher levels of abstraction.
 
 These are the stages of the deployment process.
 
-Resource Builder
-================
+Application Graph Builder
+=========================
 
 The first stage is the resource graph builder.  This takes the objects in the
 ``Chalice`` app and structures them into an ``Application`` object which
@@ -110,7 +110,7 @@ def create_default_deployer(session):
         pip_runner=pip_runner
     )
     return Deployer(
-        resource_builder=ResourceGraphBuilder(),
+        resource_builder=ApplicationGraphBuilder(),
         deps_builder=DependencyBuilder(),
         build_stage=BuildStage(
             steps=[
@@ -138,7 +138,7 @@ def create_default_deployer(session):
 
 class Deployer(object):
     def __init__(self,
-                 resource_builder,  # type: ResourceGraphBuilder
+                 resource_builder,  # type: ApplicationGraphBuilder
                  deps_builder,      # type: DependencyBuilder
                  build_stage,       # type: BuildStage
                  plan_stage,        # type: PlanStage
@@ -161,7 +161,7 @@ class Deployer(object):
         return {'resources': self._executor.resources}
 
 
-class ResourceGraphBuilder(object):
+class ApplicationGraphBuilder(object):
     def __init__(self):
         # type: () -> None
         pass

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -1,0 +1,451 @@
+"""Chalice deployer module.
+
+The deployment system in chalice is broken down into  a pipeline of multiple
+stages.  Each stage takes the input and transforms it to some other form.  The
+reason for this is so that each stage can stay simple and focused on only a
+single part of the deployment process.  This makes the code easier to follow
+and easier to test.  The biggest downside is that adding support for a new
+resource type is split across several objects now, but I imagine as we add
+support for more resource types, we'll see common patterns emerge that we can
+extract out into higher levels of abstraction.
+
+These are the stages of the deployment process.
+
+Resource Builder
+================
+
+The first stage is the resource graph builder.  This takes the objects in the
+``Chalice`` app and structures them into an ``Application`` object which
+consists of various ``models.Model`` objects.  These models are just python
+objects that describe the attributes of various AWS resources.  These
+models don't have any behavior on their own.
+
+Dependency Builder
+==================
+
+This process takes the graph of resources created from the previous step and
+orders them such that all objects are listed before objects that depend on
+them.  The AWS resources in the ``chalice.deploy.models`` module also model
+their required dependencies (see the ``dependencies()`` methods of the models).
+This is the mechanism that's used to build the correct dependency ordering.
+
+Local Build Stage
+=================
+
+This takes the ordered list of resources and allows any local build processes
+to occur.  The rule of thumb here is no remote AWS calls.  This stage includes
+auto policy generation, pip packaging, injecting default values, etc.  To
+clarify which attributes are affected by the build stage, they'll usually have
+a value of ``models.DeployPhase.BUILD``.  Processors in the build stage will
+replaced those ``models.DeployPhase.BUILD`` values with whatever the "built"
+value is (e.g the filename of the zipped deployment package).
+
+For example, we know when we create a lambda function that we need to create
+a deployment package, but we don't know the name nor contents of the
+deployment package until the ``LambdaDeploymentPackager`` runs.  Therefore,
+the Resource Builder stage can record the fact that it knows that a
+``models.DeploymentPackage`` is needed, but use ``models.DeployPhase.BUILD``
+for the value of the filename.  The enum values aren't strictly necessary,
+they just add clarity about when this value is expected to be filled in.
+These could also just be set to ``None`` and be of type ``Optional[T]``.
+
+
+Execution Plan Stage
+====================
+
+This stage takes the ordered list of resources and figures out what AWS API
+calls we have to make.  For example, if a resource doesn't exist at all, we'll
+need to make a ``create_*`` call.  If the resource exists, we may need to make
+a series of ``update_*`` calls.  If the resource exists and is already up to
+date, we might not need to make any calls at all.  The output of this stage is
+a list of ``APICall`` objects.  This stage doesn't actually make the mutating
+API calls, it only figures out what calls we should make.  This stage will
+typically only make ``describe/list`` AWS calls.
+
+
+The Executor
+============
+
+This takes the list of ``APICall`` objects from the previous stage and finally
+executes them.  It also manages taking the output of API calls and storing them
+in variables so they can be referenced in subsequent ``APICall`` objects (see
+the ``Variable`` class to see how this is used).  For example, if a lambda
+function needs the ``role_arn`` that's the result of a previous ``create_role``
+API call, a ``Variable`` object is used to forward this information.
+
+The executor also records these variables with their associated resources so a
+``deployed.json`` file can be written to disk afterwards.  An ``APICall``
+takes an optional resource object when it's created whose ``resource_name``
+is used as the key in the ``deployed.json`` dictionary.
+
+
+"""
+import os
+
+from typing import List, Set, Dict, Any, Optional, Union  # noqa
+from botocore.session import Session  # noqa
+
+from chalice.utils import OSUtils, UI
+from chalice.deploy import models
+from chalice.config import Config  # noqa
+from chalice import app  # noqa
+from chalice.deploy.packager import LambdaDeploymentPackager
+from chalice.deploy.packager import PipRunner, SubprocessPip
+from chalice.deploy.packager import DependencyBuilder as PipDependencyBuilder
+from chalice.policy import AppPolicyGenerator
+from chalice.constants import LAMBDA_TRUST_POLICY
+from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
+from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
+from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+
+
+def create_default_deployer(session):
+    # type: (Session) -> Deployer
+    client = TypedAWSClient(session)
+    osutils = OSUtils()
+    pip_runner = PipRunner(pip=SubprocessPip(osutils=osutils),
+                           osutils=osutils)
+    dependency_builder = PipDependencyBuilder(
+        osutils=osutils,
+        pip_runner=pip_runner
+    )
+    return Deployer(
+        resource_builder=ResourceGraphBuilder(),
+        deps_builder=DependencyBuilder(),
+        build_stage=BuildStage(
+            steps=[
+                InjectDefaults(),
+                DeploymentPackager(
+                    packager=LambdaDeploymentPackager(
+                        osutils=osutils,
+                        dependency_builder=dependency_builder,
+                        ui=UI(),
+                    ),
+                ),
+                PolicyGenerator(
+                    policy_gen=AppPolicyGenerator(
+                        osutils=osutils
+                    ),
+                ),
+            ],
+        ),
+        plan_stage=PlanStage(
+            client=client, osutils=osutils,
+        ),
+        executor=Executor(client),
+    )
+
+
+class Deployer(object):
+    def __init__(self,
+                 resource_builder,  # type: ResourceGraphBuilder
+                 deps_builder,      # type: DependencyBuilder
+                 build_stage,       # type: BuildStage
+                 plan_stage,        # type: PlanStage
+                 executor,          # type: Executor
+                 ):
+        # type: (...) -> None
+        self._resource_builder = resource_builder
+        self._deps_builder = deps_builder
+        self._build_stage = build_stage
+        self._plan_stage = plan_stage
+        self._executor = executor
+
+    def deploy(self, config, chalice_stage_name):
+        # type: (Config, str) -> Dict[str, Any]
+        application = self._resource_builder.build(config, chalice_stage_name)
+        resources = self._deps_builder.build_dependencies(application)
+        self._build_stage.execute(config, resources)
+        plan = self._plan_stage.execute(config, resources)
+        self._executor.execute(plan)
+        return {'resources': self._executor.resources}
+
+
+class ResourceGraphBuilder(object):
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def build(self, config, stage_name):
+        # type: (Config, str) -> models.Application
+        resources = []  # type: List[models.Model]
+        deployment = models.DeploymentPackage(models.DeployPhase.BUILD)
+        for function in config.chalice_app.pure_lambda_functions:
+            new_config = config.scope(chalice_stage=config.chalice_stage,
+                                      function_name=function.name)
+            role = self._get_role_reference(new_config, stage_name, function)
+            resource = self._build_lambda_function(
+                new_config, function, deployment, role)
+            resources.append(resource)
+        return models.Application(stage_name, resources)
+
+    def _get_role_reference(self, config, stage_name, function):
+        # type: (Config, str, app.LambdaFunction) -> models.IAMRole
+        # First option, the user doesn't want us to manage
+        # the role at all.
+        if not config.manage_iam_role:
+            # We've already validated the iam_role_arn is provided
+            # if manage_iam_role is set to False.
+            return models.PreCreatedIAMRole(
+                role_arn=config.iam_role_arn,
+            )
+        policy = models.IAMPolicy()
+        if not config.autogen_policy:
+            resource_name = 'role-%s' % function.name
+            role_name = '%s-%s-%s' % (config.app_name, stage_name,
+                                      function.name)
+            if config.iam_policy_file is not None:
+                filename = os.path.join(config.project_dir,
+                                        '.chalice',
+                                        config.iam_policy_file)
+            else:
+                filename = os.path.join(config.project_dir,
+                                        '.chalice',
+                                        'policy-%s.json' % stage_name)
+            policy = models.FileBasedIAMPolicy(filename=filename)
+        else:
+            resource_name = 'default-role'
+            role_name = '%s-%s' % (config.app_name, stage_name)
+            policy = models.AutoGenIAMPolicy(document=models.DeployPhase.BUILD)
+        return models.ManagedIAMRole(
+            resource_name=resource_name,
+            role_arn=models.DeployPhase.DEPLOY,
+            role_name=role_name,
+            trust_policy=LAMBDA_TRUST_POLICY,
+            policy=policy,
+        )
+
+    def _build_lambda_function(self,
+                               config,      # type: Config
+                               function,    # type: app.LambdaFunction
+                               deployment,  # type: models.DeploymentPackage
+                               role,        # type: models.IAMRole
+                               ):
+        # type: (...) -> models.LambdaFunction
+        function_name = '%s-%s-%s' % (
+            config.app_name, config.chalice_stage, function.name)
+        return models.LambdaFunction(
+            resource_name=function.name,
+            function_name=function_name,
+            environment_variables=config.environment_variables,
+            runtime=config.lambda_python_version,
+            handler=function.handler_string,
+            tags=config.tags,
+            timeout=config.lambda_timeout,
+            memory_size=config.lambda_memory_size,
+            deployment_package=deployment,
+            role=role,
+        )
+
+
+class DependencyBuilder(object):
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def build_dependencies(self, graph):
+        # type: (models.Model) -> List[models.Model]
+        seen = set()  # type: Set[int]
+        ordered = []  # type: List[models.Model]
+        for resource in graph.dependencies():
+            self._traverse(resource, ordered, seen)
+        return ordered
+
+    def _traverse(self, resource, ordered, seen):
+        # type: (models.Model, List[models.Model], Set[int]) -> None
+        for dep in resource.dependencies():
+            if id(dep) not in seen:
+                seen.add(id(dep))
+                self._traverse(dep, ordered, seen)
+        if resource not in ordered:
+            ordered.append(resource)
+
+
+class BaseDeployStep(object):
+
+    def handle(self, config, resource):
+        # type: (Config, models.Model) -> None
+        name = 'handle_%s' % resource.__class__.__name__.lower()
+        handler = getattr(self, name, None)
+        if handler is not None:
+            handler(config, resource)
+
+
+class InjectDefaults(BaseDeployStep):
+    def __init__(self, lambda_timeout=DEFAULT_LAMBDA_TIMEOUT,
+                 lambda_memory_size=DEFAULT_LAMBDA_MEMORY_SIZE):
+        # type: (int, int) -> None
+        self._lambda_timeout = lambda_timeout
+        self._lambda_memory_size = lambda_memory_size
+
+    def handle_lambdafunction(self, config, resource):
+        # type: (Config, models.LambdaFunction) -> None
+        if resource.timeout is None:
+            resource.timeout = self._lambda_timeout
+        if resource.memory_size is None:
+            resource.memory_size = self._lambda_memory_size
+
+
+class DeploymentPackager(BaseDeployStep):
+    def __init__(self, packager):
+        # type: (LambdaDeploymentPackager) -> None
+        self._packager = packager
+
+    def handle_deploymentpackage(self, config, resource):
+        # type: (Config, models.DeploymentPackage) -> None
+        if isinstance(resource.filename, models.DeployPhase):
+            zip_filename = self._packager.create_deployment_package(
+                config.project_dir, config.lambda_python_version
+            )
+            resource.filename = zip_filename
+
+
+class PolicyGenerator(BaseDeployStep):
+    def __init__(self, policy_gen):
+        # type: (AppPolicyGenerator) -> None
+        self._policy_gen = policy_gen
+
+    def handle_autogeniampolicy(self, config, resource):
+        # type: (Config, models.AutoGenIAMPolicy) -> None
+        if isinstance(resource.document, models.DeployPhase):
+            resource.document = self._policy_gen.generate_policy(config)
+
+
+class BuildStage(object):
+    def __init__(self, steps):
+        # type: (List[BaseDeployStep]) -> None
+        self._steps = steps
+
+    def execute(self, config, resources):
+        # type: (Config, List[models.Model]) -> None
+        for resource in resources:
+            for step in self._steps:
+                step.handle(config, resource)
+
+
+class PlanStage(object):
+    def __init__(self, client, osutils):
+        # type: (TypedAWSClient, OSUtils) -> None
+        self._client = client
+        self._osutils = osutils
+
+    def execute(self, config, resources):
+        # type: (Config, List[models.Model]) -> List[APICall]
+        plan = []
+        for resource in resources:
+            name = 'plan_%s' % resource.__class__.__name__.lower()
+            handler = getattr(self, name, None)
+            if handler is not None:
+                result = handler(config, resource)
+                if result is not None:
+                    plan.append(result)
+        return plan
+
+    def plan_lambdafunction(self, config, resource):
+        # type: (Config, models.LambdaFunction) -> Optional[APICall]
+        if self._client.lambda_function_exists(resource.function_name):
+            return None
+        role_arn = ''  # type: Union[str, Variable]
+        if isinstance(resource.role, models.PreCreatedIAMRole):
+            role_arn = resource.role.role_arn
+        elif isinstance(resource.role, models.ManagedIAMRole) and \
+                isinstance(resource.role.role_arn, models.DeployPhase):
+            role_arn = Variable('%s_role_arn' % resource.role.role_name)
+        return APICall(
+            'create_function',
+            {'function_name': resource.function_name,
+             'role_arn': role_arn,
+             'zip_contents': self._osutils.get_file_contents(
+                 resource.deployment_package.filename, binary=True),
+             'runtime': resource.runtime,
+             'handler': resource.handler,
+             'environment_variables': resource.environment_variables,
+             'tags': resource.tags,
+             'timeout': resource.timeout,
+             'memory_size': resource.memory_size},
+            '%s_arn' % resource.resource_name,
+            resource,
+        )
+
+    def plan_managediamrole(self, config, resource):
+        # type: (Config, models.ManagedIAMRole) -> Optional[APICall]
+        if isinstance(resource.role_arn, models.DeployPhase):
+            try:
+                role_arn = self._client.get_role_arn_for_name(
+                    resource.role_name)
+                resource.role_arn = role_arn
+            except ResourceDoesNotExistError:
+                document = None
+                if isinstance(resource.policy, models.AutoGenIAMPolicy):
+                    document = resource.policy.document
+                return APICall('create_role',
+                               {'name': resource.role_name,
+                                'trust_policy': resource.trust_policy,
+                                'policy': document},
+                               '%s_role_arn' % resource.role_name,
+                               resource)
+        # This is to make mypy happy, otherwise it complains
+        # about a missing return statement.
+        return None
+
+
+class APICall(object):
+    def __init__(self,
+                 method_name,    # type: str
+                 params,         # type: Dict[str, Any]
+                 output=None,    # type: Optional[str]
+                 resource=None,  # type: Optional[models.ManagedModel]
+                 ):
+        # type: (...) -> None
+        self.method_name = method_name
+        self.params = params
+        self.output = output
+        self.resource = resource
+
+    def __repr__(self):
+        # type: () -> str
+        return '%s(%s, %s)' % (self.__class__.__name__,
+                               self.method_name, self.params)
+
+
+class Variable(object):
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name
+
+
+class Executor(object):
+    def __init__(self, client):
+        # type: (TypedAWSClient) -> None
+        self._client = client
+        # A mapping of variables that's populated as API calls
+        # are made.  These can be used in subsequent API calls.
+        self.variables = {}  # type: Dict[str, Any]
+        self.resources = {}  # type: Dict[str, Dict[str, Any]]
+
+    def execute(self, api_calls):
+        # type: (List[APICall]) -> None
+        for api_call in api_calls:
+            final_kwargs = self._resolve_variables(api_call.params)
+            method = getattr(self._client, api_call.method_name)
+            result = method(**final_kwargs)
+            if api_call.output is not None:
+                varname = api_call.output
+                self.variables[varname] = result
+                if api_call.resource is not None:
+                    name = api_call.resource.resource_name
+                    mapping = self.resources.setdefault(
+                        name,
+                        {'resource_type': api_call.resource.resource_type}
+                    )
+                    mapping[varname] = result
+
+    def _resolve_variables(self, params):
+        # type: (Dict[str, Any]) -> Dict[str, Any]
+        final = {}
+        for key, value in params.items():
+            if isinstance(value, Variable):
+                final[key] = self.variables[value.name]
+            else:
+                final[key] = value
+        return final

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -429,6 +429,7 @@ class Executor(object):
         for api_call in api_calls:
             final_kwargs = self._resolve_variables(api_call.params)
             method = getattr(self._client, api_call.method_name)
+            # TODO: we need proper error handling here.
             result = method(**final_kwargs)
             if api_call.target_variable is not None:
                 varname = api_call.target_variable

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'botocore>=1.5.40,<2.0.0',
     'typing==3.5.3.0',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<10'
+    'pip>=9,<10',
+    'attrs==17.2.0',
+    'enum34==1.1.6',
 ]
 
 setup(

--- a/tests/unit/deploy/test_models.py
+++ b/tests/unit/deploy/test_models.py
@@ -1,0 +1,12 @@
+from chalice.deploy import models
+
+
+def test_can_instantiate_empty_application():
+    app = models.Application(stage='dev', resources=[])
+    assert app.dependencies() == []
+
+
+def test_can_instantiate_app_with_deps():
+    role = models.PreCreatedIAMRole(role_arn='foo')
+    app = models.Application(stage='dev', resources=[role])
+    assert app.dependencies() == [role]

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -499,7 +499,7 @@ class TestPlanStage(object):
         assert api_call.params == {'name': 'myrole',
                                    'trust_policy': {'trust': 'policy'},
                                    'policy': {'iam': 'policy'}}
-        assert api_call.output == 'myrole_role_arn'
+        assert api_call.target_variable == 'myrole_role_arn'
         assert api_call.resource == resource
 
     def test_no_action_if_role_exists(self, mock_client, mock_osutils):
@@ -525,7 +525,7 @@ class TestPlanStage(object):
         assert len(plan) == 1
         call = plan[0]
         assert call.method_name == 'create_function'
-        assert call.output == 'function_name_lambda_arn'
+        assert call.target_variable == 'function_name_lambda_arn'
         assert call.params == {
             'function_name': 'appname-dev-function_name',
             'role_arn': 'role:arn',
@@ -562,7 +562,7 @@ class TestPlanStage(object):
         assert len(plan) == 1
         call = plan[0]
         assert call.method_name == 'create_function'
-        assert call.output == 'function_name_lambda_arn'
+        assert call.target_variable == 'function_name_lambda_arn'
         assert call.resource == function
         # The params are verified in test_can_create_function,
         # we just care about how the role_arn Variable is constructed.
@@ -575,7 +575,7 @@ class TestInvoker(object):
     def test_can_invoke_api_call_with_no_output(self, mock_client):
         params = {'name': 'foo', 'trust_policy': {'trust': 'policy'},
                   'policy': {'iam': 'policy'}}
-        call = APICall('create_role', params, output=None)
+        call = APICall('create_role', params, target_variable=None)
 
         executor = Executor(mock_client)
         executor.execute([call])
@@ -585,7 +585,8 @@ class TestInvoker(object):
     def test_can_store_api_result(self, mock_client):
         params = {'name': 'foo', 'trust_policy': {'trust': 'policy'},
                   'policy': {'iam': 'policy'}}
-        call = APICall('create_role', params, output='my_variable_name')
+        call = APICall('create_role', params,
+                       target_variable='my_variable_name')
         mock_client.create_role.return_value = 'myrole:arn'
 
         executor = Executor(mock_client)
@@ -599,7 +600,8 @@ class TestInvoker(object):
             'trust_policy': {'trust': 'policy'},
             'policy': {'iam': 'policy'}
         }
-        call = APICall('create_role', params, output='my_variable_name')
+        call = APICall('create_role', params,
+                       target_variable='my_variable_name')
         mock_client.create_role.return_value = 'myrole:arn'
 
         executor = Executor(mock_client)
@@ -615,7 +617,8 @@ class TestInvoker(object):
     def test_can_return_created_resources(self, mock_client):
         function = create_function_resource('myfunction')
         params = {}
-        call = APICall('create_function', params, output='myfunction_arn',
+        call = APICall('create_function', params,
+                       target_variable='myfunction_arn',
                        resource=function)
         mock_client.create_function.return_value = 'function:arn'
         executor = Executor(mock_client)

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -18,7 +18,7 @@ from chalice.deploy.newdeployer import Deployer
 from chalice.deploy.newdeployer import BaseDeployStep
 from chalice.deploy.newdeployer import BuildStage
 from chalice.deploy.newdeployer import DependencyBuilder
-from chalice.deploy.newdeployer import ResourceGraphBuilder
+from chalice.deploy.newdeployer import ApplicationGraphBuilder
 from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
 from chalice.deploy.newdeployer import PolicyGenerator
 from chalice.deploy.newdeployer import PlanStage, APICall
@@ -98,7 +98,7 @@ def test_can_build_resource_with_dag_deps():
     assert deps == [shared_leaf, first_parent, second_parent]
 
 
-class TestResourceGraphBuilder(object):
+class TestApplicationGraphBuilder(object):
 
     def create_config(self, app, iam_role_arn=None, policy_file=None,
                       autogen_policy=False):
@@ -126,7 +126,7 @@ class TestResourceGraphBuilder(object):
 
     def test_can_build_single_lambda_function_app(self, lambda_app):
         # This is the simplest configuration we can get.
-        builder = ResourceGraphBuilder()
+        builder = ApplicationGraphBuilder()
         config = self.create_config(lambda_app, iam_role_arn='role:arn')
         application = builder.build(config, stage_name='dev')
         # The top level resource is always an Application.
@@ -153,7 +153,7 @@ class TestResourceGraphBuilder(object):
         def bar(event, context):
             return {}
 
-        builder = ResourceGraphBuilder()
+        builder = ApplicationGraphBuilder()
         config = self.create_config(lambda_app, iam_role_arn='role:arn')
         application = builder.build(config, stage_name='dev')
         assert len(application.resources) == 2
@@ -168,7 +168,7 @@ class TestResourceGraphBuilder(object):
         # for an ManagedIAMRole.  The various combinations for role
         # configuration is all tested via RoleTestCase.
         config = self.create_config(lambda_app, autogen_policy=True)
-        builder = ResourceGraphBuilder()
+        builder = ApplicationGraphBuilder()
         application = builder.build(config, stage_name='dev')
         function = application.resources[0]
         role = function.role
@@ -371,7 +371,7 @@ ROLE_TEST_CASES = [
 @pytest.mark.parametrize('case', ROLE_TEST_CASES)
 def test_role_creation(case):
     _, config = case.build()
-    builder = ResourceGraphBuilder()
+    builder = ApplicationGraphBuilder()
     application = builder.build(config, stage_name='dev')
     case.assert_required_roles_created(application)
 
@@ -648,7 +648,7 @@ def test_build_stage():
 
 class TestDeployer(unittest.TestCase):
     def setUp(self):
-        self.resource_builder = mock.Mock(spec=ResourceGraphBuilder)
+        self.resource_builder = mock.Mock(spec=ApplicationGraphBuilder)
         self.deps_builder = mock.Mock(spec=DependencyBuilder)
         self.build_stage = mock.Mock(spec=BuildStage)
         self.plan_stage = mock.Mock(spec=PlanStage)

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -1,0 +1,692 @@
+import os
+import unittest
+
+from attr import attrs, attrib
+import pytest
+from pytest import fixture
+import mock
+import botocore.session
+
+from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+from chalice.utils import OSUtils
+from chalice.deploy import models
+from chalice.deploy import packager
+from chalice.config import Config
+from chalice.app import Chalice
+from chalice.deploy.newdeployer import create_default_deployer
+from chalice.deploy.newdeployer import Deployer
+from chalice.deploy.newdeployer import BaseDeployStep
+from chalice.deploy.newdeployer import BuildStage
+from chalice.deploy.newdeployer import DependencyBuilder
+from chalice.deploy.newdeployer import ResourceGraphBuilder
+from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
+from chalice.deploy.newdeployer import PolicyGenerator
+from chalice.deploy.newdeployer import PlanStage, APICall
+from chalice.deploy.newdeployer import Executor, Variable
+from chalice.policy import AppPolicyGenerator
+from chalice.constants import LAMBDA_TRUST_POLICY
+
+
+@attrs
+class FooResource(models.Model):
+    name = attrib()
+    leaf = attrib()
+
+    def dependencies(self):
+        return [self.leaf]
+
+
+@attrs
+class LeafResource(models.Model):
+    name = attrib()
+
+
+@fixture
+def lambda_app():
+    app = Chalice('lambda-only')
+
+    @app.lambda_function()
+    def foo(event, context):
+        return {}
+
+    return app
+
+
+@fixture
+def mock_client():
+    return mock.Mock(spec=TypedAWSClient)
+
+
+@fixture
+def mock_osutils():
+    return mock.Mock(spec=OSUtils)
+
+
+def create_function_resource(name):
+    return models.LambdaFunction(
+        resource_name=name,
+        function_name='appname-dev-%s' % name,
+        environment_variables={},
+        runtime='python2.7',
+        handler='app.app',
+        tags={},
+        timeout=60,
+        memory_size=128,
+        deployment_package=models.DeploymentPackage(filename='foo'),
+        role=models.PreCreatedIAMRole(role_arn='role:arn')
+    )
+
+
+def test_can_build_resource_with_single_dep():
+    role = models.PreCreatedIAMRole(role_arn='foo')
+    app = models.Application(stage='dev', resources=[role])
+
+    dep_builder = DependencyBuilder()
+    deps = dep_builder.build_dependencies(app)
+    assert deps == [role]
+
+
+def test_can_build_resource_with_dag_deps():
+    shared_leaf = LeafResource(name='leaf-resource')
+    first_parent = FooResource(name='first', leaf=shared_leaf)
+    second_parent = FooResource(name='second', leaf=shared_leaf)
+    app = models.Application(
+        stage='dev', resources=[first_parent, second_parent])
+
+    dep_builder = DependencyBuilder()
+    deps = dep_builder.build_dependencies(app)
+    assert deps == [shared_leaf, first_parent, second_parent]
+
+
+class TestResourceGraphBuilder(object):
+
+    def create_config(self, app, iam_role_arn=None, policy_file=None,
+                      autogen_policy=False):
+        kwargs = {
+            'chalice_app': app,
+            'app_name': 'lambda-only',
+            'project_dir': '.',
+        }
+        if iam_role_arn is not None:
+            # We want to use an existing role.
+            # This will skip all the autogen-policy
+            # and role creation.
+            kwargs['manage_iam_role'] = False
+            kwargs['iam_role_arn'] = 'role:arn'
+        elif policy_file is not None:
+            # Otherwise this setting is when a user wants us to
+            # manage the role, but they've written a policy file
+            # they'd like us to use.
+            kwargs['autogen_policy'] = False
+            kwargs['iam_policy_file'] = policy_file
+        elif autogen_policy:
+            kwargs['autogen_policy'] = True
+        config = Config.create(**kwargs)
+        return config
+
+    def test_can_build_single_lambda_function_app(self, lambda_app):
+        # This is the simplest configuration we can get.
+        builder = ResourceGraphBuilder()
+        config = self.create_config(lambda_app, iam_role_arn='role:arn')
+        application = builder.build(config, stage_name='dev')
+        # The top level resource is always an Application.
+        assert isinstance(application, models.Application)
+        assert len(application.resources) == 1
+        assert application.resources[0] == models.LambdaFunction(
+            resource_name='foo',
+            function_name='lambda-only-dev-foo',
+            environment_variables={},
+            runtime=config.lambda_python_version,
+            handler='app.foo',
+            tags=config.tags,
+            timeout=None,
+            memory_size=None,
+            deployment_package=models.DeploymentPackage(
+                models.DeployPhase.BUILD),
+            role=models.PreCreatedIAMRole('role:arn'),
+        )
+
+    def test_multiple_lambda_functions_share_role_and_package(self,
+                                                              lambda_app):
+        # We're going to add another lambda_function to our app.
+        @lambda_app.lambda_function()
+        def bar(event, context):
+            return {}
+
+        builder = ResourceGraphBuilder()
+        config = self.create_config(lambda_app, iam_role_arn='role:arn')
+        application = builder.build(config, stage_name='dev')
+        assert len(application.resources) == 2
+        # The lambda functions by default share the same role
+        assert application.resources[0].role == application.resources[1].role
+        # And all lambda functions share the same deployment package.
+        assert (application.resources[0].deployment_package ==
+                application.resources[1].deployment_package)
+
+    def test_autogen_policy_for_function(self, lambda_app):
+        # This test is just a sanity test that verifies all the params
+        # for an ManagedIAMRole.  The various combinations for role
+        # configuration is all tested via RoleTestCase.
+        config = self.create_config(lambda_app, autogen_policy=True)
+        builder = ResourceGraphBuilder()
+        application = builder.build(config, stage_name='dev')
+        function = application.resources[0]
+        role = function.role
+        # We should have linked a ManagedIAMRole
+        assert isinstance(role, models.ManagedIAMRole)
+        assert role == models.ManagedIAMRole(
+            resource_name='default-role',
+            role_arn=models.DeployPhase.DEPLOY,
+            role_name='lambda-only-dev',
+            trust_policy=LAMBDA_TRUST_POLICY,
+            policy=models.AutoGenIAMPolicy(models.DeployPhase.BUILD),
+        )
+
+
+class RoleTestCase(object):
+    def __init__(self, given, roles, app_name='appname'):
+        self.given = given
+        self.roles = roles
+        self.app_name = app_name
+
+    def build(self):
+        app = Chalice(self.app_name)
+
+        for name in self.given:
+            def foo(event, context):
+                return {}
+            foo.__name__ = name
+            app.lambda_function(name)(foo)
+
+        user_provided_params = {
+            'chalice_app': app,
+            'app_name': self.app_name,
+            'project_dir': '.',
+        }
+        lambda_functions = {}
+        for key, value in self.given.items():
+            lambda_functions[key] = value
+        config_from_disk = {
+            'stages': {
+                'dev': {
+                    'lambda_functions': lambda_functions,
+                }
+            }
+        }
+        config = Config(chalice_stage='dev',
+                        user_provided_params=user_provided_params,
+                        config_from_disk=config_from_disk)
+        return app, config
+
+    def assert_required_roles_created(self, application):
+        resources = application.resources
+        assert len(resources) == len(self.given)
+        functions_by_name = {f.function_name: f for f in resources}
+        for function_name, expected in self.roles.items():
+            full_name = 'appname-dev-%s' % function_name
+            assert full_name in functions_by_name
+            actual_role = functions_by_name[full_name].role
+            expectations = self.roles[function_name]
+            if not expectations.get('managed_role', True):
+                assert isinstance(actual_role, models.PreCreatedIAMRole)
+                assert expectations['iam_role_arn'] == actual_role.role_arn
+                continue
+            assert expectations['name'] == actual_role.role_name
+
+            is_autogenerated = expectations.get('autogenerated', False)
+            policy_file = expectations.get('policy_file')
+            if is_autogenerated:
+                assert isinstance(actual_role, models.ManagedIAMRole)
+                assert isinstance(actual_role.policy, models.AutoGenIAMPolicy)
+            if policy_file is not None and not is_autogenerated:
+                assert isinstance(actual_role, models.ManagedIAMRole)
+                assert isinstance(actual_role.policy,
+                                  models.FileBasedIAMPolicy)
+                assert actual_role.policy.filename == os.path.join(
+                    '.', '.chalice', expectations['policy_file'])
+
+
+# How to read these tests:
+# 'given' is a mapping of lambda function name to config values.
+# 'roles' is a mapping of lambda function to expected attributes
+# of the role associated with the given function.
+# The first test case is explained in more detail as an example.
+ROLE_TEST_CASES = [
+    # Default case, we use the shared 'appname-dev' role.
+    RoleTestCase(
+        # Given we have a lambda function in our app.py named 'a',
+        # and we have our config file state that the 'a' function
+        # should have an autogen'd policy,
+        given={'a': {'autogen_policy': True}},
+        # then we expect the IAM role associated with the lambda
+        # function 'a' should be named 'appname-dev', and it should
+        # be an autogenerated role/policy.
+        roles={'a': {'name': 'appname-dev', 'autogenerated': True}}),
+    # If you specify an explicit policy, we generate a function
+    # specific role.
+    RoleTestCase(
+        given={'a': {'autogen_policy': False,
+                     'iam_policy_file': 'mypolicy.json'}},
+        roles={'a': {'name': 'appname-dev-a',
+                     'autogenerated': False,
+                     'policy_file': 'mypolicy.json'}}),
+    # Multiple lambda functions that use autogen policies share
+    # the same 'appname-dev' role.
+    RoleTestCase(
+        given={'a': {'autogen_policy': True},
+               'b': {'autogen_policy': True}},
+        roles={'a': {'name': 'appname-dev'},
+               'b': {'name': 'appname-dev'}}),
+    # Multiple lambda functions with separate policies result
+    # in separate roles.
+    RoleTestCase(
+        given={'a': {'autogen_policy': False,
+                     'iam_policy_file': 'a.json'},
+               'b': {'autogen_policy': False,
+                     'iam_policy_file': 'b.json'}},
+        roles={'a': {'name': 'appname-dev-a',
+                     'autogenerated': False,
+                     'policy_file': 'a.json'},
+               'b': {'name': 'appname-dev-b',
+                     'autogenerated': False,
+                     'policy_file': 'b.json'}}),
+    # You can mix autogen and explicit policy files.  Autogen will
+    # always use the '{app}-{stage}' role.
+    RoleTestCase(
+        given={'a': {'autogen_policy': True},
+               'b': {'autogen_policy': False,
+                     'iam_policy_file': 'b.json'}},
+        roles={'a': {'name': 'appname-dev',
+                     'autogenerated': True},
+               'b': {'name': 'appname-dev-b',
+                     'autogenerated': False,
+                     'policy_file': 'b.json'}}),
+    # Default location if no policy file is given is
+    # policy-dev.json
+    RoleTestCase(
+        given={'a': {'autogen_policy': False}},
+        roles={'a': {'name': 'appname-dev-a',
+                     'autogenerated': False,
+                     'policy_file': 'policy-dev.json'}}),
+    # As soon as autogen_policy is false, we will *always*
+    # create a function specific role.
+    RoleTestCase(
+        given={'a': {'autogen_policy': False},
+               'b': {'autogen_policy': True}},
+        roles={'a': {'name': 'appname-dev-a',
+                     'autogenerated': False,
+                     'policy_file': 'policy-dev.json'},
+               'b': {'name': 'appname-dev'}}),
+    RoleTestCase(
+        given={'a': {'manage_iam_role': False, 'iam_role_arn': 'role:arn'}},
+        # 'managed_role' will verify the associated role is a
+        # models.PreCreatedIAMRoleType with the provided iam_role_arn.
+        roles={'a': {'managed_role': False, 'iam_role_arn': 'role:arn'}}),
+    RoleTestCase(
+        given={'a': {'manage_iam_role': False, 'iam_role_arn': 'role:arn'},
+               'b': {'autogen_policy': True}},
+        roles={'a': {'managed_role': False, 'iam_role_arn': 'role:arn'},
+               'b': {'name': 'appname-dev', 'autogenerated': True}}),
+
+    # Functions that mix all four options:
+    RoleTestCase(
+        # 2 functions with autogen'd policies.
+        given={
+            'a': {'autogen_policy': True},
+            'b': {'autogen_policy': True},
+            # 2 functions with various iam role arns.
+            'c': {'manage_iam_role': False, 'iam_role_arn': 'role:arn'},
+            'd': {'manage_iam_role': False, 'iam_role_arn': 'role:arn2'},
+            # A function with a default filename for a policy.
+            'e': {'autogen_policy': False},
+            # Even though this uses the same policy as 'e', we will
+            # still create a new role.  This could be optimized in the
+            # future.
+            'f': {'autogen_policy': False},
+            # And finally 2 functions that have their own policy files.
+            'g': {'autogen_policy': False, 'iam_policy_file': 'g.json'},
+            'h': {'autogen_policy': False, 'iam_policy_file': 'h.json'}
+        },
+        roles={
+            'a': {'name': 'appname-dev', 'autogenerated': True},
+            'b': {'name': 'appname-dev', 'autogenerated': True},
+            'c': {'managed_role': False, 'iam_role_arn': 'role:arn'},
+            'd': {'managed_role': False, 'iam_role_arn': 'role:arn2'},
+            'e': {'name': 'appname-dev-e',
+                  'autogenerated': False,
+                  'policy_file': 'policy-dev.json'},
+            'f': {'name': 'appname-dev-f',
+                  'autogenerated': False,
+                  'policy_file': 'policy-dev.json'},
+            'g': {'name': 'appname-dev-g',
+                  'autogenerated': False,
+                  'policy_file': 'g.json'},
+            'h': {'name': 'appname-dev-h',
+                  'autogenerated': False,
+                  'policy_file': 'h.json'},
+        }),
+]
+
+
+@pytest.mark.parametrize('case', ROLE_TEST_CASES)
+def test_role_creation(case):
+    _, config = case.build()
+    builder = ResourceGraphBuilder()
+    application = builder.build(config, stage_name='dev')
+    case.assert_required_roles_created(application)
+
+
+class TestDefaultsInjector(object):
+    def test_inject_when_values_are_none(self):
+        injector = InjectDefaults(
+            lambda_timeout=100,
+            lambda_memory_size=512,
+        )
+        function = models.LambdaFunction(
+            # The timeout/memory_size are set to
+            # None, so the injector should fill them
+            # in the with the default values above.
+            timeout=None,
+            memory_size=None,
+            resource_name='foo',
+            function_name='app-dev-foo',
+            environment_variables={},
+            runtime='python2.7',
+            handler='app.app',
+            tags={},
+            deployment_package=None,
+            role=None,
+        )
+        config = Config.create()
+        injector.handle(config, function)
+        assert function.timeout == 100
+        assert function.memory_size == 512
+
+    def test_no_injection_when_values_are_set(self):
+        injector = InjectDefaults(
+            lambda_timeout=100,
+            lambda_memory_size=512,
+        )
+        function = models.LambdaFunction(
+            # The timeout/memory_size are set to
+            # None, so the injector should fill them
+            # in the with the default values above.
+            timeout=1,
+            memory_size=1,
+            resource_name='foo',
+            function_name='app-stage-foo',
+            environment_variables={},
+            runtime='python2.7',
+            handler='app.app',
+            tags={},
+            deployment_package=None,
+            role=None,
+        )
+        config = Config.create()
+        injector.handle(config, function)
+        assert function.timeout == 1
+        assert function.memory_size == 1
+
+
+class TestPolicyGeneratorStage(object):
+    def test_invokes_policy_generator(self):
+        generator = mock.Mock(spec=AppPolicyGenerator)
+        generator.generate_policy.return_value = {'policy': 'doc'}
+        policy = models.AutoGenIAMPolicy(models.DeployPhase.BUILD)
+        config = Config.create()
+
+        p = PolicyGenerator(generator)
+        p.handle(config, policy)
+
+        assert policy.document == {'policy': 'doc'}
+
+    def test_no_policy_generated_if_exists(self):
+        generator = mock.Mock(spec=AppPolicyGenerator)
+        generator.generate_policy.return_value = {'policy': 'new'}
+        policy = models.AutoGenIAMPolicy(document={'policy': 'original'})
+        config = Config.create()
+
+        p = PolicyGenerator(generator)
+        p.handle(config, policy)
+
+        assert policy.document == {'policy': 'original'}
+        assert not generator.generate_policy.called
+
+
+class TestDeploymentPackager(object):
+    def test_can_generate_package(self):
+        generator = mock.Mock(spec=packager.LambdaDeploymentPackager)
+        generator.create_deployment_package.return_value = 'package.zip'
+
+        package = models.DeploymentPackage(models.DeployPhase.BUILD)
+        config = Config.create()
+
+        p = DeploymentPackager(generator)
+        p.handle(config, package)
+
+        assert package.filename == 'package.zip'
+
+    def test_package_not_generated_if_filename_populated(self):
+        generator = mock.Mock(spec=packager.LambdaDeploymentPackager)
+        generator.create_deployment_package.return_value = 'NEWPACKAGE.zip'
+
+        package = models.DeploymentPackage(filename='original-name.zip')
+        config = Config.create()
+
+        p = DeploymentPackager(generator)
+        p.handle(config, package)
+
+        assert package.filename == 'original-name.zip'
+        assert not generator.create_deployment_package.called
+
+
+class TestPlanStage(object):
+    def test_can_plan_for_iam_role_creation(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.side_effect = \
+            ResourceDoesNotExistError()
+        planner = PlanStage(mock_client, mock_osutils)
+        resource = models.ManagedIAMRole(
+            resource_name='default-role',
+            role_arn=models.DeployPhase.DEPLOY,
+            role_name='myrole',
+            trust_policy={'trust': 'policy'},
+            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+        )
+        plan = planner.execute(Config.create(), [resource])
+        assert len(plan) == 1
+        api_call = plan[0]
+        assert api_call.method_name == 'create_role'
+        assert api_call.params == {'name': 'myrole',
+                                   'trust_policy': {'trust': 'policy'},
+                                   'policy': {'iam': 'policy'}}
+        assert api_call.output == 'myrole_role_arn'
+        assert api_call.resource == resource
+
+    def test_no_action_if_role_exists(self, mock_client, mock_osutils):
+        # This might need some tweaking to figure out if we need
+        # to update the policy or not.
+        mock_client.get_role_arn_for_name.return_value = 'role:arn'
+        planner = PlanStage(mock_client, mock_osutils)
+        resource = models.ManagedIAMRole(
+            resource_name='default-role',
+            role_arn=models.DeployPhase.DEPLOY,
+            role_name='myrole',
+            trust_policy={'trust': 'policy'},
+            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+        )
+        plan = planner.execute(Config.create(), [resource])
+        assert plan == []
+
+    def test_can_create_function(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = False
+        function = create_function_resource('function_name')
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'create_function'
+        assert call.output == 'function_name_arn'
+        assert call.params == {
+            'function_name': 'appname-dev-function_name',
+            'role_arn': 'role:arn',
+            'zip_contents': mock.ANY,
+            'runtime': 'python2.7',
+            'handler': 'app.app',
+            'environment_variables': {},
+            'tags': {},
+            'timeout': 60,
+            'memory_size': 128,
+        }
+        assert call.resource == function
+
+    def test_no_plan_if_function_exists(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = True
+        function = create_function_resource('function_name')
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        # This will change once updates are implemented.
+        assert plan == []
+
+    def test_can_create_plan_for_managed_role(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = False
+        function = create_function_resource('function_name')
+        function.role = models.ManagedIAMRole(
+            resource_name='myrole',
+            role_arn=models.DeployPhase.DEPLOY,
+            role_name='myrole-dev',
+            trust_policy={'trust': 'policy'},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'create_function'
+        assert call.output == 'function_name_arn'
+        assert call.resource == function
+        # The params are verified in test_can_create_function,
+        # we just care about how the role_arn Variable is constructed.
+        role_arn = call.params['role_arn']
+        assert isinstance(role_arn, Variable)
+        assert role_arn.name == 'myrole-dev_role_arn'
+
+
+class TestInvoker(object):
+    def test_can_invoke_api_call_with_no_output(self, mock_client):
+        params = {'name': 'foo', 'trust_policy': {'trust': 'policy'},
+                  'policy': {'iam': 'policy'}}
+        call = APICall('create_role', params, output=None)
+
+        executor = Executor(mock_client)
+        executor.execute([call])
+
+        mock_client.create_role.assert_called_with(**params)
+
+    def test_can_store_api_result(self, mock_client):
+        params = {'name': 'foo', 'trust_policy': {'trust': 'policy'},
+                  'policy': {'iam': 'policy'}}
+        call = APICall('create_role', params, output='my_variable_name')
+        mock_client.create_role.return_value = 'myrole:arn'
+
+        executor = Executor(mock_client)
+        executor.execute([call])
+
+        assert executor.variables['my_variable_name'] == 'myrole:arn'
+
+    def test_can_reference_stored_results_in_api_calls(self, mock_client):
+        params = {
+            'name': Variable('role_name'),
+            'trust_policy': {'trust': 'policy'},
+            'policy': {'iam': 'policy'}
+        }
+        call = APICall('create_role', params, output='my_variable_name')
+        mock_client.create_role.return_value = 'myrole:arn'
+
+        executor = Executor(mock_client)
+        executor.variables['role_name'] = 'myrole-name'
+        executor.execute([call])
+
+        mock_client.create_role.assert_called_with(
+            name='myrole-name',
+            trust_policy={'trust': 'policy'},
+            policy={'iam': 'policy'},
+        )
+
+    def test_can_return_created_resources(self, mock_client):
+        function = create_function_resource('myfunction')
+        params = {}
+        call = APICall('create_function', params, output='myfunction_arn',
+                       resource=function)
+        mock_client.create_function.return_value = 'function:arn'
+        executor = Executor(mock_client)
+        executor.execute([call])
+        assert executor.resources['myfunction'] == {
+            'myfunction_arn': 'function:arn',
+            'resource_type': 'lambda_function',
+        }
+
+
+def test_build_stage():
+    first = mock.Mock(spec=BaseDeployStep)
+    second = mock.Mock(spec=BaseDeployStep)
+    build = BuildStage([first, second])
+
+    foo_resource = mock.sentinel.foo_resource
+    bar_resource = mock.sentinel.bar_resource
+    config = Config.create()
+    build.execute(config, [foo_resource, bar_resource])
+
+    assert first.handle.call_args_list == [
+        mock.call(config, foo_resource),
+        mock.call(config, bar_resource),
+    ]
+    assert second.handle.call_args_list == [
+        mock.call(config, foo_resource),
+        mock.call(config, bar_resource),
+    ]
+
+
+class TestDeployer(unittest.TestCase):
+    def setUp(self):
+        self.resource_builder = mock.Mock(spec=ResourceGraphBuilder)
+        self.deps_builder = mock.Mock(spec=DependencyBuilder)
+        self.build_stage = mock.Mock(spec=BuildStage)
+        self.plan_stage = mock.Mock(spec=PlanStage)
+        self.executor = mock.Mock(spec=Executor)
+
+    def create_deployer(self):
+        return Deployer(
+            self.resource_builder,
+            self.deps_builder,
+            self.build_stage,
+            self.plan_stage,
+            self.executor
+        )
+
+    def test_deploy_delegates_properly(self):
+        app = mock.Mock(spec=models.Application)
+        resources = [mock.Mock(spec=models.Model)]
+        api_calls = [mock.Mock(spec=APICall)]
+
+        self.resource_builder.build.return_value = app
+        self.deps_builder.build_dependencies.return_value = resources
+        self.plan_stage.execute.return_value = api_calls
+        self.executor.resources = {'foo': {'name': 'bar'}}
+
+        deployer = self.create_deployer()
+        config = Config.create()
+        result = deployer.deploy(config, 'dev')
+
+        self.resource_builder.build.assert_called_with(config, 'dev')
+        self.deps_builder.build_dependencies.assert_called_with(app)
+        self.build_stage.execute.assert_called_with(config, resources)
+        self.plan_stage.execute.assert_called_with(config, resources)
+        self.executor.execute.assert_called_with(api_calls)
+
+        assert result == {'resources': {'foo': {'name': 'bar'}}}
+
+
+def test_can_create_default_deployer():
+    session = botocore.session.get_session()
+    deployer = create_default_deployer(session)
+    assert isinstance(deployer, Deployer)

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -525,7 +525,7 @@ class TestPlanStage(object):
         assert len(plan) == 1
         call = plan[0]
         assert call.method_name == 'create_function'
-        assert call.output == 'function_name_arn'
+        assert call.output == 'function_name_lambda_arn'
         assert call.params == {
             'function_name': 'appname-dev-function_name',
             'role_arn': 'role:arn',
@@ -562,7 +562,7 @@ class TestPlanStage(object):
         assert len(plan) == 1
         call = plan[0]
         assert call.method_name == 'create_function'
-        assert call.output == 'function_name_arn'
+        assert call.output == 'function_name_lambda_arn'
         assert call.resource == function
         # The params are verified in test_can_create_function,
         # we just care about how the role_arn Variable is constructed.


### PR DESCRIPTION
The existing deployer module is starting to get out of hand.
Initially it only had to handle API gateway and a single Lambda
function, but over time we've added support for AWS resources,
and continue to add additional resources (#516).

I don't think the existing deployer design is going to hold up
as all these new resources are being added.  The code is hard to
understand, hard to use, and hard to modify.  There's also a number
of customer reported bugs from the existing deployer.

Digging further into the deployer code, there are a number of
inconsistencies as well as unexpected and unintuitive behaviors.

I've been experimenting with a new redesign of the deployer to
not only fix the existing issues, but also make future changes
easier.  This initial POC only supports `@app.lambda_function()`
and only sketches out how to do the initial creation of resources,
but I think this should be able to handle the remaining gaps.

To help with initial testing, I've added a temporary `deploy-new`
command so both deployers can live side by side during development.
Before this gets merged to master, `deploy-new` will just become
`deploy` and the old code will be removed.

The `newdeployer` module docstring has a description of how
the new system works, and is a good starting point for a technical
overview.