### PR TITLE
Stop infinite recursion in analyzer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Next Release (TBD)
   (`#525 <https://github.com/aws/chalice/issues/525>`__)
 * Add ``--stage`` parameter to ``chalice local``
   (`#545 <https://github.com/aws/chalice/issues/545>`__)
+* Fix issue with analyzer that followed recursive functions infinitely
+  (`#531 <https://github.com/aws/chalice/issues/531>`__)
 
 
 1.0.2

--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -40,6 +40,7 @@ from typing import Dict, Set, Any, Optional, List, Union  # noqa
 
 
 APICallT = Dict[str, Set[str]]
+OptASTSet = Optional[Set[ast.AST]]
 
 
 def get_client_calls(source_code):
@@ -324,7 +325,7 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
     _CREATE_CLIENT = 'client'
 
     def __init__(self, parsed_code, binder=None, visited=None):
-        # type: (ParsedCode, Optional[TypeBinder]) -> None
+        # type: (ParsedCode, Optional[TypeBinder], OptASTSet) -> None
         self._symbol_table = parsed_code.symbol_table
         self._current_ast_namespace = parsed_code.parsed_ast
         self._node_inference = {}  # type: Dict[ast.AST, Any]
@@ -368,7 +369,7 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
         return self._binder.get_type_for_node(node)
 
     def _new_inference_scope(self, parsed_code, binder, visited):
-        # type: (ParsedCode, TypeBinder) -> SymbolTableTypeInfer
+        # type: (ParsedCode, TypeBinder, Set[ast.AST]) -> SymbolTableTypeInfer
         instance = self.__class__(parsed_code, binder, visited)
         return instance
 


### PR DESCRIPTION
Fixes #531 

The analyzer would follow any recursive function infinitely. This adds a visited set of AST nodes to the AST walker so that we don't attempt to jump into a function definition multiple times.