### PR TITLE
Chalice local 200s CORS OPTIONS rather than 403

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -458,7 +458,11 @@ class LocalGateway(object):
             # No options route was defined for this path. API Gateway should
             # automatically generate our CORS headers.
             options_headers = self._autogen_options_headers(lambda_event)
-            raise NoOptionsRouteDefined(options_headers)
+            return {
+                'statusCode': 200,
+                'headers': options_headers,
+                'body': None
+            }
         # The authorizer call will be a noop if there is no authorizer method
         # defined for route. Otherwise it will raise a ForbiddenError
         # which will be caught by the handler that called this and a 403 or

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -200,10 +200,6 @@ class NotAuthorizedError(LocalGatewayException):
     CODE = 401
 
 
-class NoOptionsRouteDefined(LocalGatewayException):
-    CODE = 403
-
-
 class LambdaContext(object):
     def __init__(self, function_name, memory_size,
                  max_runtime_ms=3000, time_source=None):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -345,6 +345,7 @@ def test_will_respond_with_custom_cors_enabled(handler):
                         headers=headers)
     handler.do_GET()
     response = handler.wfile.getvalue().splitlines()
+    assert b'HTTP/1.1 200 OK' in response
     assert b'Access-Control-Allow-Origin: https://foo.bar' in response
     assert (b'Access-Control-Allow-Headers: Authorization,Content-Type,'
             b'Header-A,Header-B,X-Amz-Date,X-Amz-Security-Token,'
@@ -360,6 +361,7 @@ def test_will_respond_with_custom_cors_enabled_options(handler):
                         headers=headers)
     handler.do_OPTIONS()
     response = handler.wfile.getvalue().decode().splitlines()
+    assert 'HTTP/1.1 200 OK' in response
     assert 'Access-Control-Allow-Origin: https://foo.bar' in response
     assert ('Access-Control-Allow-Headers: Authorization,Content-Type,'
             'Header-A,Header-B,X-Amz-Date,X-Amz-Security-Token,'


### PR DESCRIPTION
Hi folks,

My local preflights got broken, so this should fix them. Ran coverage reports before/after and no changes there. You could probably delete `class NoOptionsRouteDefined`, but I didn't want to make that call myself.

Thanks!
-Kyle