### PR TITLE
Fix wheel packages with _ in their name not being converted to -

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* Fix issue with some packages with `-` or `.` in their distribution name
+  (`#555 <https://github.com/aws/chalice/pull/555>`__)
 * Fix issue where chalice local returned a 403 for successful OPTIONS requests
   (`#554 <https://github.com/aws/chalice/pull/554>`__)
 * Fix issue with chalice local mode causing http clients to hang on responses

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -469,6 +469,11 @@ class Package(object):
         # The directory format is {distribution}-{version}.data
         return '%s-%s.data' % (self._name, self._version)
 
+    def _normalize_name(self, name):
+        # type: (str) -> str
+        # Taken directly from PEP 503
+        return re.sub(r"[-_.]+", "-", name).lower()
+
     @property
     def identifier(self):
         # type: () -> str
@@ -499,7 +504,7 @@ class Package(object):
             # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-
             # {platform tag}.whl
             name, version = self.filename.split('-')[:2]
-            name = name.replace('_', '-')
+            name = self._normalize_name(name)
         else:
             info_fetcher = SDistMetadataFetcher(osutils=self._osutils)
             sdist_path = self._osutils.joinpath(self._directory, self.filename)

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -499,6 +499,7 @@ class Package(object):
             # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-
             # {platform tag}.whl
             name, version = self.filename.split('-')[:2]
+            name = name.replace('_', '-')
         else:
             info_fetcher = SDistMetadataFetcher(osutils=self._osutils)
             sdist_path = self._osutils.joinpath(self._directory, self.filename)

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -39,6 +39,22 @@ def _get_random_package_name():
 
 
 class TestPackage(object):
+    def test_can_package_with_dashes_in_name(self, runner, app_skeleton):
+        req = os.path.join(app_skeleton, 'requirements.txt')
+        package = 'googleapis-common-protos==1.5.2'
+        with open(req, 'w') as f:
+            f.write('%s\n' % package)
+        cli_factory = factory.CLIFactory(app_skeleton)
+        package_output_location = os.path.join(app_skeleton, 'pkg')
+        print(package_output_location)
+        result = runner.invoke(
+            cli.package, [package_output_location],
+            obj={'project_dir': app_skeleton,
+                 'debug': False,
+                 'factory': cli_factory})
+        assert result.exit_code == 0
+        assert result.output.strip() == 'Creating deployment package.'
+
     def test_does_not_package_bad_requirements_file(
             self, runner, app_skeleton):
         req = os.path.join(app_skeleton, 'requirements.txt')

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from zipfile import ZipFile
 from contextlib import contextmanager
 
 from click.testing import CliRunner
@@ -46,7 +47,6 @@ class TestPackage(object):
             f.write('%s\n' % package)
         cli_factory = factory.CLIFactory(app_skeleton)
         package_output_location = os.path.join(app_skeleton, 'pkg')
-        print(package_output_location)
         result = runner.invoke(
             cli.package, [package_output_location],
             obj={'project_dir': app_skeleton,
@@ -54,6 +54,10 @@ class TestPackage(object):
                  'factory': cli_factory})
         assert result.exit_code == 0
         assert result.output.strip() == 'Creating deployment package.'
+        package_path = os.path.join(app_skeleton, 'pkg', 'deployment.zip')
+        package_file = ZipFile(package_path)
+        package_content = package_file.namelist()
+        assert 'google/api/__init__.py' in package_content
 
     def test_does_not_package_bad_requirements_file(
             self, runner, app_skeleton):

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -118,6 +118,10 @@ class TestPackage(object):
         pkg = Package('', 'foobar-2.0-py3-none-any.whl')
         assert pkg.data_dir == 'foobar-2.0.data'
 
+    def test_can_read_packages_with_underscore_in_name(slef):
+        pkg = Package('', 'foo_bar-2.0-py3-none-any.whl')
+        assert pkg.identifier == 'foo-bar==2.0'
+
 
 class TestSubprocessPip(object):
     def test_can_invoke_pip(self):

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -118,8 +118,12 @@ class TestPackage(object):
         pkg = Package('', 'foobar-2.0-py3-none-any.whl')
         assert pkg.data_dir == 'foobar-2.0.data'
 
-    def test_can_read_packages_with_underscore_in_name(slef):
+    def test_can_read_packages_with_underscore_in_name(self):
         pkg = Package('', 'foo_bar-2.0-py3-none-any.whl')
+        assert pkg.identifier == 'foo-bar==2.0'
+
+    def test_can_read_packages_with_period_in_name(self):
+        pkg = Package('', 'foo.bar-2.0-py3-none-any.whl')
         assert pkg.identifier == 'foo-bar==2.0'
 
 


### PR DESCRIPTION
Since wheel files use - as a delimeter between the different
components of the filename such as distribution-version-... if the
distribution has - in it they are converted to _. So when we read a
wheel file that has _ in the distribution, they need to be remaped to
-.

cc @jamesls @kyleknap @dstufft 