### PR TITLE
Adding new line for saved JSON files

### DIFF
--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -931,11 +931,12 @@ class ApplicationPolicyHandler(object):
     def record_policy(self, config, policy_document):
         # type: (Config, Dict[str, Any]) -> None
         policy_file = self._app_policy_file(config)
-        self._osutils.set_file_contents(
-            policy_file,
-            json.dumps(policy_document, indent=2, separators=(',', ': ')),
-            binary=False
-        )
+        policy_json = json.dumps(
+            policy_document,
+            indent=2,
+            separators=(',', ': ')
+        ) + '\n'
+        self._osutils.set_file_contents(policy_file, policy_json, binary=False)
 
     def _app_policy_file(self, config):
         # type: (Config) -> str

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -53,7 +53,11 @@ def record_deployed_values(deployed_values, filename):
             final_values = json.load(f)
     final_values.update(deployed_values)
     with open(filename, 'wb') as f:
-        data = json.dumps(final_values, indent=2, separators=(',', ': '))
+        data = json.dumps(
+            final_values,
+            indent=2,
+            separators=(',', ': ')
+        ) + '\n'
         f.write(data.encode('utf-8'))
 
 


### PR DESCRIPTION
### The problem

Every time when I deploy with chalice it rewrites the JSON documents (the policy and the `deployed.json`) and there is no new line at the end of these files. I am committing these files to the repos and GitHub is complaining about this:

<img width="144" alt="screen shot 2017-09-26 at 4 14 24 pm" src="https://user-images.githubusercontent.com/5182991/30882233-52fe8ba2-a2d6-11e7-9820-f63a52e5e864.png">

So for now I just add the new lines manually because a PR with files with incorrect last byte will fail PR review at the company I am working for.

### Proposed solution

Simple add new line to the policy writer and to the `deployed.json` writer. 

cc @jamesls @kyleknap @dstufft