### PR TITLE
Standardize on json serialization when writing to disk/stdout

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -3,7 +3,6 @@
 Contains commands for deploying chalice.
 
 """
-import json
 import logging
 import os
 import sys
@@ -24,7 +23,7 @@ from chalice.utils import create_zip_file
 from chalice.utils import record_deployed_values
 from chalice.utils import remove_stage_from_deployed_values
 from chalice.deploy.deployer import validate_python_version
-from chalice.utils import getting_started_prompt, UI
+from chalice.utils import getting_started_prompt, UI, serialize_to_json
 from chalice.constants import CONFIG_VERSION, TEMPLATE_APP, GITIGNORE
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
@@ -47,7 +46,7 @@ def create_new_project_skeleton(project_name, profile=None):
     if profile is not None:
         cfg['profile'] = profile
     with open(config, 'w') as f:
-        f.write(json.dumps(cfg, indent=2))
+        f.write(serialize_to_json(cfg))
     with open(os.path.join(project_name, 'requirements.txt'), 'w'):
         pass
     with open(os.path.join(project_name, 'app.py'), 'w') as f:
@@ -185,7 +184,7 @@ def gen_policy(ctx, filename):
     with open(filename) as f:
         contents = f.read()
         generated = policy.policy_from_source_code(contents)
-        click.echo(json.dumps(generated, indent=2))
+        click.echo(serialize_to_json(generated))
 
 
 @cli.command('new-project')
@@ -303,7 +302,7 @@ def generate_pipeline(ctx, filename):
     config = factory.create_config_obj()
     output = create_pipeline_template(config)
     with open(filename, 'w') as f:
-        f.write(json.dumps(output, indent=2, separators=(',', ': ')))
+        f.write(serialize_to_json(output))
 
 
 def main():

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -30,7 +30,7 @@ from chalice.config import Config, DeployedResources  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
 from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.swagger import SwaggerGenerator
-from chalice.utils import OSUtils, UI
+from chalice.utils import OSUtils, UI, serialize_to_json
 from chalice.constants import DEFAULT_STAGE_NAME, LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
@@ -764,7 +764,7 @@ class LambdaDeployer(object):
         app_policy = self._app_policy.generate_policy_from_app_source(config)
         if len(app_policy['Statement']) > 1:
             self._ui.write("The following execution policy will be used:\n")
-            self._ui.write(json.dumps(app_policy, indent=2))
+            self._ui.write(serialize_to_json(app_policy))
             self._ui.confirm("Would you like to continue? ",
                              default=True, abort=True)
         role_arn = self._aws_client.create_role(
@@ -931,11 +931,7 @@ class ApplicationPolicyHandler(object):
     def record_policy(self, config, policy_document):
         # type: (Config, Dict[str, Any]) -> None
         policy_file = self._app_policy_file(config)
-        policy_json = json.dumps(
-            policy_document,
-            indent=2,
-            separators=(',', ': ')
-        ) + '\n'
+        policy_json = serialize_to_json(policy_document)
         self._osutils.set_file_contents(policy_file, policy_json, binary=False)
 
     def _app_policy_file(self, config):

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -931,11 +931,12 @@ class ApplicationPolicyHandler(object):
     def record_policy(self, config, policy_document):
         # type: (Config, Dict[str, Any]) -> None
         policy_file = self._app_policy_file(config)
-        self._osutils.set_file_contents(
-            policy_file,
-            json.dumps(policy_document, indent=2, separators=(',', ': ')),
-            binary=False
-        )
+        policy_json = json.dumps(
+            policy_document,
+            indent=2,
+            separators=(',', ': ')
+        ) + '\n'
+        self._osutils.set_file_contents(policy_file, policy_json, binary=False)
 
     def _app_policy_file(self, config):
         # type: (Config) -> str

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1,6 +1,5 @@
 import os
 import copy
-import json
 import hashlib
 import re
 
@@ -13,7 +12,7 @@ from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.deployer import ApplicationPolicyHandler
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
-from chalice.utils import OSUtils, UI
+from chalice.utils import OSUtils, UI, serialize_to_json
 from chalice.config import Config  # noqa
 from chalice.app import Chalice  # noqa
 from chalice.policy import AppPolicyGenerator
@@ -201,7 +200,7 @@ class AppPackager(object):
 
     def _to_json(self, doc):
         # type: (Any) -> str
-        return json.dumps(doc, indent=2, separators=(',', ': '))
+        return serialize_to_json(doc)
 
     def package_app(self, config, outdir):
         # type: (Config, str) -> None

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -53,7 +53,11 @@ def record_deployed_values(deployed_values, filename):
             final_values = json.load(f)
     final_values.update(deployed_values)
     with open(filename, 'wb') as f:
-        data = json.dumps(final_values, indent=2, separators=(',', ': '))
+        data = json.dumps(
+            final_values,
+            indent=2,
+            separators=(',', ': ')
+        ) + '\n'
         f.write(data.encode('utf-8'))
 
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -33,7 +33,7 @@ def remove_stage_from_deployed_values(key, filename):
     try:
         del final_values[key]
         with open(filename, 'wb') as f:
-            data = json.dumps(final_values, indent=2, separators=(',', ': '))
+            data = serialize_to_json(final_values)
             f.write(data.encode('utf-8'))
     except KeyError:
         # If they key didn't exist then there is nothing to remove.
@@ -53,12 +53,20 @@ def record_deployed_values(deployed_values, filename):
             final_values = json.load(f)
     final_values.update(deployed_values)
     with open(filename, 'wb') as f:
-        data = json.dumps(
-            final_values,
-            indent=2,
-            separators=(',', ': ')
-        ) + '\n'
+        data = serialize_to_json(final_values)
         f.write(data.encode('utf-8'))
+
+
+def serialize_to_json(data):
+    # type: (Any) -> str
+    """Serialize to pretty printed JSON.
+
+    This includes using 2 space indentation, no trailing whitespace, and
+    including a newline at the end of the JSON document.  Useful when you want
+    to serialize JSON to disk.
+
+    """
+    return json.dumps(data, indent=2, separators=(',', ': ')) + '\n'
 
 
 def create_zip_file(source_dir, outfile):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -35,3 +35,11 @@ class TestUI(object):
         ui = utils.UI(self.out, self.err, confirm)
         return_value = ui.confirm("Confirm?")
         assert return_value == 'foo'
+
+
+def test_serialize_json():
+    assert utils.serialize_to_json({'foo': 'bar'}) == (
+        '{\n'
+        '  "foo": "bar"\n'
+        '}\n'
+    )


### PR DESCRIPTION
This pulls in https://github.com/aws/chalice/pull/556 and adds a test as well as additional refactoring.

Every occurrence of `json.dumps` now goes through `serialize_to_json`.  Added a test for the new function and verified the existing tests pass.