### PR TITLE
Add file encoding argument to the get_file_contents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBA)
+==================
+
+* Fix issue deploying some packages in Windows with utf-8 characters
+   (`#560 <https://github.com/aws/chalice/pull/560>`__)
+
+
 1.0.3
 =====
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -117,13 +117,15 @@ class OSUtils(object):
         # type: (str) -> bool
         return os.path.isfile(filename)
 
-    def get_file_contents(self, filename, binary=True):
+    def get_file_contents(self, filename, binary=True, encoding='utf-8'):
         # type: (str, bool) -> str
         if binary:
             mode = 'rb'
+            # In binary mode the encoding is not used and most be None.
+            encoding  = None
         else:
             mode = 'r'
-        with open(filename, mode) as f:
+        with open(filename, mode, encoding=encoding) as f:
             return f.read()
 
     def set_file_contents(self, filename, contents, binary=True):

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -1,3 +1,4 @@
+import io
 import os
 import zipfile
 import json
@@ -9,7 +10,7 @@ import tarfile
 
 import click
 from typing import IO, Dict, List, Any, Tuple, Iterator, BinaryIO  # noqa
-from typing import Optional  # noqa
+from typing import Optional, Union  # noqa
 from typing import MutableMapping  # noqa
 
 from chalice.constants import WELCOME_PROMPT
@@ -118,14 +119,14 @@ class OSUtils(object):
         return os.path.isfile(filename)
 
     def get_file_contents(self, filename, binary=True, encoding='utf-8'):
-        # type: (str, bool) -> str
+        # type: (str, bool, Optional[str]) -> str
         if binary:
             mode = 'rb'
             # In binary mode the encoding is not used and most be None.
             encoding  = None
         else:
             mode = 'r'
-        with open(filename, mode, encoding=encoding) as f:
+        with io.open(filename, mode, encoding=encoding) as f:
             return f.read()
 
     def set_file_contents(self, filename, contents, binary=True):

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -123,7 +123,7 @@ class OSUtils(object):
         if binary:
             mode = 'rb'
             # In binary mode the encoding is not used and most be None.
-            encoding  = None
+            encoding = None
         else:
             mode = 'r'
         with io.open(filename, mode, encoding=encoding) as f:

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -119,7 +119,10 @@ class OSUtils(object):
         return os.path.isfile(filename)
 
     def get_file_contents(self, filename, binary=True, encoding='utf-8'):
-        # type: (str, bool, Optional[str]) -> str
+        # type: (str, bool, Any) -> str
+        # It looks like the type definition for io.open is wrong.
+        # the encoding arg is unicode, but the actual type is
+        # Optional[Text].  For now we have to use Any to keep mypy happy.
         if binary:
             mode = 'rb'
             # In binary mode the encoding is not used and most be None.

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -2,7 +2,14 @@ import zipfile
 import json
 import os
 
+import pytest
+
 from chalice import utils
+
+
+@pytest.fixture
+def osutils():
+    return utils.OSUtils()
 
 
 def test_can_zip_single_file(tmpdir):
@@ -98,3 +105,14 @@ def test_remove_stage_from_deployed_values_no_file(tmpdir):
 
     # Make sure it doesn't create the file if it didn't already exist
     assert not os.path.isfile(filename)
+
+
+class TestOSUtils(object):
+    def test_can_read_unicode(self, tmpdir, osutils):
+        filename = tmpdir.join('file.txt')
+        checkmark = u'\2713'
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(checkmark)
+
+        content = osutils.get_file_contents(filename, binary=False)
+        assert content == checkmark

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -114,5 +114,6 @@ class TestOSUtils(object):
         with open(filename, 'w', encoding='utf-8') as f:
             f.write(checkmark)
 
-        content = osutils.get_file_contents(filename, binary=False)
+        content = osutils.get_file_contents(filename, binary=False,
+                                            encoding='utf-8')
         assert content == checkmark

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,6 +1,7 @@
 import zipfile
 import json
 import os
+import io
 
 import pytest
 
@@ -109,9 +110,9 @@ def test_remove_stage_from_deployed_values_no_file(tmpdir):
 
 class TestOSUtils(object):
     def test_can_read_unicode(self, tmpdir, osutils):
-        filename = tmpdir.join('file.txt')
+        filename = str(tmpdir.join('file.txt'))
         checkmark = u'\2713'
-        with open(filename, 'w', encoding='utf-8') as f:
+        with io.open(filename, 'w', encoding='utf-8') as f:
             f.write(checkmark)
 
         content = osutils.get_file_contents(filename, binary=False,

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -112,9 +112,9 @@ class TestOSUtils(object):
     def test_can_read_unicode(self, tmpdir, osutils):
         filename = str(tmpdir.join('file.txt'))
         checkmark = u'\2713'
-        with io.open(filename, 'w', encoding='utf-8') as f:
+        with io.open(filename, 'w', encoding='utf-16') as f:
             f.write(checkmark)
 
         content = osutils.get_file_contents(filename, binary=False,
-                                            encoding='utf-8')
+                                            encoding='utf-16')
         assert content == checkmark


### PR DESCRIPTION
Specifically using the default causes an issue on windows if any file
has contents that are not readable by cp1252. This comes up during the
packaging of a deployment. Some egg-info files contain unicode
characters. Windows fails to build the deployment bundle since it
crashes trying to read the egg-info file.

@jamesls @kyleknap 