### PR TITLE
Add update support to new-deployer

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -272,12 +272,17 @@ class TypedAWSClient(object):
 
     def get_role_arn_for_name(self, name):
         # type: (str) -> str
+        role = self.get_role(name)
+        return role['Arn']
+
+    def get_role(self, name):
+        # type: (str) -> Dict[str, Any]
         client = self._client('iam')
         try:
             role = client.get_role(RoleName=name)
         except client.exceptions.NoSuchEntityException:
             raise ResourceDoesNotExistError("No role ARN found for: %s" % name)
-        return role['Role']['Arn']
+        return role['Role']
 
     def delete_role_policy(self, role_name, policy_name):
         # type: (str, str) -> None

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -158,8 +158,9 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
     session = factory.create_botocore_session()
     d = factory.create_new_default_deployer(session=session)
     deployed_values = d.deploy(config, chalice_stage_name=stage)
-    record_deployed_values(deployed_values, os.path.join(
-        config.project_dir, '.chalice', 'deployed.json'))
+    if deployed_values.get('resources'):
+        record_deployed_values(deployed_values, os.path.join(
+            config.project_dir, '.chalice', 'deployed.json'))
 
 
 @cli.command('delete')

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -7,6 +7,14 @@ class Placeholder(enum.Enum):
     DEPLOY_STAGE = 'deploy_stage'
 
 
+@attrs(frozen=True)
+class APICall(object):
+    method_name = attrib()
+    params = attrib()
+    target_variable = attrib(default=None)
+    resource = attrib(default=None)
+
+
 class Model(object):
     def dependencies(self):
         return []

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -1,9 +1,25 @@
-from typing import List, Dict, Any, TypeVar, Union
+from typing import List, Dict, Any, TypeVar, Union, Optional
 import enum
 
 class Placeholder(enum.Enum):
     BUILD_STAGE = 'build_stage'
     DEPLOY_STAGE = 'deploy_stage'
+
+
+class APICall:
+    method_name = ...  # type: str
+    params = ...  # type: Dict[str, Any]
+    target_variable = ...  # type: Optional[str]
+    resource = ...  # type: Optional[ManagedModel]
+
+    def __init__(self,
+                 method_name,           # type: str
+                 params,                # type: Dict[str, Any]
+                 target_variable=None,  # type: Optional[str]
+                 resource=None,         # type: Optional[ManagedModel]
+                 ):
+        # type: (...) -> None
+        ...
 
 
 T = TypeVar('T')

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -67,7 +67,7 @@ class AutoGenIAMPolicy(IAMPolicy):
 
 
 class IAMRole(Model):
-    pass
+    role_arn = ... # type: DV[str]
 
 
 class PreCreatedIAMRole(IAMRole):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -82,10 +82,8 @@ is used as the key in the ``deployed.json`` dictionary.
 
 """
 import os
-import json
 
 from typing import List, Set, Dict, Any, Optional, Union  # noqa
-from typing import cast
 from botocore.session import Session  # noqa
 
 from chalice.utils import OSUtils, UI
@@ -95,11 +93,12 @@ from chalice import app  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
 from chalice.deploy.packager import PipRunner, SubprocessPip
 from chalice.deploy.packager import DependencyBuilder as PipDependencyBuilder
+from chalice.deploy.planner import PlanStage, Variable
 from chalice.policy import AppPolicyGenerator
 from chalice.constants import LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
-from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+from chalice.awsclient import TypedAWSClient
 
 
 def create_default_deployer(session):
@@ -341,130 +340,6 @@ class BuildStage(object):
         for resource in resources:
             for step in self._steps:
                 step.handle(config, resource)
-
-
-class PlanStage(object):
-    def __init__(self, client, osutils):
-        # type: (TypedAWSClient, OSUtils) -> None
-        self._client = client
-        self._osutils = osutils
-
-    def execute(self, config, resources):
-        # type: (Config, List[models.Model]) -> List[models.APICall]
-        plan = []  # type: List[models.APICall]
-        for resource in resources:
-            name = 'plan_%s' % resource.__class__.__name__.lower()
-            handler = getattr(self, name, None)
-            if handler is not None:
-                result = handler(config, resource)
-                if result:
-                    plan.extend(result)
-        return plan
-
-    def plan_lambdafunction(self, config, resource):
-        # type: (Config, models.LambdaFunction) -> List[models.APICall]
-        role_arn = ''  # type: Optional[Union[str, Variable]]
-        if isinstance(resource.role, models.PreCreatedIAMRole):
-            role_arn = resource.role.role_arn
-        elif isinstance(resource.role, models.ManagedIAMRole):
-            role_arn = self._get_role_arn(resource.role)
-            if role_arn is not None:
-                resource.role.role_arn = role_arn
-            if isinstance(resource.role.role_arn, models.Placeholder):
-                role_arn = Variable('%s_role_arn' % resource.role.role_name)
-        if self._client.lambda_function_exists(resource.function_name):
-            params = {
-                'function_name': resource.function_name,
-                'role_arn': resource.role.role_arn,
-                'zip_contents': self._osutils.get_file_contents(
-                    resource.deployment_package.filename, binary=True),
-                'runtime': resource.runtime,
-                'environment_variables': resource.environment_variables,
-                'tags': resource.tags,
-                'timeout': resource.timeout,
-                'memory_size': resource.memory_size,
-            }
-            return [
-                models.APICall(
-                    method_name='update_function',
-                    params=params,
-                    resource=resource,
-                )
-            ]
-        return [models.APICall(
-            method_name='create_function',
-            params={'function_name': resource.function_name,
-                    'role_arn': role_arn,
-                    'zip_contents': self._osutils.get_file_contents(
-                        resource.deployment_package.filename, binary=True),
-                    'runtime': resource.runtime,
-                    'handler': resource.handler,
-                    'environment_variables': resource.environment_variables,
-                    'tags': resource.tags,
-                    'timeout': resource.timeout,
-                    'memory_size': resource.memory_size},
-            target_variable='%s_lambda_arn' % resource.resource_name,
-            resource=resource,
-        )]
-
-    def plan_managediamrole(self, config, resource):
-        # type: (Config, models.ManagedIAMRole) -> List[models.APICall]
-        document = self._get_policy_document(resource.policy)
-        role_arn = self._get_role_arn(resource)
-        if role_arn is not None:
-            resource.role_arn = role_arn
-        if isinstance(resource.role_arn, models.Placeholder):
-            return [
-                models.APICall(
-                    method_name='create_role',
-                    params={'name': resource.role_name,
-                            'trust_policy': resource.trust_policy,
-                            'policy': document},
-                    target_variable='%s_role_arn' % resource.role_name,
-                    resource=resource
-                )
-            ]
-        return [
-            models.APICall(
-                method_name='delete_role_policy',
-                params={'role_name': resource.role_name,
-                        'policy_name': resource.role_name},
-                resource=resource
-            ),
-            models.APICall(
-                method_name='put_role_policy',
-                params={'role_name': resource.role_name,
-                        'policy_name': resource.role_name,
-                        'policy_document': document},
-                resource=resource
-            )
-        ]
-
-    def _get_role_arn(self, resource):
-        # type: (models.ManagedIAMRole) -> Optional[str]
-        try:
-            return self._client.get_role_arn_for_name(resource.role_name)
-        except ResourceDoesNotExistError:
-            return None
-
-    def _get_policy_document(self, resource):
-        # type: (models.IAMPolicy) -> Dict[str, Any]
-        if isinstance(resource, models.AutoGenIAMPolicy):
-            # mypy can't check this, but we assert that the
-            # placeholder values are filled in before we invoke
-            # any planners, so we can safely cast from
-            # Placholder[T] to T.
-            document = cast(Dict[str, Any], resource.document)
-        elif isinstance(resource, models.FileBasedIAMPolicy):
-            document = json.loads(
-                self._osutils.get_file_contents(resource.filename))
-        return document
-
-
-class Variable(object):
-    def __init__(self, name):
-        # type: (str) -> None
-        self.name = name
 
 
 class Executor(object):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -82,8 +82,10 @@ is used as the key in the ``deployed.json`` dictionary.
 
 """
 import os
+import json
 
 from typing import List, Set, Dict, Any, Optional, Union  # noqa
+from typing import cast
 from botocore.session import Session  # noqa
 
 from chalice.utils import OSUtils, UI
@@ -349,27 +351,47 @@ class PlanStage(object):
 
     def execute(self, config, resources):
         # type: (Config, List[models.Model]) -> List[APICall]
-        plan = []
+        plan = []  # type: List[APICall]
         for resource in resources:
             name = 'plan_%s' % resource.__class__.__name__.lower()
             handler = getattr(self, name, None)
             if handler is not None:
                 result = handler(config, resource)
-                if result is not None:
-                    plan.append(result)
+                if result:
+                    plan.extend(result)
         return plan
 
     def plan_lambdafunction(self, config, resource):
-        # type: (Config, models.LambdaFunction) -> Optional[APICall]
-        if self._client.lambda_function_exists(resource.function_name):
-            return None
-        role_arn = ''  # type: Union[str, Variable]
+        # type: (Config, models.LambdaFunction) -> List[APICall]
+        role_arn = ''  # type: Optional[Union[str, Variable]]
         if isinstance(resource.role, models.PreCreatedIAMRole):
             role_arn = resource.role.role_arn
-        elif isinstance(resource.role, models.ManagedIAMRole) and \
-                isinstance(resource.role.role_arn, models.Placeholder):
-            role_arn = Variable('%s_role_arn' % resource.role.role_name)
-        return APICall(
+        elif isinstance(resource.role, models.ManagedIAMRole):
+            role_arn = self._get_role_arn(resource.role)
+            if role_arn is not None:
+                resource.role.role_arn = role_arn
+            if isinstance(resource.role.role_arn, models.Placeholder):
+                role_arn = Variable('%s_role_arn' % resource.role.role_name)
+        if self._client.lambda_function_exists(resource.function_name):
+            params = {
+                'function_name': resource.function_name,
+                'role_arn': resource.role.role_arn,
+                'zip_contents': self._osutils.get_file_contents(
+                    resource.deployment_package.filename, binary=True),
+                'runtime': resource.runtime,
+                'environment_variables': resource.environment_variables,
+                'tags': resource.tags,
+                'timeout': resource.timeout,
+                'memory_size': resource.memory_size,
+            }
+            return [
+                APICall(
+                    method_name='update_function',
+                    params=params,
+                    resource=resource,
+                )
+            ]
+        return [APICall(
             method_name='create_function',
             params={'function_name': resource.function_name,
                     'role_arn': role_arn,
@@ -383,29 +405,62 @@ class PlanStage(object):
                     'memory_size': resource.memory_size},
             target_variable='%s_lambda_arn' % resource.resource_name,
             resource=resource,
-        )
+        )]
 
     def plan_managediamrole(self, config, resource):
-        # type: (Config, models.ManagedIAMRole) -> Optional[APICall]
+        # type: (Config, models.ManagedIAMRole) -> List[APICall]
+        document = self._get_policy_document(resource.policy)
+        role_arn = self._get_role_arn(resource)
+        if role_arn is not None:
+            resource.role_arn = role_arn
         if isinstance(resource.role_arn, models.Placeholder):
-            try:
-                role_arn = self._client.get_role_arn_for_name(
-                    resource.role_name)
-                resource.role_arn = role_arn
-            except ResourceDoesNotExistError:
-                document = None
-                if isinstance(resource.policy, models.AutoGenIAMPolicy):
-                    document = resource.policy.document
-                return APICall(
+            return [
+                APICall(
                     method_name='create_role',
                     params={'name': resource.role_name,
                             'trust_policy': resource.trust_policy,
                             'policy': document},
                     target_variable='%s_role_arn' % resource.role_name,
-                    resource=resource)
-        # This is to make mypy happy, otherwise it complains
-        # about a missing return statement.
-        return None
+                    resource=resource
+                )
+            ]
+        else:
+            return [
+                APICall(
+                    method_name='delete_role_policy',
+                    params={'role_name': resource.role_name,
+                            'policy_name': resource.role_name},
+                    resource=resource
+                ),
+                APICall(
+                    method_name='put_role_policy',
+                    params={'role_name': resource.role_name,
+                            'policy_name': resource.role_name,
+                            'policy_document': document},
+                    resource=resource
+                )
+            ]
+        return []
+
+    def _get_role_arn(self, resource):
+        # type: (models.ManagedIAMRole) -> Optional[str]
+        try:
+            return self._client.get_role_arn_for_name(resource.role_name)
+        except ResourceDoesNotExistError:
+            return None
+
+    def _get_policy_document(self, resource):
+        # type: (models.IAMPolicy) -> Dict[str, Any]
+        if isinstance(resource, models.AutoGenIAMPolicy):
+            # mypy can't check this, but we assert that the
+            # placeholder values are filled in before we invoke
+            # any planners, so we can safely cast from
+            # Placholder[T] to T.
+            document = cast(Dict[str, Any], resource.document)
+        elif isinstance(resource, models.FileBasedIAMPolicy):
+            document = json.loads(
+                self._osutils.get_file_contents(resource.filename))
+        return document
 
 
 class APICall(object):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -297,7 +297,11 @@ class DependencyBuilder(object):
             if id(dep) not in seen:
                 seen.add(id(dep))
                 self._traverse(dep, ordered, seen)
-        ordered.append(resource)
+        # If recreating this list is a perf issue later on,
+        # we can create yet-another set of ids that gets updated
+        # when we add a resource to the ordered list.
+        if id(resource) not in [id(r) for r in ordered]:
+            ordered.append(resource)
 
 
 class BaseDeployStep(object):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -174,7 +174,7 @@ class Deployer(object):
             config, chalice_stage_name)
         resources = self._deps_builder.build_dependencies(application)
         self._build_stage.execute(config, resources)
-        plan = self._plan_stage.execute(config, resources)
+        plan = self._plan_stage.execute(resources)
         self._executor.execute(plan)
         return {'resources': self._executor.resources}
 

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -6,7 +6,6 @@ from chalice.utils import OSUtils  # noqa
 from chalice.deploy import models
 from chalice.awsclient import ResourceDoesNotExistError
 from chalice.awsclient import TypedAWSClient  # noqa
-from chalice.config import Config  # noqa
 
 
 class PlanStage(object):
@@ -15,20 +14,20 @@ class PlanStage(object):
         self._client = client
         self._osutils = osutils
 
-    def execute(self, config, resources):
-        # type: (Config, List[models.Model]) -> List[models.APICall]
+    def execute(self, resources):
+        # type: (List[models.Model]) -> List[models.APICall]
         plan = []  # type: List[models.APICall]
         for resource in resources:
             name = 'plan_%s' % resource.__class__.__name__.lower()
             handler = getattr(self, name, None)
             if handler is not None:
-                result = handler(config, resource)
+                result = handler(resource)
                 if result:
                     plan.extend(result)
         return plan
 
-    def plan_lambdafunction(self, config, resource):
-        # type: (Config, models.LambdaFunction) -> List[models.APICall]
+    def plan_lambdafunction(self, resource):
+        # type: (models.LambdaFunction) -> List[models.APICall]
         role_arn = ''  # type: Optional[Union[str, Variable]]
         if isinstance(resource.role, models.PreCreatedIAMRole):
             role_arn = resource.role.role_arn
@@ -73,8 +72,8 @@ class PlanStage(object):
             resource=resource,
         )]
 
-    def plan_managediamrole(self, config, resource):
-        # type: (Config, models.ManagedIAMRole) -> List[models.APICall]
+    def plan_managediamrole(self, resource):
+        # type: (models.ManagedIAMRole) -> List[models.APICall]
         document = self._get_policy_document(resource.policy)
         role_arn = self._get_role_arn(resource)
         if role_arn is not None:

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -23,6 +23,9 @@ class RemoteState(object):
         key = self._cache_key(resource)
         if key in self._cache:
             return self._cache[key]
+        # TODO: This code will likely be refactored and pulled into
+        # per-resource classes so the RemoteState object doesn't need
+        # to know about every type of resource.
         if isinstance(resource, models.ManagedIAMRole):
             result = self._resource_exists_iam_role(resource)
         elif isinstance(resource, models.LambdaFunction):
@@ -46,6 +49,8 @@ class RemoteState(object):
         # type: (models.ManagedIAMRole) -> Optional[models.ManagedModel]
         # We only need ManagedIAMRole support for now, but this will
         # need to grow as needed.
+        # TODO: revisit adding caching.  We don't need to make 2 API calls
+        # here.
         if not self.resource_exists(resource):
             return None
         role = self._client.get_role(resource.role_name)
@@ -71,6 +76,10 @@ class PlanStage(object):
                 if result:
                     plan.extend(result)
         return plan
+
+    # TODO: This code will likely be refactored and pulled into
+    # per-resource classes so the PlanStage object doesn't need
+    # to know about every type of resource.
 
     def plan_lambdafunction(self, resource):
         # type: (models.LambdaFunction) -> List[models.APICall]
@@ -98,6 +107,8 @@ class PlanStage(object):
                     resource=resource,
                 )
             ]
+        # TODO: Consider a smarter diff where we check if we even need
+        # to do an update() API call.
         params = {
             'function_name': resource.function_name,
             'role_arn': resource.role.role_arn,

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1,0 +1,133 @@
+import json
+
+from typing import List, Dict, Any, Optional, Union, cast  # noqa
+
+from chalice.utils import OSUtils  # noqa
+from chalice.deploy import models
+from chalice.awsclient import ResourceDoesNotExistError
+from chalice.awsclient import TypedAWSClient  # noqa
+from chalice.config import Config  # noqa
+
+
+class PlanStage(object):
+    def __init__(self, client, osutils):
+        # type: (TypedAWSClient, OSUtils) -> None
+        self._client = client
+        self._osutils = osutils
+
+    def execute(self, config, resources):
+        # type: (Config, List[models.Model]) -> List[models.APICall]
+        plan = []  # type: List[models.APICall]
+        for resource in resources:
+            name = 'plan_%s' % resource.__class__.__name__.lower()
+            handler = getattr(self, name, None)
+            if handler is not None:
+                result = handler(config, resource)
+                if result:
+                    plan.extend(result)
+        return plan
+
+    def plan_lambdafunction(self, config, resource):
+        # type: (Config, models.LambdaFunction) -> List[models.APICall]
+        role_arn = ''  # type: Optional[Union[str, Variable]]
+        if isinstance(resource.role, models.PreCreatedIAMRole):
+            role_arn = resource.role.role_arn
+        elif isinstance(resource.role, models.ManagedIAMRole):
+            role_arn = self._get_role_arn(resource.role)
+            if role_arn is not None:
+                resource.role.role_arn = role_arn
+            if isinstance(resource.role.role_arn, models.Placeholder):
+                role_arn = Variable('%s_role_arn' % resource.role.role_name)
+        if self._client.lambda_function_exists(resource.function_name):
+            params = {
+                'function_name': resource.function_name,
+                'role_arn': resource.role.role_arn,
+                'zip_contents': self._osutils.get_file_contents(
+                    resource.deployment_package.filename, binary=True),
+                'runtime': resource.runtime,
+                'environment_variables': resource.environment_variables,
+                'tags': resource.tags,
+                'timeout': resource.timeout,
+                'memory_size': resource.memory_size,
+            }
+            return [
+                models.APICall(
+                    method_name='update_function',
+                    params=params,
+                    resource=resource,
+                )
+            ]
+        return [models.APICall(
+            method_name='create_function',
+            params={'function_name': resource.function_name,
+                    'role_arn': role_arn,
+                    'zip_contents': self._osutils.get_file_contents(
+                        resource.deployment_package.filename, binary=True),
+                    'runtime': resource.runtime,
+                    'handler': resource.handler,
+                    'environment_variables': resource.environment_variables,
+                    'tags': resource.tags,
+                    'timeout': resource.timeout,
+                    'memory_size': resource.memory_size},
+            target_variable='%s_lambda_arn' % resource.resource_name,
+            resource=resource,
+        )]
+
+    def plan_managediamrole(self, config, resource):
+        # type: (Config, models.ManagedIAMRole) -> List[models.APICall]
+        document = self._get_policy_document(resource.policy)
+        role_arn = self._get_role_arn(resource)
+        if role_arn is not None:
+            resource.role_arn = role_arn
+        if isinstance(resource.role_arn, models.Placeholder):
+            return [
+                models.APICall(
+                    method_name='create_role',
+                    params={'name': resource.role_name,
+                            'trust_policy': resource.trust_policy,
+                            'policy': document},
+                    target_variable='%s_role_arn' % resource.role_name,
+                    resource=resource
+                )
+            ]
+        return [
+            models.APICall(
+                method_name='delete_role_policy',
+                params={'role_name': resource.role_name,
+                        'policy_name': resource.role_name},
+                resource=resource
+            ),
+            models.APICall(
+                method_name='put_role_policy',
+                params={'role_name': resource.role_name,
+                        'policy_name': resource.role_name,
+                        'policy_document': document},
+                resource=resource
+            )
+        ]
+
+    def _get_role_arn(self, resource):
+        # type: (models.ManagedIAMRole) -> Optional[str]
+        try:
+            return self._client.get_role_arn_for_name(resource.role_name)
+        except ResourceDoesNotExistError:
+            return None
+
+    def _get_policy_document(self, resource):
+        # type: (models.IAMPolicy) -> Dict[str, Any]
+        if isinstance(resource, models.AutoGenIAMPolicy):
+            # mypy can't check this, but we assert that the
+            # placeholder values are filled in before we invoke
+            # any planners, so we can safely cast from
+            # Placholder[T] to T.
+            document = cast(Dict[str, Any], resource.document)
+        elif isinstance(resource, models.FileBasedIAMPolicy):
+            document = json.loads(
+                self._osutils.get_file_contents(resource.filename))
+        return document
+
+
+class Variable(object):
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -91,12 +91,6 @@ class PlanStage(object):
             ]
         return [
             models.APICall(
-                method_name='delete_role_policy',
-                params={'role_name': resource.role_name,
-                        'policy_name': resource.role_name},
-                resource=resource
-            ),
-            models.APICall(
                 method_name='put_role_policy',
                 params={'role_name': resource.role_name,
                         'policy_name': resource.role_name,

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -264,6 +264,36 @@ class TestGetRoleArn(object):
         stubbed_session.verify_stubs()
 
 
+class TestGetRole(object):
+    def test_get_role_success(self, stubbed_session):
+        today = datetime.datetime.today()
+        response = {
+            'Role': {
+                'Path': '/',
+                'RoleName': 'Yes',
+                'RoleId': 'abcd' * 4,
+                'CreateDate': today,
+                'Arn': 'good_arn' * 3,
+            }
+        }
+        stubbed_session.stub('iam').get_role(RoleName='Yes').returns(response)
+        stubbed_session.activate_stubs()
+        awsclient = TypedAWSClient(stubbed_session)
+        actual = awsclient.get_role(name='Yes')
+        assert actual == response['Role']
+        stubbed_session.verify_stubs()
+
+    def test_get_role_raises_exception_when_no_exists(self, stubbed_session):
+        stubbed_session.stub('iam').get_role(RoleName='Yes').raises_error(
+            error_code='NoSuchEntity',
+            message='Foo')
+        stubbed_session.activate_stubs()
+        awsclient = TypedAWSClient(stubbed_session)
+        with pytest.raises(ResourceDoesNotExistError):
+            awsclient.get_role(name='Yes')
+        stubbed_session.verify_stubs()
+
+
 class TestCreateRole(object):
     def test_create_role(self, stubbed_session):
         arn = 'good_arn' * 3

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -7,7 +7,7 @@ from pytest import fixture
 import mock
 import botocore.session
 
-from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+from chalice.awsclient import TypedAWSClient
 from chalice.utils import OSUtils
 from chalice.deploy import models
 from chalice.deploy import packager
@@ -21,8 +21,8 @@ from chalice.deploy.newdeployer import DependencyBuilder
 from chalice.deploy.newdeployer import ApplicationGraphBuilder
 from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
 from chalice.deploy.newdeployer import PolicyGenerator
-from chalice.deploy.newdeployer import PlanStage
-from chalice.deploy.newdeployer import Executor, Variable
+from chalice.deploy.planner import PlanStage, Variable
+from chalice.deploy.newdeployer import Executor
 from chalice.deploy.newdeployer import UnresolvedValueError
 from chalice.deploy.models import APICall
 from chalice.policy import AppPolicyGenerator
@@ -480,213 +480,6 @@ class TestDeploymentPackager(object):
 
         assert package.filename == 'original-name.zip'
         assert not generator.create_deployment_package.called
-
-
-class TestPlanStageCreate(object):
-    def test_can_plan_for_iam_role_creation(self, mock_client, mock_osutils):
-        mock_client.get_role_arn_for_name.side_effect = \
-            ResourceDoesNotExistError()
-        planner = PlanStage(mock_client, mock_osutils)
-        resource = models.ManagedIAMRole(
-            resource_name='default-role',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole',
-            trust_policy={'trust': 'policy'},
-            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
-        )
-        plan = planner.execute(Config.create(), [resource])
-        assert len(plan) == 1
-        api_call = plan[0]
-        assert api_call.method_name == 'create_role'
-        assert api_call.params == {'name': 'myrole',
-                                   'trust_policy': {'trust': 'policy'},
-                                   'policy': {'iam': 'policy'}}
-        assert api_call.target_variable == 'myrole_role_arn'
-        assert api_call.resource == resource
-
-    def test_can_create_plan_for_filebased_role(self, mock_client,
-                                                mock_osutils):
-        mock_client.get_role_arn_for_name.side_effect = \
-                ResourceDoesNotExistError
-        resource = models.ManagedIAMRole(
-            resource_name='default-role',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole',
-            trust_policy={'trust': 'policy'},
-            policy=models.FileBasedIAMPolicy(filename='foo.json'),
-        )
-        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(project_dir='.'), [resource])
-        assert len(plan) == 1
-        api_call = plan[0]
-        assert api_call.method_name == 'create_role'
-        assert api_call.params == {'name': 'myrole',
-                                   'trust_policy': {'trust': 'policy'},
-                                   'policy': {'iam': 'policy'}}
-        assert api_call.target_variable == 'myrole_role_arn'
-        assert api_call.resource == resource
-
-    def test_can_create_function(self, mock_client, mock_osutils):
-        mock_client.lambda_function_exists.return_value = False
-        function = create_function_resource('function_name')
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [function])
-        assert len(plan) == 1
-        call = plan[0]
-        assert call.method_name == 'create_function'
-        assert call.target_variable == 'function_name_lambda_arn'
-        assert call.params == {
-            'function_name': 'appname-dev-function_name',
-            'role_arn': 'role:arn',
-            'zip_contents': mock.ANY,
-            'runtime': 'python2.7',
-            'handler': 'app.app',
-            'environment_variables': {},
-            'tags': {},
-            'timeout': 60,
-            'memory_size': 128,
-        }
-        assert call.resource == function
-
-    def test_can_create_plan_for_managed_role(self, mock_client, mock_osutils):
-        mock_client.lambda_function_exists.return_value = False
-        mock_client.get_role_arn_for_name.side_effect = \
-            ResourceDoesNotExistError
-        function = create_function_resource('function_name')
-        function.role = models.ManagedIAMRole(
-            resource_name='myrole',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole-dev',
-            trust_policy={'trust': 'policy'},
-            policy=models.FileBasedIAMPolicy(filename='foo.json'),
-        )
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [function])
-        assert len(plan) == 1
-        call = plan[0]
-        assert call.method_name == 'create_function'
-        assert call.target_variable == 'function_name_lambda_arn'
-        assert call.resource == function
-        # The params are verified in test_can_create_function,
-        # we just care about how the role_arn Variable is constructed.
-        role_arn = call.params['role_arn']
-        assert isinstance(role_arn, Variable)
-        assert role_arn.name == 'myrole-dev_role_arn'
-
-
-class TestPlanStageUpdate(object):
-    def test_can_update_lambda_function_code(self, mock_client, mock_osutils):
-        mock_client.lambda_function_exists.return_value = True
-        function = create_function_resource('function_name')
-        # Now let's change the memory size and ensure we
-        # get an update.
-        function.memory_size = 256
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [function])
-        assert len(plan) == 1
-        call = plan[0]
-        assert call.method_name == 'update_function'
-        assert call.resource == function
-        # We don't need to set a target variable because the
-        # function already exists and we know the arn.
-        assert call.target_variable is None
-        existing_params = {
-            'function_name': 'appname-dev-function_name',
-            'role_arn': 'role:arn',
-            'zip_contents': mock.ANY,
-            'runtime': 'python2.7',
-            'environment_variables': {},
-            'tags': {},
-            'timeout': 60,
-        }
-        expected = dict(memory_size=256, **existing_params)
-        assert call.params == expected
-
-    def test_can_update_managed_role(self, mock_client, mock_osutils):
-        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
-        role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn='myrole:arn',
-            role_name='myrole',
-            trust_policy={},
-            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
-        )
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [role])
-        assert len(plan) == 2
-        delete_call = plan[0]
-        assert delete_call.method_name == 'delete_role_policy'
-        assert delete_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole'}
-        assert delete_call.resource == role
-
-        update_call = plan[1]
-        assert update_call.method_name == 'put_role_policy'
-        assert update_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole',
-                                      'policy_document': {'role': 'policy'}}
-        assert update_call.resource == role
-
-    def test_can_update_file_based_policy(self, mock_client, mock_osutils):
-        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
-        role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn='myrole:arn',
-            role_name='myrole',
-            trust_policy={},
-            policy=models.FileBasedIAMPolicy(filename='foo.json'),
-        )
-        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [role])
-        assert len(plan) == 2
-        delete_call = plan[0]
-        assert delete_call.method_name == 'delete_role_policy'
-        assert delete_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole'}
-        assert delete_call.resource == role
-
-        update_call = plan[1]
-        assert update_call.method_name == 'put_role_policy'
-        assert update_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole',
-                                      'policy_document': {'iam': 'policy'}}
-        assert update_call.resource == role
-
-    def test_no_update_for_non_managed_role(self):
-        role = models.PreCreatedIAMRole(role_arn='role:arn')
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [role])
-        assert plan == []
-
-    def test_can_update_with_placeholder_but_exists(self, mock_client,
-                                                    mock_osutils):
-        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
-        role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole',
-            trust_policy={},
-            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
-        )
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [role])
-        assert len(plan) == 2
-        delete_call = plan[0]
-        assert delete_call.method_name == 'delete_role_policy'
-        assert delete_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole'}
-        assert delete_call.resource == role
-
-        update_call = plan[1]
-        assert update_call.method_name == 'put_role_policy'
-        assert update_call.params == {'role_name': 'myrole',
-                                      'policy_name': 'myrole',
-                                      'policy_document': {'role': 'policy'}}
-        assert update_call.resource == role
-
-        assert role.role_arn == 'myrole:arn'
 
 
 class TestInvoker(object):

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -608,7 +608,7 @@ class TestDeployer(unittest.TestCase):
         self.resource_builder.build.assert_called_with(config, 'dev')
         self.deps_builder.build_dependencies.assert_called_with(app)
         self.build_stage.execute.assert_called_with(config, resources)
-        self.plan_stage.execute.assert_called_with(config, resources)
+        self.plan_stage.execute.assert_called_with(resources)
         self.executor.execute.assert_called_with(api_calls)
 
         assert result == {'resources': {'foo': {'name': 'bar'}}}

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -481,7 +481,7 @@ class TestDeploymentPackager(object):
         assert not generator.create_deployment_package.called
 
 
-class TestPlanStage(object):
+class TestPlanStageCreate(object):
     def test_can_plan_for_iam_role_creation(self, mock_client, mock_osutils):
         mock_client.get_role_arn_for_name.side_effect = \
             ResourceDoesNotExistError()
@@ -503,20 +503,28 @@ class TestPlanStage(object):
         assert api_call.target_variable == 'myrole_role_arn'
         assert api_call.resource == resource
 
-    def test_no_action_if_role_exists(self, mock_client, mock_osutils):
-        # This might need some tweaking to figure out if we need
-        # to update the policy or not.
-        mock_client.get_role_arn_for_name.return_value = 'role:arn'
-        planner = PlanStage(mock_client, mock_osutils)
+    def test_can_create_plan_for_filebased_role(self, mock_client,
+                                                mock_osutils):
+        mock_client.get_role_arn_for_name.side_effect = \
+                ResourceDoesNotExistError
         resource = models.ManagedIAMRole(
             resource_name='default-role',
             role_arn=models.Placeholder.DEPLOY_STAGE,
             role_name='myrole',
             trust_policy={'trust': 'policy'},
-            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
         )
-        plan = planner.execute(Config.create(), [resource])
-        assert plan == []
+        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(project_dir='.'), [resource])
+        assert len(plan) == 1
+        api_call = plan[0]
+        assert api_call.method_name == 'create_role'
+        assert api_call.params == {'name': 'myrole',
+                                   'trust_policy': {'trust': 'policy'},
+                                   'policy': {'iam': 'policy'}}
+        assert api_call.target_variable == 'myrole_role_arn'
+        assert api_call.resource == resource
 
     def test_can_create_function(self, mock_client, mock_osutils):
         mock_client.lambda_function_exists.return_value = False
@@ -540,16 +548,10 @@ class TestPlanStage(object):
         }
         assert call.resource == function
 
-    def test_no_plan_if_function_exists(self, mock_client, mock_osutils):
-        mock_client.lambda_function_exists.return_value = True
-        function = create_function_resource('function_name')
-        planner = PlanStage(mock_client, mock_osutils)
-        plan = planner.execute(Config.create(), [function])
-        # This will change once updates are implemented.
-        assert plan == []
-
     def test_can_create_plan_for_managed_role(self, mock_client, mock_osutils):
         mock_client.lambda_function_exists.return_value = False
+        mock_client.get_role_arn_for_name.side_effect = \
+            ResourceDoesNotExistError
         function = create_function_resource('function_name')
         function.role = models.ManagedIAMRole(
             resource_name='myrole',
@@ -570,6 +572,120 @@ class TestPlanStage(object):
         role_arn = call.params['role_arn']
         assert isinstance(role_arn, Variable)
         assert role_arn.name == 'myrole-dev_role_arn'
+
+
+class TestPlanStageUpdate(object):
+    def test_can_update_lambda_function_code(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = True
+        function = create_function_resource('function_name')
+        # Now let's change the memory size and ensure we
+        # get an update.
+        function.memory_size = 256
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'update_function'
+        assert call.resource == function
+        # We don't need to set a target variable because the
+        # function already exists and we know the arn.
+        assert call.target_variable is None
+        existing_params = {
+            'function_name': 'appname-dev-function_name',
+            'role_arn': 'role:arn',
+            'zip_contents': mock.ANY,
+            'runtime': 'python2.7',
+            'environment_variables': {},
+            'tags': {},
+            'timeout': 60,
+        }
+        expected = dict(memory_size=256, **existing_params)
+        assert call.params == expected
+
+    def test_can_update_managed_role(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'role': 'policy'}}
+        assert update_call.resource == role
+
+    def test_can_update_file_based_policy(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'iam': 'policy'}}
+        assert update_call.resource == role
+
+    def test_no_update_for_non_managed_role(self):
+        role = models.PreCreatedIAMRole(role_arn='role:arn')
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert plan == []
+
+    def test_can_update_with_placeholder_but_exists(self, mock_client,
+                                                    mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'role': 'policy'}}
+        assert update_call.resource == role
+
+        assert role.role_arn == 'myrole:arn'
 
 
 class TestInvoker(object):

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -101,6 +101,16 @@ class TestDependencyBuilder(object):
         deps = dep_builder.build_dependencies(app)
         assert deps == [shared_leaf, first_parent, second_parent]
 
+    def test_is_first_element_in_list(self):
+        shared_leaf = LeafResource(name='leaf-resource')
+        first_parent = FooResource(name='first', leaf=shared_leaf)
+        app = models.Application(
+            stage='dev', resources=[first_parent, shared_leaf],
+        )
+        dep_builder = DependencyBuilder()
+        deps = dep_builder.build_dependencies(app)
+        assert deps == [shared_leaf, first_parent]
+
     def test_can_compares_with_identity_not_equality(self):
         first_leaf = LeafResource(name='same-name')
         second_leaf = LeafResource(name='same-name')

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -21,9 +21,10 @@ from chalice.deploy.newdeployer import DependencyBuilder
 from chalice.deploy.newdeployer import ApplicationGraphBuilder
 from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
 from chalice.deploy.newdeployer import PolicyGenerator
-from chalice.deploy.newdeployer import PlanStage, APICall
+from chalice.deploy.newdeployer import PlanStage
 from chalice.deploy.newdeployer import Executor, Variable
 from chalice.deploy.newdeployer import UnresolvedValueError
+from chalice.deploy.models import APICall
 from chalice.policy import AppPolicyGenerator
 from chalice.constants import LAMBDA_TRUST_POLICY
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1,44 +1,70 @@
 import mock
 
-from chalice.deploy import models
+import attr
+
 from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+from chalice.deploy import models
 from chalice.utils import OSUtils
-from chalice.deploy.planner import PlanStage, Variable
+from chalice.deploy.planner import PlanStage, Variable, RemoteState
+
+
+def create_function_resource(name, function_name=None,
+                             environment_variables=None,
+                             runtime='python2.7', handler='app.app',
+                             tags=None, timeout=60,
+                             memory_size=128, deployment_package=None,
+                             role=None):
+    if function_name is None:
+        function_name = 'appname-dev-%s' % name
+    if environment_variables is None:
+        environment_variables = {}
+    if tags is None:
+        tags = {}
+    if deployment_package is None:
+        deployment_package = models.DeploymentPackage(filename='foo')
+    if role is None:
+        role = models.PreCreatedIAMRole(role_arn='role:arn')
+    return models.LambdaFunction(
+        resource_name=name,
+        function_name=function_name,
+        environment_variables=environment_variables,
+        runtime=runtime,
+        handler=handler,
+        tags=tags,
+        timeout=timeout,
+        memory_size=memory_size,
+        deployment_package=deployment_package,
+        role=role,
+    )
+
+
+class InMemoryRemoteState(object):
+    def __init__(self, known_resources=None):
+        if known_resources is None:
+            known_resources = {}
+        self.known_resources = known_resources
+
+    def resource_exists(self, resource):
+        return (
+            (resource.resource_type, resource.resource_name)
+            in self.known_resources)
+
+    def get_remote_model(self, resource):
+        key = (resource.resource_type, resource.resource_name)
+        return self.known_resources.get(key)
+
+    def declare_resource_exists(self, resource):
+        key = (resource.resource_type, resource.resource_name)
+        self.known_resources[key] = resource
+
+    def declare_no_resources_exists(self):
+        self.known_resources = {}
 
 
 class BasePlannerTests(object):
     def setup_method(self):
-        self.client = mock.Mock(spec=TypedAWSClient)
         self.osutils = mock.Mock(spec=OSUtils)
-
-    def create_function_resource(self, name, function_name=None,
-                                 environment_variables=None,
-                                 runtime='python2.7', handler='app.app',
-                                 tags=None, timeout=60,
-                                 memory_size=128, deployment_package=None,
-                                 role=None):
-        if function_name is None:
-            function_name = 'appname-dev-%s' % name
-        if environment_variables is None:
-            environment_variables = {}
-        if tags is None:
-            tags = {}
-        if deployment_package is None:
-            deployment_package = models.DeploymentPackage(filename='foo')
-        if role is None:
-            role = models.PreCreatedIAMRole(role_arn='role:arn')
-        return models.LambdaFunction(
-            resource_name=name,
-            function_name=function_name,
-            environment_variables=environment_variables,
-            runtime=runtime,
-            handler=handler,
-            tags=tags,
-            timeout=timeout,
-            memory_size=memory_size,
-            deployment_package=deployment_package,
-            role=role,
-        )
+        self.remote_state = InMemoryRemoteState()
 
     def assert_apicall_equals(self, expected, actual_api_call):
         # models.APICall has its own __eq__ method from attrs,
@@ -51,12 +77,15 @@ class BasePlannerTests(object):
         assert expected.target_variable == actual_api_call.target_variable
         assert expected.resource == actual_api_call.resource
 
+    def determine_plan(self, resource):
+        planner = PlanStage(self.remote_state, self.osutils)
+        plan = planner.execute([resource])
+        return plan
 
-class TestPlanStageCreate(BasePlannerTests):
+
+class TestPlanManagedRole(BasePlannerTests):
     def test_can_plan_for_iam_role_creation(self):
-        self.client.get_role_arn_for_name.side_effect = \
-            ResourceDoesNotExistError()
-        planner = PlanStage(self.client, self.osutils)
+        self.remote_state.declare_no_resources_exists()
         resource = models.ManagedIAMRole(
             resource_name='default-role',
             role_arn=models.Placeholder.DEPLOY_STAGE,
@@ -64,7 +93,7 @@ class TestPlanStageCreate(BasePlannerTests):
             trust_policy={'trust': 'policy'},
             policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
         )
-        plan = planner.execute([resource])
+        plan = self.determine_plan(resource)
         assert len(plan) == 1
         expected = models.APICall(
             method_name='create_role',
@@ -77,8 +106,7 @@ class TestPlanStageCreate(BasePlannerTests):
         self.assert_apicall_equals(plan[0], expected)
 
     def test_can_create_plan_for_filebased_role(self):
-        self.client.get_role_arn_for_name.side_effect = \
-                ResourceDoesNotExistError
+        self.remote_state.declare_no_resources_exists()
         resource = models.ManagedIAMRole(
             resource_name='default-role',
             role_arn=models.Placeholder.DEPLOY_STAGE,
@@ -87,8 +115,7 @@ class TestPlanStageCreate(BasePlannerTests):
             policy=models.FileBasedIAMPolicy(filename='foo.json'),
         )
         self.osutils.get_file_contents.return_value = '{"iam": "policy"}'
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([resource])
+        plan = self.determine_plan(resource)
         assert len(plan) == 1
         expected = models.APICall(
             method_name='create_role',
@@ -100,11 +127,87 @@ class TestPlanStageCreate(BasePlannerTests):
         )
         self.assert_apicall_equals(plan[0], expected)
 
+    def test_can_update_managed_role(self):
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        self.remote_state.declare_resource_exists(role)
+        plan = self.determine_plan(role)
+        assert len(plan) == 1
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='put_role_policy',
+                params={'role_name': 'myrole',
+                        'policy_name': 'myrole',
+                        'policy_document': {'role': 'policy'}},
+                resource=role,
+            )
+        )
+
+    def test_can_update_file_based_policy(self):
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        self.remote_state.declare_resource_exists(role)
+        self.osutils.get_file_contents.return_value = '{"iam": "policy"}'
+        plan = self.determine_plan(role)
+        assert len(plan) == 1
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='put_role_policy',
+                params={'role_name': 'myrole',
+                        'policy_name': 'myrole',
+                        'policy_document': {'iam': 'policy'}},
+                resource=role,
+            )
+        )
+
+    def test_no_update_for_non_managed_role(self):
+        role = models.PreCreatedIAMRole(role_arn='role:arn')
+        plan = self.determine_plan(role)
+        assert plan == []
+
+    def test_can_update_with_placeholder_but_exists(self):
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        remote_role = attr.evolve(role, role_arn='myrole:arn')
+        self.remote_state.declare_resource_exists(remote_role)
+        plan = self.determine_plan(role)
+        assert len(plan) == 1
+        # We've filled in the role arn.
+        assert role.role_arn == 'myrole:arn'
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='put_role_policy',
+                params={'role_name': 'myrole',
+                        'policy_name': 'myrole',
+                        'policy_document': {'role': 'policy'}},
+                resource=role,
+            )
+        )
+
+
+class TestPlanLambdaFunction(BasePlannerTests):
     def test_can_create_function(self):
-        self.client.lambda_function_exists.return_value = False
-        function = self.create_function_resource('function_name')
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([function])
+        function = create_function_resource('function_name')
+        self.remote_state.declare_no_resources_exists()
+        plan = self.determine_plan(function)
         assert len(plan) == 1
         expected = models.APICall(
             method_name='create_function',
@@ -124,41 +227,14 @@ class TestPlanStageCreate(BasePlannerTests):
         )
         self.assert_apicall_equals(plan[0], expected)
 
-    def test_can_create_plan_for_managed_role(self):
-        self.client.lambda_function_exists.return_value = False
-        self.client.get_role_arn_for_name.side_effect = \
-            ResourceDoesNotExistError
-        function = self.create_function_resource('function_name')
-        function.role = models.ManagedIAMRole(
-            resource_name='myrole',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole-dev',
-            trust_policy={'trust': 'policy'},
-            policy=models.FileBasedIAMPolicy(filename='foo.json'),
-        )
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([function])
-        assert len(plan) == 1
-        call = plan[0]
-        assert call.method_name == 'create_function'
-        assert call.target_variable == 'function_name_lambda_arn'
-        assert call.resource == function
-        # The params are verified in test_can_create_function,
-        # we just care about how the role_arn Variable is constructed.
-        role_arn = call.params['role_arn']
-        assert isinstance(role_arn, Variable)
-        assert role_arn.name == 'myrole-dev_role_arn'
-
-
-class TestPlanStageUpdate(BasePlannerTests):
     def test_can_update_lambda_function_code(self):
-        self.client.lambda_function_exists.return_value = True
-        function = self.create_function_resource('function_name')
+        function = create_function_resource('function_name')
+        copy_of_function = attr.evolve(function)
+        self.remote_state.declare_resource_exists(copy_of_function)
         # Now let's change the memory size and ensure we
         # get an update.
         function.memory_size = 256
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([function])
+        plan = self.determine_plan(function)
         assert len(plan) == 1
         existing_params = {
             'function_name': 'appname-dev-function_name',
@@ -180,80 +256,101 @@ class TestPlanStageUpdate(BasePlannerTests):
         )
         self.assert_apicall_equals(plan[0], expected)
 
-    def test_can_update_managed_role(self):
-        self.client.get_role_arn_for_name.return_value = 'myrole:arn'
-        role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn='myrole:arn',
-            role_name='myrole',
-            trust_policy={},
-            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
-        )
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([role])
-        assert len(plan) == 1
-        self.assert_apicall_equals(
-            plan[0],
-            models.APICall(
-                method_name='put_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole',
-                        'policy_document': {'role': 'policy'}},
-                resource=role,
-            )
-        )
-
-    def test_can_update_file_based_policy(self):
-        self.client.get_role_arn_for_name.return_value = 'myrole:arn'
-        role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn='myrole:arn',
-            role_name='myrole',
-            trust_policy={},
+    def test_can_set_variables_when_needed(self):
+        function = create_function_resource('function_name')
+        self.remote_state.declare_no_resources_exists()
+        function.role = models.ManagedIAMRole(
+            resource_name='myrole',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole-dev',
+            trust_policy={'trust': 'policy'},
             policy=models.FileBasedIAMPolicy(filename='foo.json'),
         )
-        self.osutils.get_file_contents.return_value = '{"iam": "policy"}'
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([role])
+        plan = self.determine_plan(function)
         assert len(plan) == 1
-        self.assert_apicall_equals(
-            plan[0],
-            models.APICall(
-                method_name='put_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole',
-                        'policy_document': {'iam': 'policy'}},
-                resource=role,
-            )
-        )
+        call = plan[0]
+        assert call.method_name == 'create_function'
+        assert call.target_variable == 'function_name_lambda_arn'
+        assert call.resource == function
+        # The params are verified in test_can_create_function,
+        # we just care about how the role_arn Variable is constructed.
+        role_arn = call.params['role_arn']
+        assert isinstance(role_arn, Variable)
+        assert role_arn.name == 'myrole-dev_role_arn'
 
-    def test_no_update_for_non_managed_role(self):
-        role = models.PreCreatedIAMRole(role_arn='role:arn')
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([role])
-        assert plan == []
 
-    def test_can_update_with_placeholder_but_exists(self):
-        self.client.get_role_arn_for_name.return_value = 'myrole:arn'
+class TestRemoteState(object):
+    def setup_method(self):
+        self.client = mock.Mock(spec=TypedAWSClient)
+        self.remote_state = RemoteState(self.client)
+
+    def test_role_exists(self):
+        self.client.get_role_arn_for_name.return_value = 'role:arn'
+        role = models.ManagedIAMRole('my_role', role_arn=None,
+                                     role_name='app-dev', trust_policy={},
+                                     policy=None)
+        assert self.remote_state.resource_exists(role)
+        self.client.get_role_arn_for_name.assert_called_with('app-dev')
+
+    def test_role_does_not_exist(self):
+        client = self.client
+        client.get_role_arn_for_name.side_effect = ResourceDoesNotExistError()
+        role = models.ManagedIAMRole('my_role', role_arn=None,
+                                     role_name='app-dev', trust_policy={},
+                                     policy=None)
+        assert not self.remote_state.resource_exists(role)
+        self.client.get_role_arn_for_name.assert_called_with('app-dev')
+
+    def test_lambda_function_exists(self):
+        function = create_function_resource('function-name')
+        self.client.lambda_function_exists.return_value = True
+        assert self.remote_state.resource_exists(function)
+        self.client.lambda_function_exists.assert_called_with(
+            function.function_name)
+
+    def test_lambda_function_does_not_exist(self):
+        function = create_function_resource('function-name')
+        self.client.lambda_function_exists.return_value = False
+        assert not self.remote_state.resource_exists(function)
+        self.client.lambda_function_exists.assert_called_with(
+            function.function_name)
+
+    def test_remote_model_exists(self):
         role = models.ManagedIAMRole(
-            resource_name='resource_name',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
-            role_name='myrole',
+            resource_name='my_role',
+            role_arn=None,
+            role_name='app-dev',
             trust_policy={},
-            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+            policy=None
         )
-        planner = PlanStage(self.client, self.osutils)
-        plan = planner.execute([role])
-        assert len(plan) == 1
-        # We've filled in the role arn.
-        assert role.role_arn == 'myrole:arn'
-        self.assert_apicall_equals(
-            plan[0],
-            models.APICall(
-                method_name='put_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole',
-                        'policy_document': {'role': 'policy'}},
-                resource=role,
-            )
-        )
+        self.client.get_role.return_value = {
+            'AssumeRolePolicyDocument': {'trust': 'policy'},
+            'RoleId': 'roleid',
+            'RoleName': 'app-dev',
+            'Arn': 'my_role_arn'
+        }
+        # We don't fill in the policy document because that's an extra
+        # API call and we don't do any smart diffing with it.
+        remote_model = self.remote_state.get_remote_model(role)
+        remote_model.role_arn = 'my_role_arn'
+        remote_model.trust_policy = {'trust': 'policy'}
+        self.client.get_role.assert_called_with('app-dev')
+
+    def test_remote_model_does_not_exist(self):
+        client = self.client
+        client.get_role_arn_for_name.side_effect = ResourceDoesNotExistError()
+        role = models.ManagedIAMRole(resource_name='my_role', role_arn=None,
+                                     role_name='app-dev', trust_policy={},
+                                     policy=None)
+        assert self.remote_state.get_remote_model(role) is None
+
+    def test_exists_check_is_cached(self):
+        function = create_function_resource('function-name')
+        self.client.lambda_function_exists.return_value = True
+        assert self.remote_state.resource_exists(function)
+        # Now if we call this method repeatedly we should only invoke
+        # the underlying client method once.  Subsequent calls are cached.
+        assert self.remote_state.resource_exists(function)
+        assert self.remote_state.resource_exists(function)
+
+        assert self.client.lambda_function_exists.call_count == 1

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1,0 +1,240 @@
+from pytest import fixture
+import mock
+
+from chalice.deploy import models
+from chalice.config import Config
+from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
+from chalice.utils import OSUtils
+from chalice.deploy.planner import PlanStage, Variable
+
+
+@fixture
+def mock_client():
+    return mock.Mock(spec=TypedAWSClient)
+
+
+@fixture
+def mock_osutils():
+    return mock.Mock(spec=OSUtils)
+
+
+def create_function_resource(name):
+    return models.LambdaFunction(
+        resource_name=name,
+        function_name='appname-dev-%s' % name,
+        environment_variables={},
+        runtime='python2.7',
+        handler='app.app',
+        tags={},
+        timeout=60,
+        memory_size=128,
+        deployment_package=models.DeploymentPackage(filename='foo'),
+        role=models.PreCreatedIAMRole(role_arn='role:arn')
+    )
+
+
+class TestPlanStageCreate(object):
+    def test_can_plan_for_iam_role_creation(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.side_effect = \
+            ResourceDoesNotExistError()
+        planner = PlanStage(mock_client, mock_osutils)
+        resource = models.ManagedIAMRole(
+            resource_name='default-role',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole',
+            trust_policy={'trust': 'policy'},
+            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+        )
+        plan = planner.execute(Config.create(), [resource])
+        assert len(plan) == 1
+        api_call = plan[0]
+        assert api_call.method_name == 'create_role'
+        assert api_call.params == {'name': 'myrole',
+                                   'trust_policy': {'trust': 'policy'},
+                                   'policy': {'iam': 'policy'}}
+        assert api_call.target_variable == 'myrole_role_arn'
+        assert api_call.resource == resource
+
+    def test_can_create_plan_for_filebased_role(self, mock_client,
+                                                mock_osutils):
+        mock_client.get_role_arn_for_name.side_effect = \
+                ResourceDoesNotExistError
+        resource = models.ManagedIAMRole(
+            resource_name='default-role',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole',
+            trust_policy={'trust': 'policy'},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(project_dir='.'), [resource])
+        assert len(plan) == 1
+        api_call = plan[0]
+        assert api_call.method_name == 'create_role'
+        assert api_call.params == {'name': 'myrole',
+                                   'trust_policy': {'trust': 'policy'},
+                                   'policy': {'iam': 'policy'}}
+        assert api_call.target_variable == 'myrole_role_arn'
+        assert api_call.resource == resource
+
+    def test_can_create_function(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = False
+        function = create_function_resource('function_name')
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'create_function'
+        assert call.target_variable == 'function_name_lambda_arn'
+        assert call.params == {
+            'function_name': 'appname-dev-function_name',
+            'role_arn': 'role:arn',
+            'zip_contents': mock.ANY,
+            'runtime': 'python2.7',
+            'handler': 'app.app',
+            'environment_variables': {},
+            'tags': {},
+            'timeout': 60,
+            'memory_size': 128,
+        }
+        assert call.resource == function
+
+    def test_can_create_plan_for_managed_role(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = False
+        mock_client.get_role_arn_for_name.side_effect = \
+            ResourceDoesNotExistError
+        function = create_function_resource('function_name')
+        function.role = models.ManagedIAMRole(
+            resource_name='myrole',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole-dev',
+            trust_policy={'trust': 'policy'},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'create_function'
+        assert call.target_variable == 'function_name_lambda_arn'
+        assert call.resource == function
+        # The params are verified in test_can_create_function,
+        # we just care about how the role_arn Variable is constructed.
+        role_arn = call.params['role_arn']
+        assert isinstance(role_arn, Variable)
+        assert role_arn.name == 'myrole-dev_role_arn'
+
+
+class TestPlanStageUpdate(object):
+    def test_can_update_lambda_function_code(self, mock_client, mock_osutils):
+        mock_client.lambda_function_exists.return_value = True
+        function = create_function_resource('function_name')
+        # Now let's change the memory size and ensure we
+        # get an update.
+        function.memory_size = 256
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [function])
+        assert len(plan) == 1
+        call = plan[0]
+        assert call.method_name == 'update_function'
+        assert call.resource == function
+        # We don't need to set a target variable because the
+        # function already exists and we know the arn.
+        assert call.target_variable is None
+        existing_params = {
+            'function_name': 'appname-dev-function_name',
+            'role_arn': 'role:arn',
+            'zip_contents': mock.ANY,
+            'runtime': 'python2.7',
+            'environment_variables': {},
+            'tags': {},
+            'timeout': 60,
+        }
+        expected = dict(memory_size=256, **existing_params)
+        assert call.params == expected
+
+    def test_can_update_managed_role(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'role': 'policy'}}
+        assert update_call.resource == role
+
+    def test_can_update_file_based_policy(self, mock_client, mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn='myrole:arn',
+            role_name='myrole',
+            trust_policy={},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        mock_osutils.get_file_contents.return_value = '{"iam": "policy"}'
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'iam': 'policy'}}
+        assert update_call.resource == role
+
+    def test_no_update_for_non_managed_role(self):
+        role = models.PreCreatedIAMRole(role_arn='role:arn')
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert plan == []
+
+    def test_can_update_with_placeholder_but_exists(self, mock_client,
+                                                    mock_osutils):
+        mock_client.get_role_arn_for_name.return_value = 'myrole:arn'
+        role = models.ManagedIAMRole(
+            resource_name='resource_name',
+            role_arn=models.Placeholder.DEPLOY_STAGE,
+            role_name='myrole',
+            trust_policy={},
+            policy=models.AutoGenIAMPolicy(document={'role': 'policy'}),
+        )
+        planner = PlanStage(mock_client, mock_osutils)
+        plan = planner.execute(Config.create(), [role])
+        assert len(plan) == 2
+        delete_call = plan[0]
+        assert delete_call.method_name == 'delete_role_policy'
+        assert delete_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole'}
+        assert delete_call.resource == role
+
+        update_call = plan[1]
+        assert update_call.method_name == 'put_role_policy'
+        assert update_call.params == {'role_name': 'myrole',
+                                      'policy_name': 'myrole',
+                                      'policy_document': {'role': 'policy'}}
+        assert update_call.resource == role
+
+        assert role.role_arn == 'myrole:arn'

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -191,18 +191,9 @@ class TestPlanStageUpdate(BasePlannerTests):
         )
         planner = PlanStage(self.client, self.osutils)
         plan = planner.execute([role])
-        assert len(plan) == 2
+        assert len(plan) == 1
         self.assert_apicall_equals(
             plan[0],
-            models.APICall(
-                method_name='delete_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole'},
-                resource=role
-            )
-        )
-        self.assert_apicall_equals(
-            plan[1],
             models.APICall(
                 method_name='put_role_policy',
                 params={'role_name': 'myrole',
@@ -224,18 +215,9 @@ class TestPlanStageUpdate(BasePlannerTests):
         self.osutils.get_file_contents.return_value = '{"iam": "policy"}'
         planner = PlanStage(self.client, self.osutils)
         plan = planner.execute([role])
-        assert len(plan) == 2
+        assert len(plan) == 1
         self.assert_apicall_equals(
             plan[0],
-            models.APICall(
-                method_name='delete_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole'},
-                resource=role
-            )
-        )
-        self.assert_apicall_equals(
-            plan[1],
             models.APICall(
                 method_name='put_role_policy',
                 params={'role_name': 'myrole',
@@ -262,20 +244,11 @@ class TestPlanStageUpdate(BasePlannerTests):
         )
         planner = PlanStage(self.client, self.osutils)
         plan = planner.execute([role])
-        assert len(plan) == 2
+        assert len(plan) == 1
         # We've filled in the role arn.
         assert role.role_arn == 'myrole:arn'
         self.assert_apicall_equals(
             plan[0],
-            models.APICall(
-                method_name='delete_role_policy',
-                params={'role_name': 'myrole',
-                        'policy_name': 'myrole'},
-                resource=role
-            )
-        )
-        self.assert_apicall_equals(
-            plan[1],
             models.APICall(
                 method_name='put_role_policy',
                 params={'role_name': 'myrole',
@@ -284,7 +257,3 @@ class TestPlanStageUpdate(BasePlannerTests):
                 resource=role,
             )
         )
-
-
-class TestRemoteState(object):
-    pass


### PR DESCRIPTION
This PR adds support for updating lambda functions.  There's a few structural
changes made with no functional changes.  The deployer code is growing large
and as parts start to evolve I'm pulling them out into separate modules:

* The planner code has been extracted out to a separate module.
* The APICall has been pulled into models.  These need to be shared across
  the deployer and the planner and models.py seemed like a natural place

This PR omits the call to `delete_role_policy` that's in the update code in the
master branch.  This call is unnecessary, and `put_role_policy` will replaced
the existing policy associated with the IAM Role (I've verified this).

In terms of new components, I've introduced a `RemoteState` object that's used
to compute deltas between what's deployed and what's not.  In terms of
implementation you think of this as a higher level abstraction over
`TypedAWSClient` that's more resource based, but by adding an interface to
remote state it gives us the opportunity to try out different implementations
of computing deployment deltas.

There's one gap missing right now, the ability to delete lambda functions that
are no longer referenced by your app.  This will by additive code in a separate
object and likely in a separate PR.
