### PR TITLE
Check comprehension generators in the analyzer

### DIFF
--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -41,6 +41,7 @@ from typing import Dict, Set, Any, Optional, List, Union  # noqa
 
 APICallT = Dict[str, Set[str]]
 OptASTSet = Optional[Set[ast.AST]]
+ComprehensionNode = Union[ast.DictComp, ast.GeneratorExp, ast.ListComp]
 
 
 def get_client_calls(source_code):
@@ -537,10 +538,7 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
 
     def visit_DictComp(self, node):
         # type: (ast.DictComp) -> None
-        # Not implemented yet.  This creates a new scope,
-        # so we'd need to treat this similar to how we treat
-        # functions.
-        pass
+        self._handle_comprehension(node, 'dictcomp')
 
     def visit_Return(self, node):
         # type: (Any) -> None
@@ -570,32 +568,62 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
         self._handle_comprehension(node, 'genexpr')
 
     def _handle_comprehension(self, node, comprehension_type):
-        # type: (Union[ast.ListComp, ast.GeneratorExp], str) -> None
-        child_scope = self._get_matching_sub_namespace(
-            comprehension_type, node.lineno)
+        # type: (ComprehensionNode, str) -> None
+
+        if isinstance(node, ast.DictComp):
+            # dict comprehensions have two values to be checked
+            child_nodes = [node.key, node.value]
+        else:
+            child_nodes = [node.elt]
+
+        # first generator's iterator is visited in the current scope
+        first_generator = node.generators[0]
+        self.visit(first_generator.iter)
+        child_nodes.append(first_generator.target)
+        for if_expr in first_generator.ifs:
+            child_nodes.append(if_expr)
+
+        for generator in node.generators[1:]:
+            # rest need to be visited in the child scope
+            child_nodes.append(generator.iter)
+            child_nodes.append(generator.target)
+            for if_expr in generator.ifs:
+                child_nodes.append(if_expr)
+
+        child_scope = self._get_matching_sub_namespace(comprehension_type,
+                                                       node.lineno)
         if child_scope is None:
-            # If there's no child scope (listcomps in py2) then we can
-            # just analyze the node.elt node in the current scope instead
-            # of creating a new child scope.
-            self.visit(node.elt)
+            # In Python 2 there's no child scope for list comp
+            # Or we failed to locate the child scope, this happens in Python 2
+            # when there are multiple comprehensions of the same type in the
+            # same scope. The line number trick doesn't work as Python 2 always
+            # passes line number 0, make a best effort
+            for child_node in child_nodes:
+                try:
+                    self.visit(child_node)
+                except KeyError:
+                    pass
             return
-        child_table = self._symbol_table.new_sub_table(child_scope)
-        child_infer = self._new_inference_scope(
-            ParsedCode(node.elt, child_table), self._binder, self._visited)
-        child_infer.bind_types()
+        for child_node in child_nodes:
+            # visit sub expressions in the child scope
+            child_table = self._symbol_table.new_sub_table(child_scope)
+            child_infer = self._new_inference_scope(
+                ParsedCode(child_node, child_table),
+                self._binder, self._visited)
+            child_infer.bind_types()
 
     def _get_matching_sub_namespace(self, name, lineno):
         # type: (str, int) -> symtable.SymbolTable
-        namespaces = [
-            t for t in self._symbol_table.get_sub_namespaces()
-            if t.get_name() == name and t.get_lineno() == lineno]
-        if not namespaces:
-            return
-        # We're making a simplification and using the genexpr subnamespace.
-        # This has potential to miss a client call but we don't do
-        # inference on node.generators so this doesn't matter for now.
-        child_scope = namespaces[0]
-        return child_scope
+        namespaces = [t for t in self._symbol_table.get_sub_namespaces()
+                      if t.get_name() == name]
+        if len(namespaces) == 1:
+            # if there's only one match for the name, return it
+            return namespaces[0]
+        for namespace in namespaces:
+            # otherwise disambiguate by using the line number
+            if namespace.get_lineno() == lineno:
+                return namespace
+        return None
 
     def visit(self, node):
         # type: (Any) -> None


### PR DESCRIPTION
This implements more closely the handle_comprehension logic present in the CPython [source code](https://github.com/python/cpython/blob/20cbc1d29facead32c2da06c81a09af0e057015c/Python/symtable.c#L1496-L1531)

This allows us to handle dictionary comprehensions as well as explore the generators.

Also present is a change to how we handle ambiguous child scope. Previously on Python 2, if two comprehensions of the same type (excluding List) were present in the same scope we would fail to disambiguate them by line number as Python 2 always passes 0 for these as can be seen [here](https://github.com/python/cpython/blob/20cbc1d29facead32c2da06c81a09af0e057015c/Python/symtable.c#L1509). From my research it isn't possible to perform this disambiguation perfectly in Python 2 as the appropriate C bindings are not exposed. Specifically, the AST used to create the symbol table is kept in an arena within the C code and those objects are never exposed to Python. Because of this we cannot use the `get_id` method on the child symbol table to match the `id(ast_node)` as the AST nodes no longer exist. [This](https://github.com/python/cpython/blob/dae0276bb6bc7281d59fb0b8f1aab31634ee80dc/Python/pythonrun.c#L1074-L1095) function in the CPython source is what takes our source code string and produces the symbol table.

This means we will fail to understand references to variables that are introduced in the comprehension's child scope (via a KeyError exception), however this is not really a big issue as the analyzer currently cannot infer the type of variables introduced in the comprehension scope as that would require understanding what type is coming out of the iterator present in the generator.