### PR TITLE
Scale the lambda_timeout parameter correctly.

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -392,10 +392,14 @@ class LocalGateway(object):
 
     def _generate_lambda_context(self):
         # type: () -> LambdaContext
+        if self._config.lambda_timeout is None:
+            timeout = None
+        else:
+            timeout = self._config.lambda_timeout * 1000
         return LambdaContext(
             function_name=self._config.function_name,
             memory_size=self._config.lambda_memory_size,
-            max_runtime_ms=self._config.lambda_timeout
+            max_runtime_ms=timeout
         )
 
     def _generate_lambda_event(self, method, path, headers, body):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -664,7 +664,8 @@ class TestLocalGateway(object):
         assert body['name'] == 'api_handler'
         assert body['memory'] == 256
         assert body['version'] == '$LATEST'
-        assert body['timeout'] <= 10
+        assert body['timeout'] > 10
+        assert body['timeout'] <= 10000
         assert AWS_REQUEST_ID_PATTERN.match(body['request_id'])
 
     def test_can_validate_route_with_variables(self, demo_app_auth):


### PR DESCRIPTION
lambda_timeout in the config is in seconds, but LambdaContext wants the timeout in ms.