### PR TITLE
Add support for custom authorizers with SAM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBA)
 
 * Fix issue deploying some packages in Windows with utf-8 characters
    (`#560 <https://github.com/aws/chalice/pull/560>`__)
+* Add support for custom authorizers with ``chalice package``
+  (`#580 <https://github.com/aws/chalice/pull/580>`__)
 
 
 1.0.3

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1,7 +1,5 @@
 import os
 import copy
-import hashlib
-import re
 
 from typing import Any, Dict  # noqa
 
@@ -12,7 +10,7 @@ from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.deployer import ApplicationPolicyHandler
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
 from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
-from chalice.utils import OSUtils, UI, serialize_to_json
+from chalice.utils import OSUtils, UI, serialize_to_json, to_cfn_resource_name
 from chalice.config import Config  # noqa
 from chalice.app import Chalice  # noqa
 from chalice.policy import AppPolicyGenerator
@@ -91,31 +89,39 @@ class SAMTemplateGenerator(object):
 
     def generate_sam_template(self, config, code_uri='<placeholder>'):
         # type: (Config, str) -> Dict[str, Any]
-        self._check_for_unsupported_features(config)
         template = copy.deepcopy(self._BASE_TEMPLATE)
         resources = {
-            'APIHandler': self._generate_serverless_function(config, code_uri),
+            'APIHandler': self._generate_serverless_function(
+                config, code_uri, 'app.app', 'api'),
             'RestAPI': self._generate_rest_api(
                 config.chalice_app, config.api_gateway_stage),
         }
+        self._add_auth_handlers(resources, config, code_uri)
         template['Resources'] = resources
         self._update_endpoint_url_output(template, config)
         return template
 
-    def _check_for_unsupported_features(self, config):
-        # type: (Config) -> None
-        if config.chalice_app.builtin_auth_handlers:
-            # It doesn't look like SAM templates support everything
-            # we need to fully support built in authorizers.
-            # See: awslabs/serverless-application-model#49
-            # and: https://forums.aws.amazon.com/thread.jspa?messageID=787920
-            #
-            # We might need to switch to low level cfn to fix this.
-            raise UnsupportedFeatureError(
-                "SAM templates do not currently support these "
-                "built-in auth handlers: %s" % ', '.join(
-                    [c.name for c in
-                     config.chalice_app.builtin_auth_handlers]))
+    def _add_auth_handlers(self, resources, config, code_uri):
+        # type: (Dict[str, Any], Config, str) -> None
+        for auth_config in config.chalice_app.builtin_auth_handlers:
+            auth_resource_name = to_cfn_resource_name(auth_config.name)
+            new_config = config.scope(chalice_stage=config.chalice_stage,
+                                      function_name=auth_config.name)
+            resources[auth_resource_name] = self._generate_serverless_function(
+                new_config, code_uri, auth_config.handler_string, 'authorizer')
+            resources[auth_resource_name + 'InvokePermission'] = \
+                self._generate_lambda_permission(auth_resource_name)
+
+    def _generate_lambda_permission(self, lambda_ref):
+        # type: (str) -> Dict[str, Any]
+        return {
+            'Type': 'AWS::Lambda::Permission',
+            'Properties': {
+                'FunctionName': {'Fn::GetAtt': [lambda_ref, 'Arn']},
+                'Action': 'lambda:InvokeFunction',
+                'Principal': 'apigateway.amazonaws.com'
+            }
+        }
 
     def _update_endpoint_url_output(self, template, config):
         # type: (Dict[str, Any], Config) -> None
@@ -123,13 +129,15 @@ class SAMTemplateGenerator(object):
         template['Outputs']['EndpointURL']['Value']['Fn::Sub'] = (
             url % config.api_gateway_stage)
 
-    def _generate_serverless_function(self, config, code_uri):
-        # type: (Config, str) -> Dict[str, Any]
+    def _generate_serverless_function(self, config, code_uri, handler_string,
+                                      function_type):
+        # type: (Config, str, str, str) -> Dict[str, Any]
         properties = {
             'Runtime': config.lambda_python_version,
-            'Handler': 'app.app',
+            'Handler': handler_string,
             'CodeUri': code_uri,
-            'Events': self._generate_function_events(config.chalice_app),
+            'Events': self._generate_function_events(
+                config.chalice_app, function_type),
             'Tags': config.tags,
             'Timeout': DEFAULT_LAMBDA_TIMEOUT,
             'MemorySize': DEFAULT_LAMBDA_MEMORY_SIZE
@@ -151,17 +159,18 @@ class SAMTemplateGenerator(object):
             'Properties': properties,
         }
 
-    def _generate_function_events(self, app):
+    def _generate_function_events(self, app, function_type):
+        # type: (Chalice, str) -> Dict[str, Any]
+        return getattr(
+            self, '_generate_' + function_type + '_function_events')(app)
+
+    def _generate_api_function_events(self, app):
         # type: (Chalice) -> Dict[str, Any]
         events = {}
         for methods in app.routes.values():
             for http_method, view in methods.items():
-                mod_view_name = re.sub(r'[^A-Za-z0-9]+', '', view.view_name)
-                key_name = ''.join([
-                    mod_view_name, http_method.lower(),
-                    hashlib.md5(
-                        view.view_name.encode('utf-8')).hexdigest()[:4],
-                ])
+                key_name = to_cfn_resource_name(
+                    view.view_name + http_method.lower())
                 events[key_name] = {
                     'Type': 'Api',
                     'Properties': {
@@ -171,6 +180,10 @@ class SAMTemplateGenerator(object):
                     }
                 }
         return events
+
+    def _generate_authorizer_function_events(self, app):
+        # type: (Chalice) -> Dict[str, Any]
+        return {}
 
     def _generate_rest_api(self, app, api_gateway_stage):
         # type: (Chalice, str) -> Dict[str, Any]

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -69,7 +69,7 @@ class SAMTemplateGenerator(object):
     }  # type: Dict[str, Any]
 
     def __init__(self, swagger_generator, policy_generator):
-        # type: (SwaggerGenerator, PreconfiguredPolicyGenerator) -> None
+        # type: (SwaggerGenerator, ApplicationPolicyHandler) -> None
         self._swagger_generator = swagger_generator
         self._policy_generator = policy_generator
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -3,7 +3,9 @@ import os
 import zipfile
 import json
 import contextlib
+import hashlib
 import tempfile
+import re
 import shutil
 import sys
 import tarfile
@@ -18,6 +20,19 @@ from chalice.constants import WELCOME_PROMPT
 
 class AbortedError(Exception):
     pass
+
+
+def to_cfn_resource_name(name):
+    # type: (str) -> str
+    """Transform a name to a valid cfn name.
+
+    This transform ensures that only alphanumeric characters are used
+    and prevent collisions by appending the hash of the original name.
+    """
+    alphanumeric_only_name = re.sub(r'[^A-Za-z0-9]+', '', name)
+    return ''.join([
+        alphanumeric_only_name, hashlib.md5(
+            name.encode('utf-8')).hexdigest()[:4]])
 
 
 def remove_stage_from_deployed_values(key, filename):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -15,7 +15,7 @@ def mock_swagger_generator():
 
 @pytest.fixture
 def mock_policy_generator():
-    return mock.Mock(spec=package.PreconfiguredPolicyGenerator)
+    return mock.Mock(ApplicationPolicyHandler)
 
 
 def test_can_create_app_packager():
@@ -36,12 +36,9 @@ def test_can_create_app_packager_with_no_autogen():
 def test_preconfigured_policy_proxies():
     policy_gen = mock.Mock(spec=ApplicationPolicyHandler)
     config = Config.create(project_dir='project_dir', autogen_policy=False)
-    generator = package.PreconfiguredPolicyGenerator(
-        config, policy_gen=policy_gen)
     policy_gen.generate_policy_from_app_source.return_value = {
         'policy': True}
-    policy = generator.generate_policy_from_app_source()
-    policy_gen.generate_policy_from_app_source.assert_called_with(config)
+    policy = policy_gen.generate_policy_from_app_source(config)
     assert policy == {'policy': True}
 
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -260,21 +260,6 @@ def test_role_arn_added_to_function(sample_app,
     assert 'Policies' not in properties
 
 
-def test_fails_with_custom_auth(sample_app_with_auth,
-                                mock_swagger_generator,
-                                mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app_with_auth, api_gateway_stage='dev',
-        app_name='myapp', manage_iam_role=False, iam_role_arn='role-arn')
-    with pytest.raises(package.UnsupportedFeatureError):
-        p.generate_sam_template(config)
-
-
 def test_app_incompatible_with_cf(sample_app,
                                   mock_swagger_generator,
                                   mock_policy_generator):
@@ -294,4 +279,99 @@ def test_app_incompatible_with_cf(sample_app,
     template = p.generate_sam_template(config)
     events = template['Resources']['APIHandler']['Properties']['Events']
     # The underscore should be removed from the event name.
-    assert 'fooinvalidget2cda' in events
+    assert 'fooinvalidget4cee' in events
+
+
+def test_app_with_auth(sample_app,
+                       mock_swagger_generator,
+                       mock_policy_generator):
+
+    @sample_app.authorizer('myauth')
+    def myauth(auth_request):
+        pass
+
+    @sample_app.route('/authorized', authorizer=myauth)
+    def foo():
+        return {}
+    # The last four digits come from the hash of the auth name
+    cfn_auth_name = 'myauthdb6d'
+
+    p = package.SAMTemplateGenerator(
+        mock_swagger_generator, mock_policy_generator)
+    mock_swagger_generator.generate_swagger.return_value = {
+        'swagger': 'document'
+    }
+    config = Config.create(
+        chalice_app=sample_app,
+        api_gateway_stage='dev',
+    )
+    template = p.generate_sam_template(config)
+    assert cfn_auth_name in template['Resources']
+    auth_function = template['Resources'][cfn_auth_name]
+    assert auth_function['Type'] == 'AWS::Serverless::Function'
+    assert auth_function['Properties']['Handler'] == 'app.myauth'
+
+    # Assert that the invoke permsissions were added as well.
+    assert cfn_auth_name + 'InvokePermission' in template['Resources']
+    assert template['Resources'][cfn_auth_name + 'InvokePermission'] == {
+        'Type': 'AWS::Lambda::Permission',
+        'Properties': {
+            'Action': 'lambda:InvokeFunction',
+            'FunctionName': {
+                'Fn::GetAtt': [
+                    cfn_auth_name,
+                    'Arn'
+                ]
+            },
+            'Principal': 'apigateway.amazonaws.com'
+        }
+    }
+
+
+def test_app_with_auth_but_invalid_cfn_name(sample_app,
+                                            mock_swagger_generator,
+                                            mock_policy_generator):
+
+    # Underscores are not allowed for CFN resource names
+    # This instead should be referred to as customauth in CFN templates
+    # where the underscore is removed.
+    @sample_app.authorizer('custom_auth')
+    def custom_auth(auth_request):
+        pass
+
+    @sample_app.route('/authorized', authorizer=custom_auth)
+    def foo():
+        return {}
+
+    # The last four digits come from the hash of the auth name
+    cfn_auth_name = 'customauth8767'
+    p = package.SAMTemplateGenerator(
+        mock_swagger_generator, mock_policy_generator)
+    mock_swagger_generator.generate_swagger.return_value = {
+        'swagger': 'document'
+    }
+    config = Config.create(
+        chalice_app=sample_app,
+        api_gateway_stage='dev',
+    )
+    template = p.generate_sam_template(config)
+    assert cfn_auth_name in template['Resources']
+    auth_function = template['Resources'][cfn_auth_name]
+    assert auth_function['Type'] == 'AWS::Serverless::Function'
+    assert auth_function['Properties']['Handler'] == 'app.custom_auth'
+
+    # Assert that the invoke permsissions were added as well.
+    assert cfn_auth_name + 'InvokePermission' in template['Resources']
+    assert template['Resources'][cfn_auth_name + 'InvokePermission'] == {
+        'Type': 'AWS::Lambda::Permission',
+        'Properties': {
+            'Action': 'lambda:InvokeFunction',
+            'FunctionName': {
+                'Fn::GetAtt': [
+                    cfn_auth_name,
+                    'Arn'
+                ]
+            },
+            'Principal': 'apigateway.amazonaws.com'
+        }
+    }


### PR DESCRIPTION
This now works for the `chalice package` command and scopes configuration and policies to the specifically configured lambda functions.