### PR TITLE
Adding RequestTimeoutError

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -82,6 +82,10 @@ class MethodNotAllowedError(ChaliceViewError):
     STATUS_CODE = 405
 
 
+class RequestTimeoutError(ChaliceViewError):
+    STATUS_CODE = 408
+
+
 class ConflictError(ChaliceViewError):
     STATUS_CODE = 409
 
@@ -96,6 +100,7 @@ ALL_ERRORS = [
     NotFoundError,
     UnauthorizedError,
     ForbiddenError,
+    RequestTimeoutError,
     ConflictError,
     TooManyRequestsError]
 


### PR DESCRIPTION
Very minor addition - HTTP 408 Error as `RequestTimeoutError`.

The reason behind this PR is that sometimes we are using Chalice to proxy some 3rd party APIs and sometimes we are returning the 3rd party API response through the API Gateway. Currently we have to add `RequestTimeoutError` to our own code in `app.py`, but it would be nice to have it as builtin class.