### PR TITLE
Recategorize several packager unit tests as functional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,33 +6,6 @@ from botocore.stub import Stubber
 from pytest import fixture
 
 
-FakePipCall = namedtuple('FakePipEntry', ['args', 'env_vars', 'shim'])
-
-
-class FakeSdistBuilder(object):
-    _SETUP_PY = (
-        'from setuptools import setup\n'
-        'setup(\n'
-        '    name="%s",\n'
-        '    version="%s"\n'
-        ')\n'
-    )
-
-    def write_fake_sdist(self, directory, name, version):
-        filename = '%s-%s.zip' % (name, version)
-        path = '%s/%s' % (directory, filename)
-        with zipfile.ZipFile(path, 'w',
-                             compression=zipfile.ZIP_DEFLATED) as z:
-            z.writestr('sdist/setup.py', self._SETUP_PY % (name, version))
-        return directory, filename
-
-
-@fixture
-def sdist_builder():
-    s = FakeSdistBuilder()
-    return s
-
-
 def pytest_addoption(parser):
     parser.addoption('--skip-slow', action='store_true',
                      help='Skip slow tests')

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -1,9 +1,12 @@
 import os
 import zipfile
-import mock
+import tarfile
+import io
 from collections import defaultdict
 
 import pytest
+import mock
+
 from chalice.config import Config
 from chalice import Chalice
 from chalice import package
@@ -11,6 +14,9 @@ from chalice.deploy.packager import PipRunner
 from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.packager import Package
 from chalice.deploy.packager import MissingDependencyError
+from chalice.deploy.packager import SubprocessPip
+from chalice.deploy.packager import SDistMetadataFetcher
+from chalice.deploy.packager import InvalidSourceDistributionNameError
 from chalice.compat import lambda_abi
 from chalice.compat import pip_no_compile_c_env_vars
 from chalice.compat import pip_no_compile_c_shim
@@ -34,6 +40,11 @@ def sample_app():
         return {"hello": "world"}
 
     return app
+
+
+@pytest.fixture
+def sdist_reader():
+    return SDistMetadataFetcher()
 
 
 class PathArgumentEndingWith(object):
@@ -718,3 +729,159 @@ def test_will_create_outdir_if_needed(tmpdir):
     contents = os.listdir(str(outdir))
     assert 'deployment.zip' in contents
     assert 'sam.json' in contents
+
+
+class TestSubprocessPip(object):
+    def test_can_invoke_pip(self):
+        pip = SubprocessPip()
+        rc, err = pip.main(['--version'])
+        # Simple assertion that we can execute pip and it gives us some output
+        # and nothing on stderr.
+        assert rc == 0
+        assert err == b''
+
+    def test_does_error_code_propagate(self):
+        pip = SubprocessPip()
+        rc, err = pip.main(['badcommand'])
+        assert rc != 0
+        # Don't want to depend on a particular error message from pip since it
+        # may change if we pin a differnet version to Chalice at some point.
+        # But there should be a non-empty error message of some kind.
+        assert err != b''
+
+
+class TestSdistMetadataFetcher(object):
+    _SETUPTOOLS = 'from setuptools import setup'
+    _DISTUTILS = 'from distutils.core import setup'
+    _BOTH = (
+        'try:\n'
+        '    from setuptools import setup\n'
+        'except ImportError:\n'
+        '    from distutils.core import setuptools\n'
+    )
+
+    _SETUP_PY = (
+        '%s\n'
+        'setup(\n'
+        '    name="%s",\n'
+        '    version="%s"\n'
+        ')\n'
+    )
+
+    def _write_fake_sdist(self, setup_py, directory, ext):
+        filename = 'sdist.%s' % ext
+        path = '%s/%s' % (directory, filename)
+        if ext == 'zip':
+            with zipfile.ZipFile(path, 'w',
+                                 compression=zipfile.ZIP_DEFLATED) as z:
+                z.writestr('sdist/setup.py', setup_py)
+        else:
+            with tarfile.open(path, 'w:gz') as tar:
+                tarinfo = tarfile.TarInfo('sdist/setup.py')
+                tarinfo.size = len(setup_py)
+                tar.addfile(tarinfo, io.BytesIO(setup_py.encode()))
+        filepath = os.path.join(directory, filename)
+        return filepath
+
+    def test_setup_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_setup_tar_gz_hyphens_in_name(self, osutils, sdist_reader):
+        # The whole reason we need to use the egg info to get the name and
+        # version is that we cannot deterministically parse that information
+        # from the filenames themselves. This test puts hyphens in the name
+        # and version which would break a simple ``split("-")`` attempt to get
+        # that information.
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo-bar', '1.0-2b'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo-bar'
+        assert version == '1.0-2b'
+
+    def test_setup_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_distutil_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._DISTUTILS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_distutil_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._DISTUTILS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_both_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo-bar', '1.0-2b'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo-bar'
+        assert version == '1.0-2b'
+
+    def test_both_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                filepath)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_bad_format(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz2')
+            with pytest.raises(InvalidSourceDistributionNameError):
+                name, version = sdist_reader.get_package_name_and_version(
+                    filepath)
+
+
+class TestPackage(object):
+
+    def test_same_pkg_sdist_and_wheel_collide(self, osutils, sdist_builder):
+        with osutils.tempdir() as tempdir:
+            sdist_builder.write_fake_sdist(tempdir, 'foobar', '1.0')
+            pkgs = set()
+            pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
+            pkgs.add(Package(tempdir, 'foobar-1.0.zip'))
+            assert len(pkgs) == 1

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+from collections import namedtuple
 
 from chalice.utils import OSUtils
 from chalice.compat import pip_no_compile_c_env_vars
@@ -9,7 +10,9 @@ from chalice.deploy.packager import PipRunner
 from chalice.deploy.packager import InvalidSourceDistributionNameError
 from chalice.deploy.packager import NoSuchPackageError
 from chalice.deploy.packager import PackageDownloadError
-from tests.conftest import FakePipCall
+
+
+FakePipCall = namedtuple('FakePipEntry', ['args', 'env_vars', 'shim'])
 
 
 class FakePip(object):

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -1,18 +1,12 @@
 import sys
-import os
 import pytest
-import zipfile
-import tarfile
-import io
 
 from chalice.utils import OSUtils
 from chalice.compat import pip_no_compile_c_env_vars
 from chalice.compat import pip_no_compile_c_shim
 from chalice.deploy.packager import Package
 from chalice.deploy.packager import PipRunner
-from chalice.deploy.packager import SDistMetadataFetcher
 from chalice.deploy.packager import InvalidSourceDistributionNameError
-from chalice.deploy.packager import SubprocessPip
 from chalice.deploy.packager import NoSuchPackageError
 from chalice.deploy.packager import PackageDownloadError
 from tests.conftest import FakePipCall
@@ -60,11 +54,6 @@ def osutils():
     return OSUtils()
 
 
-@pytest.fixture
-def sdist_reader():
-    return SDistMetadataFetcher()
-
-
 class TestPackage(object):
     def test_can_create_package_with_custom_osutils(self, osutils):
         pkg = Package('', 'foobar-1.0-py3-none-any.whl', osutils)
@@ -81,14 +70,6 @@ class TestPackage(object):
     def test_invalid_package(self):
         with pytest.raises(InvalidSourceDistributionNameError):
             Package('', 'foobar.jpg')
-
-    def test_same_pkg_sdist_and_wheel_collide(self, osutils, sdist_builder):
-        with osutils.tempdir() as tempdir:
-            sdist_builder.write_fake_sdist(tempdir, 'foobar', '1.0')
-            pkgs = set()
-            pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
-            pkgs.add(Package(tempdir, 'foobar-1.0.zip'))
-            assert len(pkgs) == 1
 
     def test_diff_pkg_sdist_and_whl_do_not_collide(self):
         pkgs = set()
@@ -125,25 +106,6 @@ class TestPackage(object):
     def test_can_read_packages_with_period_in_name(self):
         pkg = Package('', 'foo.bar-2.0-py3-none-any.whl')
         assert pkg.identifier == 'foo-bar==2.0'
-
-
-class TestSubprocessPip(object):
-    def test_can_invoke_pip(self):
-        pip = SubprocessPip()
-        rc, err = pip.main(['--version'])
-        # Simple assertion that we can execute pip and it gives us some output
-        # and nothing on stderr.
-        assert rc == 0
-        assert err == b''
-
-    def test_does_error_code_propagate(self):
-        pip = SubprocessPip()
-        rc, err = pip.main(['badcommand'])
-        assert rc != 0
-        # Don't want to depend on a particular error message from pip since it
-        # may change if we pin a differnet version to Chalice at some point.
-        # But there should be a non-empty error message of some kind.
-        assert err != b''
 
 
 class TestPipRunner(object):
@@ -248,129 +210,3 @@ class TestPipRunner(object):
         with pytest.raises(PackageDownloadError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
         assert str(einfo.value) == 'Unknown error'
-
-
-class TestSdistMetadataFetcher(object):
-    _SETUPTOOLS = 'from setuptools import setup'
-    _DISTUTILS = 'from distutils.core import setup'
-    _BOTH = (
-        'try:\n'
-        '    from setuptools import setup\n'
-        'except ImportError:\n'
-        '    from distutils.core import setuptools\n'
-    )
-
-    _SETUP_PY = (
-        '%s\n'
-        'setup(\n'
-        '    name="%s",\n'
-        '    version="%s"\n'
-        ')\n'
-    )
-
-    def _write_fake_sdist(self, setup_py, directory, ext):
-        filename = 'sdist.%s' % ext
-        path = '%s/%s' % (directory, filename)
-        if ext == 'zip':
-            with zipfile.ZipFile(path, 'w',
-                                 compression=zipfile.ZIP_DEFLATED) as z:
-                z.writestr('sdist/setup.py', setup_py)
-        else:
-            with tarfile.open(path, 'w:gz') as tar:
-                tarinfo = tarfile.TarInfo('sdist/setup.py')
-                tarinfo.size = len(setup_py)
-                tar.addfile(tarinfo, io.BytesIO(setup_py.encode()))
-        filepath = os.path.join(directory, filename)
-        return filepath
-
-    def test_setup_tar_gz(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._SETUPTOOLS, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo'
-        assert version == '1.0'
-
-    def test_setup_tar_gz_hyphens_in_name(self, osutils, sdist_reader):
-        # The whole reason we need to use the egg info to get the name and
-        # version is that we cannot deterministically parse that information
-        # from the filenames themselves. This test puts hyphens in the name
-        # and version which would break a simple ``split("-")`` attempt to get
-        # that information.
-        setup_py = self._SETUP_PY % (
-            self._SETUPTOOLS, 'foo-bar', '1.0-2b'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo-bar'
-        assert version == '1.0-2b'
-
-    def test_setup_zip(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._SETUPTOOLS, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo'
-        assert version == '1.0'
-
-    def test_distutil_tar_gz(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._DISTUTILS, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo'
-        assert version == '1.0'
-
-    def test_distutil_zip(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._DISTUTILS, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo'
-        assert version == '1.0'
-
-    def test_both_tar_gz(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._BOTH, 'foo-bar', '1.0-2b'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo-bar'
-        assert version == '1.0-2b'
-
-    def test_both_zip(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._BOTH, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
-            name, version = sdist_reader.get_package_name_and_version(
-                filepath)
-        assert name == 'foo'
-        assert version == '1.0'
-
-    def test_bad_format(self, osutils, sdist_reader):
-        setup_py = self._SETUP_PY % (
-            self._BOTH, 'foo', '1.0'
-        )
-        with osutils.tempdir() as tempdir:
-            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz2')
-            with pytest.raises(InvalidSourceDistributionNameError):
-                name, version = sdist_reader.get_package_name_and_version(
-                    filepath)


### PR DESCRIPTION
commit 7b1dab6a6a600be14f31d70905c1e7f9e9ec023f

Recategorize several packager unit tests as functional

There were packager tests in the unit/ test
directory that really were functional tests because they:

* Touched the filesystem
* Executed subprocesses

This was becomming a hindrance to quick feedback cycles
when running the unit test suite, and notable the unit/deploy/
suite.

Before:

```
$ time py.test tests/unit/
...
434 passed, 1 skipped in 6.70 seconds

$ time py.test tests/unit/deploy/
122 passed in 3.69 seconds
```

After:

```
$ time py.test tests/unit
423 passed, 1 skipped in 2.93 seconds

$ time py.test tests/unit/deploy/
111 passed in 0.46 seconds
```


commit 7dc146fcd039f9bf3ad624acfcdb839cebbd1f7e

Don't import from conftest

Looks like this might have been missed in the original PR.
It's unusual to import explicitly from conftest modules.

Additionally, now that the package tests have moved into the
functional/ tests, the only shared bits of code was the
FakePipCall, which I've just defined in both modules.
Seems like a reasonable compromise to me, it's a one line
namedtuple definition.
