### PR TITLE
Fix Local Query Params Issue

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -167,7 +167,8 @@ class LambdaEventConverter(object):
                 },
             },
             'headers': {k.lower(): v for k, v in headers.items()},
-            'queryStringParameters': view_route.query_params,
+            'queryStringParameters': view_route.query_params if
+            view_route.query_params else None,
             'pathParameters': view_route.captured,
             'stageVariables': {},
         }

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -534,7 +534,7 @@ def test_can_create_lambda_event():
         },
         'headers': {'content-type': 'application/json'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': {},
+        'queryStringParameters': None,
         'body': None,
         'stageVariables': {},
     }
@@ -559,7 +559,7 @@ def test_can_create_lambda_event_for_put_request():
         },
         'headers': {'content-type': 'application/json'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': {},
+        'queryStringParameters': None,
         'body': '{"foo": "bar"}',
         'stageVariables': {},
     }
@@ -585,7 +585,7 @@ def test_can_create_lambda_event_for_post_with_formencoded_body():
         },
         'headers': {'content-type': 'application/x-www-form-urlencoded'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': {},
+        'queryStringParameters': None,
         'body': form_body,
         'stageVariables': {},
     }


### PR DESCRIPTION
When running an application locally the `current_request.query_params` defaults to `{}` if there are no query params. This can be very misleading when running locally because when the lambda is deployed `current_request.query_params` defaults to `None`.

Closes [#593](https://github.com/aws/chalice/issues/593)