### PR TITLE
Add support for deleting unreferenced resources

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -163,7 +163,7 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
     session = factory.create_botocore_session()
     d = factory.create_new_default_deployer(session=session)
     deployed_values = d.deploy(config, chalice_stage_name=stage)
-    if deployed_values.get('resources'):
+    if deployed_values['stages'][stage].get('resources'):
         record_deployed_values(deployed_values, os.path.join(
             config.project_dir, '.chalice', 'deployed.json'))
 
@@ -199,7 +199,7 @@ def logs(ctx, num_entries, include_lambda_messages, stage, profile):
     factory = ctx.obj['factory']  # type: CLIFactory
     factory.profile = profile
     config = factory.create_config_obj(stage, False)
-    deployed = config.deployed_resources(stage)
+    deployed = config.old_deployed_resources(stage)
     if deployed is not None:
         session = factory.create_botocore_session()
         retriever = factory.create_log_retriever(
@@ -247,7 +247,7 @@ def url(ctx, stage):
     # type: (click.Context, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj(stage)
-    deployed = config.deployed_resources(stage)
+    deployed = config.old_deployed_resources(stage)
     if deployed is not None:
         click.echo(
             "https://{api_id}.execute-api.{region}.amazonaws.com/{stage}/"
@@ -275,7 +275,7 @@ def generate_sdk(ctx, sdk_type, stage, outdir):
     config = factory.create_config_obj(stage)
     session = factory.create_botocore_session()
     client = TypedAWSClient(session)
-    deployed = config.deployed_resources(stage)
+    deployed = config.old_deployed_resources(stage)
     if deployed is None:
         click.echo("Could not find API ID, has this application "
                    "been deployed?", err=True)

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -336,7 +336,7 @@ class Deployer(object):
 
     def delete(self, config, chalice_stage_name=DEFAULT_STAGE_NAME):
         # type: (Config, str) -> None
-        existing_resources = config.deployed_resources(chalice_stage_name)
+        existing_resources = config.old_deployed_resources(chalice_stage_name)
         if existing_resources is None:
             self._ui.write('No existing resources found for stage %s.\n' %
                            chalice_stage_name)
@@ -369,7 +369,7 @@ class Deployer(object):
         # type: (Config, str) -> Dict[str, Any]
         LOGGER.debug("Validating chalice configuration.")
         validate_configuration(config)
-        existing_resources = config.deployed_resources(chalice_stage_name)
+        existing_resources = config.old_deployed_resources(chalice_stage_name)
         LOGGER.debug("Existing deployed resources: %s", existing_resources)
         LOGGER.debug("Deploying Lambda resources.")
         deployed_values = self._lambda_deploy.deploy(

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -24,11 +24,26 @@ class StoreValue(Instruction):
 
 
 @attrs(frozen=True)
+class RecordResource(Instruction):
+    resource_type = attrib()
+    resource_name = attrib()
+    name = attrib()
+
+
+@attrs(frozen=True)
+class RecordResourceVariable(Instruction):
+    resource_type = attrib()
+    resource_name = attrib()
+    name = attrib()
+    variable_name = attrib()
+
+
+@attrs(frozen=True)
 class RecordResourceValue(Instruction):
     resource_type = attrib()
     resource_name = attrib()
     name = attrib()
-    variable_name = attrib(default=None)
+    value = attrib()
 
 
 @attrs(frozen=True)

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -7,12 +7,43 @@ class Placeholder(enum.Enum):
     DEPLOY_STAGE = 'deploy_stage'
 
 
+class Instruction(object):
+    pass
+
+
 @attrs(frozen=True)
-class APICall(object):
+class APICall(Instruction):
     method_name = attrib()
     params = attrib()
-    target_variable = attrib(default=None)
     resource = attrib(default=None)
+
+
+@attrs(frozen=True)
+class StoreValue(Instruction):
+    name = attrib()
+
+
+@attrs(frozen=True)
+class RecordResourceValue(Instruction):
+    resource_type = attrib()
+    resource_name = attrib()
+    name = attrib()
+    variable_name = attrib(default=None)
+
+
+@attrs(frozen=True)
+class Push(Instruction):
+    value = attrib()
+
+
+@attrs(frozen=True)
+class Pop(Instruction):
+    pass
+
+
+@attrs(frozen=True)
+class JPSearch(Instruction):
+    expression = attrib()
 
 
 class Model(object):

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -32,7 +32,21 @@ class StoreValue(Instruction):
         # type: (...) -> None
         ...
 
-class RecordResourceValue(Instruction):
+class RecordResource(Instruction):
+    resource_type = ...  # type: str
+    resource_name = ...  # type: str
+    name = ...  # type: str
+
+    def __init__(self,
+                 resource_type,       # type: str
+                 resource_name,       # type: str
+                 name,                # type: str
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class RecordResourceVariable(Instruction):
     resource_type = ...  # type: str
     resource_name = ...  # type: str
     name = ...  # type: str
@@ -42,7 +56,23 @@ class RecordResourceValue(Instruction):
                  resource_type,       # type: str
                  resource_name,       # type: str
                  name,                # type: str
-                 variable_name=None,  # type: Any
+                 variable_name,       # type: Any
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class RecordResourceValue(Instruction):
+    resource_type = ...  # type: str
+    resource_name = ...  # type: str
+    name = ...  # type: str
+    value = ...  # type: Any
+
+    def __init__(self,
+                 resource_type,       # type: str
+                 resource_name,       # type: str
+                 name,                # type: str
+                 value,               # type: Any
                  ):
         # type: (...) -> None
         ...

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -6,20 +6,62 @@ class Placeholder(enum.Enum):
     DEPLOY_STAGE = 'deploy_stage'
 
 
-class APICall:
+class Instruction:
+    pass
+
+
+class APICall(Instruction):
     method_name = ...  # type: str
     params = ...  # type: Dict[str, Any]
-    target_variable = ...  # type: Optional[str]
     resource = ...  # type: Optional[ManagedModel]
 
     def __init__(self,
                  method_name,           # type: str
                  params,                # type: Dict[str, Any]
-                 target_variable=None,  # type: Optional[str]
                  resource=None,         # type: Optional[ManagedModel]
                  ):
         # type: (...) -> None
         ...
+
+class StoreValue(Instruction):
+    name = ...  # type: str
+
+    def __init__(self,
+                 name,  # type: str
+                 ):
+        # type: (...) -> None
+        ...
+
+class RecordResourceValue(Instruction):
+    resource_type = ...  # type: str
+    resource_name = ...  # type: str
+    name = ...  # type: str
+    variable_name = ...  # type: Any
+
+    def __init__(self,
+                 resource_type,       # type: str
+                 resource_name,       # type: str
+                 name,                # type: str
+                 variable_name=None,  # type: Any
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class Push(Instruction):
+    value = ...  # type: Any
+
+    def __init__(self, value: Any) -> None: ...
+
+
+class Pop(Instruction):
+    pass
+
+
+class JPSearch(Instruction):
+    expression = ...  # type: str
+
+    def __init__(self, expression: str) -> None: ...
 
 
 T = TypeVar('T')

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -94,7 +94,8 @@ from chalice import app  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
 from chalice.deploy.packager import PipRunner, SubprocessPip
 from chalice.deploy.packager import DependencyBuilder as PipDependencyBuilder
-from chalice.deploy.planner import PlanStage, Variable, RemoteState, Sweeper
+from chalice.deploy.planner import PlanStage, Variable, RemoteState
+from chalice.deploy.planner import UnreferencedResourcePlanner
 from chalice.policy import AppPolicyGenerator
 from chalice.constants import LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
@@ -135,7 +136,7 @@ def create_default_deployer(session):
         plan_stage=PlanStage(
             osutils=osutils, remote_state=RemoteState(client),
         ),
-        sweeper=Sweeper(),
+        sweeper=UnreferencedResourcePlanner(),
         executor=Executor(client),
     )
 
@@ -161,7 +162,7 @@ class Deployer(object):
                  deps_builder,         # type: DependencyBuilder
                  build_stage,          # type: BuildStage
                  plan_stage,           # type: PlanStage
-                 sweeper,              # type: Sweeper
+                 sweeper,              # type: UnreferencedResourcePlanner
                  executor,             # type: Executor
                  ):
         # type: (...) -> None

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -407,17 +407,28 @@ class Executor(object):
         # type: (models.StoreValue) -> None
         self.variables[instruction.name] = self.stack[-1]
 
+    def _do_recordresource(self, instruction):
+        # type: (models.RecordResource) -> None
+        d = self.resource_values.setdefault(
+            instruction.resource_name, {})
+        d['resource_type'] = instruction.resource_type
+        value = self.stack[-1]
+        d[instruction.name] = value
+
+    def _do_recordresourcevariable(self, instruction):
+        # type: (models.RecordResourceVariable) -> None
+        d = self.resource_values.setdefault(
+            instruction.resource_name, {})
+        d['resource_type'] = instruction.resource_type
+        value = self.variables[instruction.variable_name]
+        d[instruction.name] = value
+
     def _do_recordresourcevalue(self, instruction):
         # type: (models.RecordResourceValue) -> None
         d = self.resource_values.setdefault(
             instruction.resource_name, {})
         d['resource_type'] = instruction.resource_type
-        variable_name = instruction.variable_name
-        if variable_name is not None:
-            value = self.variables[variable_name]
-        else:
-            value = self.stack[-1]
-        d[instruction.name] = value
+        d[instruction.name] = instruction.value
 
     def _do_push(self, instruction):
         # type: (models.Push) -> None

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -60,7 +60,7 @@ class RemoteState(object):
                            role_arn=role['Arn'])
 
 
-class Sweeper(object):
+class UnreferencedResourcePlanner(object):
 
     def execute(self, plan, config):
         # type: (List[models.Instruction], Config) -> None

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -75,7 +75,7 @@ class UnreferencedResourcePlanner(object):
         # type: (List[models.Instruction]) -> List[str]
         marked = []  # type: List[str]
         for instruction in plan:
-            if isinstance(instruction, models.RecordResourceValue):
+            if isinstance(instruction, models.RecordResource):
                 marked.append(instruction.resource_name)
         return marked
 
@@ -143,7 +143,7 @@ class PlanStage(object):
                     resource=resource,
                 ),
                 models.StoreValue(name=varname),
-                models.RecordResourceValue(
+                models.RecordResourceVariable(
                     resource_type='lambda_function',
                     resource_name=resource.resource_name,
                     name='lambda_arn',
@@ -169,11 +169,9 @@ class PlanStage(object):
                 params=params,
                 resource=resource,
             ),
-            # TODO: Technically wrong, we need to pull out the
-            # FunctionArn key.  JMESPath??
             models.JPSearch('FunctionArn'),
             models.StoreValue(name=varname),
-            models.RecordResourceValue(
+            models.RecordResourceVariable(
                 resource_type='lambda_function',
                 resource_name=resource.resource_name,
                 name='lambda_arn',
@@ -196,7 +194,7 @@ class PlanStage(object):
                     resource=resource
                 ),
                 models.StoreValue(varname),
-                models.RecordResourceValue(
+                models.RecordResourceVariable(
                     resource_type='iam_role',
                     resource_name=resource.resource_name,
                     name='role_arn',
@@ -216,12 +214,11 @@ class PlanStage(object):
                         'policy_document': document},
                 resource=resource
             ),
-            models.Pop(),
-            models.Push(resource.role_arn),
             models.RecordResourceValue(
                 resource_type='iam_role',
                 resource_name=resource.resource_name,
                 name='role_arn',
+                value=resource.role_arn,
             )
         ]
 

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -75,9 +75,8 @@ class Sweeper(object):
         # type: (List[models.Instruction]) -> List[str]
         marked = []  # type: List[str]
         for instruction in plan:
-            if not isinstance(instruction, models.RecordResourceValue):
-                continue
-            marked.append(instruction.resource_name)
+            if isinstance(instruction, models.RecordResourceValue):
+                marked.append(instruction.resource_name)
         return marked
 
     def _plan_deletion(self,

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     'pip>=9,<10',
     'attrs==17.2.0',
     'enum34==1.1.6',
+    'jmespath>=0.9.3,<1.0.0',
 ]
 
 setup(

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -599,7 +599,7 @@ class TestDeployer(object):
             'chalice_version': '0',
             'lambda_functions': {},
         })
-        cfg.deployed_resources.return_value = deployed_resources
+        cfg.old_deployed_resources.return_value = deployed_resources
 
         d = Deployer(apig_deploy, lambda_deploy, ui)
         d.delete(cfg)
@@ -613,7 +613,7 @@ class TestDeployer(object):
         apig_deploy = mock.Mock(spec=APIGatewayDeployer)
         cfg = mock.Mock(spec=Config)
         deployed_resources = None
-        cfg.deployed_resources.return_value = deployed_resources
+        cfg.old_deployed_resources.return_value = deployed_resources
         d = Deployer(apig_deploy, lambda_deploy, ui)
         d.delete(cfg)
 
@@ -1571,7 +1571,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
 
         self.app_policy = app_policy
 
-        self.deployed_resources = DeployedResources(
+        self.old_deployed_resources = DeployedResources(
             'api', 'api_handler_arn', self.lambda_function_name,
             None, 'dev', None, None, {})
 
@@ -1585,7 +1585,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,
@@ -1609,7 +1609,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,
@@ -1633,7 +1633,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,
@@ -1657,7 +1657,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,
@@ -1681,7 +1681,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.aws_client, self.packager, self.ui, self.osutils,
             self.app_policy)
 
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,
@@ -1707,7 +1707,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
             self.app_policy)
 
         self.aws_client.get_role_arn_for_name.return_value = 'role-arn'
-        deployer.deploy(cfg, self.deployed_resources, 'dev')
+        deployer.deploy(cfg, self.old_deployed_resources, 'dev')
         self.aws_client.update_function.assert_called_with(
             function_name=self.lambda_function_name,
             zip_contents=self.package_contents,

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -21,7 +21,8 @@ from chalice.deploy.newdeployer import DependencyBuilder
 from chalice.deploy.newdeployer import ApplicationGraphBuilder
 from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
 from chalice.deploy.newdeployer import PolicyGenerator
-from chalice.deploy.planner import PlanStage, Variable, Sweeper
+from chalice.deploy.planner import PlanStage, Variable
+from chalice.deploy.planner import UnreferencedResourcePlanner
 from chalice.deploy.newdeployer import Executor
 from chalice.deploy.newdeployer import UnresolvedValueError
 from chalice.deploy.models import APICall, StoreValue, RecordResourceValue
@@ -677,7 +678,7 @@ class TestDeployer(unittest.TestCase):
         self.deps_builder = mock.Mock(spec=DependencyBuilder)
         self.build_stage = mock.Mock(spec=BuildStage)
         self.plan_stage = mock.Mock(spec=PlanStage)
-        self.sweeper = mock.Mock(spec=Sweeper)
+        self.sweeper = mock.Mock(spec=UnreferencedResourcePlanner)
         self.executor = mock.Mock(spec=Executor)
 
     def create_deployer(self):

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -26,6 +26,7 @@ from chalice.deploy.planner import UnreferencedResourcePlanner
 from chalice.deploy.newdeployer import Executor
 from chalice.deploy.newdeployer import UnresolvedValueError
 from chalice.deploy.models import APICall, StoreValue, RecordResourceValue
+from chalice.deploy.models import RecordResource, RecordResourceVariable
 from chalice.deploy.models import Push, Pop, JPSearch
 from chalice.policy import AppPolicyGenerator
 from chalice.constants import LAMBDA_TRUST_POLICY
@@ -587,7 +588,7 @@ class TestExecutor(object):
         params = {}
         call = APICall('create_function', params, resource=function)
         self.mock_client.create_function.return_value = 'function:arn'
-        record_instruction = RecordResourceValue(
+        record_instruction = RecordResource(
             resource_type='lambda_function',
             resource_name='myfunction',
             name='myfunction_arn',
@@ -603,7 +604,7 @@ class TestExecutor(object):
         self.executor.execute([
             APICall('create_function', {}),
             StoreValue('myvarname'),
-            RecordResourceValue(
+            RecordResourceVariable(
                 resource_type='lambda_function',
                 resource_name='myfunction',
                 name='myfunction_arn',
@@ -614,6 +615,22 @@ class TestExecutor(object):
             'myfunction': {
                 'resource_type': 'lambda_function',
                 'myfunction_arn': 'function:arn',
+            }
+        }
+
+    def test_can_record_value_directly(self):
+        self.executor.execute([
+            RecordResourceValue(
+                resource_type='lambda_function',
+                resource_name='myfunction',
+                name='myfunction_arn',
+                value='arn:foo',
+            )
+        ])
+        assert self.executor.resource_values == {
+            'myfunction': {
+                'resource_type': 'lambda_function',
+                'myfunction_arn': 'arn:foo',
             }
         }
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -8,7 +8,7 @@ from chalice.deploy import models
 from chalice.config import DeployedResources2
 from chalice.utils import OSUtils
 from chalice.deploy.planner import PlanStage, Variable, RemoteState
-from chalice.deploy.planner import Sweeper
+from chalice.deploy.planner import UnreferencedResourcePlanner
 
 
 def create_function_resource(name, function_name=None,
@@ -352,13 +352,13 @@ class TestRemoteState(object):
         assert self.client.lambda_function_exists.call_count == 1
 
 
-class TestSweeper(object):
+class TestUnreferencedResourcePlanner(object):
     def setup_method(self):
         pass
 
     @pytest.fixture
     def sweeper(self):
-        return Sweeper()
+        return UnreferencedResourcePlanner()
 
     @pytest.fixture
     def function_resource(self):

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -154,6 +154,7 @@ class TestPlanManagedRole(BasePlannerTests):
                 resource=role,
             )
         )
+        assert plan[-1].value == 'myrole:arn'
 
     def test_can_update_file_based_policy(self):
         role = models.ManagedIAMRole(
@@ -367,7 +368,7 @@ class TestUnreferencedResourcePlanner(object):
     def test_noop_when_all_resources_accounted_for(self, sweeper,
                                                    function_resource):
         plan = [
-            models.RecordResourceValue(
+            models.RecordResource(
                 resource_type='lambda_function',
                 resource_name='myfunction',
                 name='foo',
@@ -408,12 +409,12 @@ class TestUnreferencedResourcePlanner(object):
         second = create_function_resource('second')
         third = create_function_resource('third')
         plan = [
-            models.RecordResourceValue(
+            models.RecordResource(
                 resource_type='lambda_function',
                 resource_name=first.resource_name,
                 name='foo',
             ),
-            models.RecordResourceValue(
+            models.RecordResource(
                 resource_type='asdf',
                 resource_name=second.resource_name,
                 name='foo',


### PR DESCRIPTION
As part of this work, general improvements to the executor
and deployer have been added that fixed several issues with
the update process.  You can now add new lambda functions
to your app.py and the deployer will properly record these
values in the deployed.json.

There are a few high level changes included.

* The deployed.json was updated to have a consistent format
  for all resources.  All resources now go under a ``resources``
  key that's specific to a stage.  Each resource must have a
  ``resource_type``.  This allows us to add support for new resource
  types without having to worry about updating the deployed.json
  file.  To handle the old format I've added a ``schema_version`` key.
  I'll still need to add some backwards compatibility code that can
  load the v1 format.  For now you can't mix the v1 and v2 formats.
  This will need to be addressed before merging to master.
* The APICall has been split out into 6 new instructions and the planner
  and executor now take a list of Instructions.  An APICall is now
  a type of Instruction.  This level of granularity was needed to
  properly track which resources we've accounted for locally so we
  can compare them to the set of remote resources.
* One of the new instructions, ``JPSearch``, requires a dependency
  on JMESPath.  This was required in order to properly generate
  the deployed.json file.  The ``create_function`` call returns
  a function arn, but the ``update_function`` returns the entire
  response of ``update_function_code``.  We need to extract out
  the ``FunctionArn`` key from the response.  We'll also need this
  capability in the future.  In practice this isn't a big deal,
  botocore already requires JMESPath, we're just also calling out
  an explicit dependency in our setup.py.