### PR TITLE
 request's binary types can't be change after initializing api-gateway

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -391,6 +391,7 @@ class RouteEntry(object):
 class APIGateway(object):
 
     _DEFAULT_BINARY_TYPES = [
+        'multipart/form-data',
         'application/octet-stream',
         'application/x-tar',
         'application/zip',


### PR DESCRIPTION
Kindly check the change and my opinion.
Actually, I've been figuring out how to change binary type of request.
I know chalice support change binary types.
But it only changes response's binary type for api -gateway. it means request's binary type never change. I've checked it makes a problem.

So, I suggest we add multipart/form-data.
I'm developing kpi server. if we don't add multipar/form-data, lamba can't get a file over 2.5MB with multpart/form-data.
As you know, Many many people use "multipart/form-data".

Futhermore, I suggest we support api for setting default binary types at first time.

Thank you