### PR TITLE
Allow user to override default codebuild image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ Next Release (TBD)
 * Fix local mode handling of routes with trailing slashes
   (`#582 <https://github.com/aws/chalice/issues/582>`__)
 * Scale ``lambda_timeout`` parameter correctly in local mode
-  (`#579 <https://github.com/aws/chalice/pull/579`>__)
+  (`#579 <https://github.com/aws/chalice/pull/579>`__)
+* Add ``--codebuild-image`` to the ``generate-pipeline`` command
+  (`#609 <https://github.com/aws/chalice/issues/609>`__)
 
 
 1.0.4

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -312,8 +312,10 @@ def generate_pipeline(ctx, codebuild_image, filename):
     from chalice import pipeline
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj()
-    p = pipeline.CreatePipelineTemplate(codebuild_image)
-    output = p.create_template(config.app_name, config.lambda_python_version)
+    p = pipeline.CreatePipelineTemplate()
+    output = p.create_template(config.app_name,
+                               config.lambda_python_version,
+                               codebuild_image)
     with open(filename, 'w') as f:
         f.write(serialize_to_json(output))
 

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -286,10 +286,14 @@ def package(ctx, single_file, stage, out):
 
 
 @cli.command('generate-pipeline')
+@click.option('-i', '--codebuild-image',
+              help=("Specify default codebuild image to use.  "
+                    "This option must be provided when using a python "
+                    "version besides 2.7."))
 @click.argument('filename')
 @click.pass_context
-def generate_pipeline(ctx, filename):
-    # type: (click.Context, str) -> None
+def generate_pipeline(ctx, codebuild_image, filename):
+    # type: (click.Context, str, str) -> None
     """Generate a cloudformation template for a starter CD pipeline.
 
     This command will write a starter cloudformation template to
@@ -305,10 +309,11 @@ def generate_pipeline(ctx, filename):
         $ aws cloudformation deploy --stack-name mystack \b
             --template-file pipeline.json --capabilities CAPABILITY_IAM
     """
-    from chalice.pipeline import create_pipeline_template
+    from chalice import pipeline
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj()
-    output = create_pipeline_template(config)
+    p = pipeline.CreatePipelineTemplate(codebuild_image)
+    output = p.create_template(config.app_name, config.lambda_python_version)
     with open(filename, 'w') as f:
         f.write(serialize_to_json(output))
 

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -313,9 +313,12 @@ def generate_pipeline(ctx, codebuild_image, filename):
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj()
     p = pipeline.CreatePipelineTemplate()
-    output = p.create_template(config.app_name,
-                               config.lambda_python_version,
-                               codebuild_image)
+    params = pipeline.PipelineParameters(
+        app_name=config.app_name,
+        lambda_python_version=config.lambda_python_version,
+        codebuild_image=codebuild_image,
+    )
+    output = p.create_template(params)
     with open(filename, 'w') as f:
         f.write(serialize_to_json(output))
 

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -38,27 +38,24 @@ class CreatePipelineTemplate(object):
         "Outputs": {},
     }
 
-    def __init__(self, codebuild_image=None):
-        # type: (Optional[str]) -> None
-        self._codebuild_image = codebuild_image
-
-    def _get_codebuild_image(self, lambda_python_version):
-        # type: (str) -> str
-        if self._codebuild_image is not None:
-            return self._codebuild_image
+    def _get_codebuild_image(self, lambda_python_version, codebuild_image):
+        # type: (str, Optional[str]) -> str
+        if codebuild_image is not None:
+            return codebuild_image
         try:
             image_suffix = self._CODEBUILD_IMAGE[lambda_python_version]
             return 'aws/codebuild/%s' % image_suffix
         except KeyError as e:
             raise InvalidCodeBuildPythonVersion(str(e))
 
-    def create_template(self, app_name, python_lambda_version):
-        # type: (str, str) -> Dict[str, Any]
+    def create_template(self, app_name, python_lambda_version,
+                        codebuild_image=None):
+        # type: (str, str, Optional[str]) -> Dict[str, Any]
         t = copy.deepcopy(self._BASE_TEMPLATE)  # type: Dict[str, Any]
         params = t['Parameters']
         params['ApplicationName']['Default'] = app_name
         params['CodeBuildImage']['Default'] = self._get_codebuild_image(
-            python_lambda_version)
+            python_lambda_version, codebuild_image)
 
         resources = [SourceRepository, CodeBuild, CodePipeline]
         for resource_cls in resources:

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -311,6 +311,23 @@ def test_can_generate_pipeline_for_all(runner):
             assert "Outputs" in template
 
 
+def test_no_errors_if_override_codebuil_image(runner):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        result = _run_cli_command(
+            runner, cli.generate_pipeline,
+            ['-i', 'python:3.6.1', 'pipeline.json'])
+        assert result.exit_code == 0, result.output
+        assert os.path.isfile('pipeline.json')
+        with open('pipeline.json', 'r') as f:
+            template = json.load(f)
+            # The actual contents are tested in the unit
+            # tests.  Just a sanity check that it looks right.
+            image = template['Parameters']['CodeBuildImage']['Default']
+            assert image == 'python:3.6.1'
+
+
 def test_env_vars_set_in_local(runner, mock_cli_factory,
                                monkeypatch):
     local_server = mock.Mock(spec=local.LocalDevServer)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -311,7 +311,7 @@ def test_can_generate_pipeline_for_all(runner):
             assert "Outputs" in template
 
 
-def test_no_errors_if_override_codebuil_image(runner):
+def test_no_errors_if_override_codebuild_image(runner):
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')
         os.chdir('testproject')

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 
 from chalice import pipeline
-from chalice.pipeline import InvalidCodeBuildPythonVersion
+from chalice.pipeline import InvalidCodeBuildPythonVersion, PipelineParameters
 
 
 @pytest.fixture
@@ -17,13 +17,17 @@ class TestPipelineGen(object):
     def generate_template(self, app_name='appname',
                           lambda_python_version='python2.7',
                           codebuild_image=None):
-        template = self.pipeline_gen.create_template(
-            app_name, lambda_python_version, codebuild_image)
+        params = PipelineParameters(
+            app_name=app_name,
+            lambda_python_version=lambda_python_version,
+            codebuild_image=codebuild_image
+        )
+        template = self.pipeline_gen.create_template(params)
         return template
 
     def test_app_name_in_param_default(self):
-        template = self.generate_template(app_name='appname')
-        assert template['Parameters']['ApplicationName']['Default'] == 'appname'
+        template = self.generate_template(app_name='app')
+        assert template['Parameters']['ApplicationName']['Default'] == 'app'
 
     def test_python_version_in_param_default(self):
         template = self.generate_template(lambda_python_version='python2.7')
@@ -31,7 +35,8 @@ class TestPipelineGen(object):
             'aws/codebuild/python:2.7.12'
 
     def test_py3_throws_error(self):
-        # This test can be removed when there is a 3.6 codebuild image available
+        # This test can be removed when there is a 3.6 codebuild image
+        # available.
         with pytest.raises(InvalidCodeBuildPythonVersion):
             self.generate_template('app', 'python3.6')
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -96,7 +96,7 @@ def test_install_requirements_in_buildspec(pipeline_gen):
 
 
 def test_can_provide_codebuild_image(pipeline_gen):
-    p = pipeline.CreatePipelineTemplate(codebuild_image='python:3.6.1')
-    template = p.create_template('appname', 'python2.7')
+    template = pipeline_gen.create_template('appname', 'python2.7',
+                                            codebuild_image='python:3.6.1')
     default_image = template['Parameters']['CodeBuildImage']['Default']
     assert default_image == 'python:3.6.1'

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -93,3 +93,10 @@ def test_install_requirements_in_buildspec(pipeline_gen):
     build = template['Resources']['AppPackageBuild']
     build_spec = build['Properties']['Source']['BuildSpec']
     assert 'pip install -r requirements.txt' in build_spec
+
+
+def test_can_provide_codebuild_image(pipeline_gen):
+    p = pipeline.CreatePipelineTemplate(codebuild_image='python:3.6.1')
+    template = p.create_template('appname', 'python2.7')
+    default_image = template['Parameters']['CodeBuildImage']['Default']
+    assert default_image == 'python:3.6.1'


### PR DESCRIPTION
If you're not using python2.7, you can still generate a
pipeline as long as you provide a codebuild image to use.
This allows pipeline generation in python3.

Fixes #609.