### PR TITLE
Add option to map env vars to template params in package command

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -267,22 +267,24 @@ def generate_sdk(ctx, sdk_type, stage, outdir):
                     "this argument is specified, a single "
                     "zip file will be created instead."))
 @click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('--map-env-to-params', is_flag=True, default=False)
 @click.argument('out')
 @click.pass_context
-def package(ctx, single_file, stage, out):
-    # type: (click.Context, bool, str, str) -> None
+def package(ctx, single_file, stage, map_env_to_params, out):
+    # type: (click.Context, bool, str, bool, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj(stage)
     packager = factory.create_app_packager(config)
     if single_file:
         dirname = tempfile.mkdtemp()
         try:
-            packager.package_app(config, dirname)
+            packager.package_app(config, dirname,
+                                 map_env_to_params=map_env_to_params)
             create_zip_file(source_dir=dirname, outfile=out)
         finally:
             shutil.rmtree(dirname)
     else:
-        packager.package_app(config, out)
+        packager.package_app(config, out, map_env_to_params=map_env_to_params)
 
 
 @cli.command('generate-pipeline')

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -22,6 +22,23 @@ class AbortedError(Exception):
     pass
 
 
+def to_cfn_case(key):
+    # type: (str) -> str
+    """Transform a name to a readable cfn name.
+
+    This is similar to the to_cfn_resource_name function
+    except it will first try to create a readable name.
+
+    This is useful when you want to generate something that's
+    user visible such as an output value or a parameter key name.
+
+    If this function is not able to generate a readable cfn
+    name it will fall back to to_cfn_resource_name.
+
+    """
+    return ''.join([k.capitalize() for k in key.split('_')])
+
+
 def to_cfn_resource_name(name):
     # type: (str) -> str
     """Transform a name to a valid cfn name.

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -10,12 +10,23 @@ from chalice.deploy.swagger import SwaggerGenerator
 
 @pytest.fixture
 def mock_swagger_generator():
-    return mock.Mock(spec=SwaggerGenerator)
+    swagger = mock.Mock(spec=SwaggerGenerator)
+    swagger.generate_swagger.return_value = {
+        'swagger': 'document'
+    }
+    return swagger
 
 
 @pytest.fixture
 def mock_policy_generator():
     return mock.Mock(spec=ApplicationPolicyHandler)
+
+
+@pytest.fixture
+def cfn_gen(mock_swagger_generator, mock_policy_generator):
+    p = package.SAMTemplateGenerator(mock_swagger_generator,
+                                     mock_policy_generator)
+    return p
 
 
 def test_can_create_app_packager():
@@ -42,14 +53,10 @@ def test_preconfigured_policy_proxies():
     assert policy == {'policy': True}
 
 
-def test_sam_generates_sam_template_basic(sample_app,
-                                          mock_swagger_generator,
-                                          mock_policy_generator):
-    p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                     mock_policy_generator)
+def test_sam_generates_sam_template_basic(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app,
                            api_gateway_stage='dev')
-    template = p.generate_sam_template(config, 'code-uri')
+    template = cfn_gen.generate_sam_template(config, 'code-uri')
     # Verify the basic structure is in place.  The specific parts
     # are validated in other tests.
     assert template['AWSTemplateFormatVersion'] == '2010-09-09'
@@ -76,29 +83,15 @@ def test_sam_injects_policy(sample_app,
     assert 'Role' not in template['Resources']['APIHandler']['Properties']
 
 
-def test_sam_injects_swagger_doc(sample_app,
-                                 mock_swagger_generator,
-                                 mock_policy_generator):
-    p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                     mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_sam_injects_swagger_doc(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app,
                            api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['RestAPI']['Properties']
     assert properties['DefinitionBody'] == {'swagger': 'document'}
 
 
-def test_can_inject_environment_vars(sample_app,
-                                     mock_swagger_generator,
-                                     mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_can_inject_environment_vars(sample_app, cfn_gen):
     config = Config.create(
         chalice_app=sample_app,
         api_gateway_stage='dev',
@@ -106,39 +99,25 @@ def test_can_inject_environment_vars(sample_app,
             'FOO': 'BAR'
         }
     )
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert 'Environment' in properties
     assert properties['Environment']['Variables'] == {'FOO': 'BAR'}
 
 
-def test_chalice_tag_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_chalice_tag_added_to_function(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
                            app_name='myapp')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['Tags'] == {
         'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version}
 
 
-def test_custom_tags_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_custom_tags_added_to_function(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
                            app_name='myapp', tags={'mykey': 'myvalue'})
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['Tags'] == {
         'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version,
@@ -146,142 +125,84 @@ def test_custom_tags_added_to_function(sample_app,
     }
 
 
-def test_default_function_timeout(sample_app,
-                                  mock_swagger_generator,
-                                  mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_default_function_timeout(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['Timeout'] == 60
 
 
-def test_timeout_added_to_function(sample_app,
-                                   mock_swagger_generator,
-                                   mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_timeout_added_to_function(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
                            app_name='myapp', lambda_timeout=240)
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['Timeout'] == 240
 
 
-def test_default_function_memory_size(sample_app,
-                                      mock_swagger_generator,
-                                      mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_default_function_memory_size(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['MemorySize'] == 128
 
 
-def test_memory_size_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_memory_size_added_to_function(sample_app, cfn_gen):
     config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
                            app_name='myapp', lambda_memory_size=256)
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['MemorySize'] == 256
 
 
-def test_endpoint_url_reflects_apig_stage(sample_app,
-                                          mock_swagger_generator,
-                                          mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_endpoint_url_reflects_apig_stage(sample_app, cfn_gen):
     config = Config.create(
         chalice_app=sample_app,
         api_gateway_stage='prod',
     )
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     endpoint_url = template['Outputs']['EndpointURL']['Value']['Fn::Sub']
     assert endpoint_url == (
         'https://${RestAPI}.execute-api.${AWS::Region}.amazonaws.com/prod/')
 
 
-def test_maps_python_version(sample_app,
-                             mock_swagger_generator,
-                             mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_maps_python_version(sample_app, cfn_gen):
     config = Config.create(
         chalice_app=sample_app,
         api_gateway_stage='dev',
     )
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     expected = config.lambda_python_version
     actual = template['Resources']['APIHandler']['Properties']['Runtime']
     assert actual == expected
 
 
-def test_role_arn_added_to_function(sample_app,
-                                    mock_swagger_generator,
-                                    mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
+def test_role_arn_added_to_function(sample_app, cfn_gen):
     config = Config.create(
         chalice_app=sample_app, api_gateway_stage='dev', app_name='myapp',
         manage_iam_role=False, iam_role_arn='role-arn')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     properties = template['Resources']['APIHandler']['Properties']
     assert properties['Role'] == 'role-arn'
     assert 'Policies' not in properties
 
 
-def test_app_incompatible_with_cf(sample_app,
-                                  mock_swagger_generator,
-                                  mock_policy_generator):
+def test_app_incompatible_with_cf(sample_app, cfn_gen):
 
     @sample_app.route('/foo')
     def foo_invalid():
         return {}
 
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
     config = Config.create(chalice_app=sample_app,
                            api_gateway_stage='dev',
                            app_name='sample_invalid_cf')
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     events = template['Resources']['APIHandler']['Properties']['Events']
     # The underscore should be removed from the event name.
     assert 'fooinvalidget4cee' in events
 
 
-def test_app_with_auth(sample_app,
-                       mock_swagger_generator,
-                       mock_policy_generator):
+def test_app_with_auth(sample_app, cfn_gen):
 
     @sample_app.authorizer('myauth')
     def myauth(auth_request):
@@ -293,16 +214,11 @@ def test_app_with_auth(sample_app,
     # The last four digits come from the hash of the auth name
     cfn_auth_name = 'myauthdb6d'
 
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
     config = Config.create(
         chalice_app=sample_app,
         api_gateway_stage='dev',
     )
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     assert cfn_auth_name in template['Resources']
     auth_function = template['Resources'][cfn_auth_name]
     assert auth_function['Type'] == 'AWS::Serverless::Function'
@@ -325,10 +241,7 @@ def test_app_with_auth(sample_app,
     }
 
 
-def test_app_with_auth_but_invalid_cfn_name(sample_app,
-                                            mock_swagger_generator,
-                                            mock_policy_generator):
-
+def test_app_with_auth_but_invalid_cfn_name(sample_app, cfn_gen):
     # Underscores are not allowed for CFN resource names
     # This instead should be referred to as customauth in CFN templates
     # where the underscore is removed.
@@ -342,16 +255,11 @@ def test_app_with_auth_but_invalid_cfn_name(sample_app,
 
     # The last four digits come from the hash of the auth name
     cfn_auth_name = 'customauth8767'
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
     config = Config.create(
         chalice_app=sample_app,
         api_gateway_stage='dev',
     )
-    template = p.generate_sam_template(config)
+    template = cfn_gen.generate_sam_template(config)
     assert cfn_auth_name in template['Resources']
     auth_function = template['Resources'][cfn_auth_name]
     assert auth_function['Type'] == 'AWS::Serverless::Function'


### PR DESCRIPTION
Fixes #608.

For example, given this `.chalice/config.json`:

```json
$ cat .chalice/config.json
{
  "version": "2.0",
  "app_name": "foo",
  "stages": {
    "dev": {
      "api_gateway_stage": "api",
      "environment_variables": {
        "FOO_BAR": "yeah",
        "BAR_BAZ": "ok"
      }
    }
  }
}
```

You can get these cfn template params:

```
$ chalice package --map-env-to-params outdir
$ cat outdir/sam.json
...
  "Parameters": {
    "ApiHandlerFooBar": {
      "Default": "yeah",
      "Type": "String"
    },
    "ApiHandlerBarBaz": {
      "Default": "ok",
      "Type": "String"
    }
  }
```

Notes:

* Need to translate `UPPER_SNAKE` to `UpperSnake` because of the alphanumeric restriction on cfn params
* Rather than using the `to_cfn_resource_name` which appends a hash based on the name, I went for a more direct translation.  This is because these values are user facing and I wanted something with a more readable name (vs. resource names which a user doesn't directly need to worry about).
* In the case of duplicate names, an exception is raised.