### PR TITLE
Setup Environment Variables Locally

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -89,12 +89,10 @@ def local(ctx, host='127.0.0.1', port=8000, stage=DEFAULT_STAGE_NAME):
 def run_local_server(factory, host, port, stage, env):
     # type: (CLIFactory, str, int, str, MutableMapping) -> None
     config = factory.create_config_obj(
-        chalice_stage_name=stage
+        chalice_stage_name=stage,
+        env=env
     )
-    # We only load the chalice app after loading the config
-    # so we can set any env vars needed before importing the
-    # app.
-    env.update(config.environment_variables)
+
     app_obj = factory.load_chalice_app()
     # Check that `chalice deploy` would let us deploy these routes, otherwise
     # there is no point in testing locally.

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -129,7 +129,8 @@ class CLIFactory(object):
                         default_params=default_params)
         return config
 
-    def _handle_environment_variables(stage,
+    def _handle_environment_variables(self,
+                                      stage,
                                       config,
                                       env):
         # Import Global Variables First.

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -111,9 +111,10 @@ class CLIFactory(object):
         # so we can set any env vars needed here, before importing
         # the app.
         if env is not None:
-            self._handle_environment_variables(
-                chalice_stage_name, config_from_disk, env
-            )
+            env=os.environ
+        self._handle_environment_variables(
+            chalice_stage_name, config_from_disk, env
+        )
 
         app_obj = self.load_chalice_app()
         user_provided_params['chalice_app'] = app_obj

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -111,15 +111,9 @@ class CLIFactory(object):
         # so we can set any env vars needed here, before importing
         # the app.
         if env is not None:
-            # Import Global Variables First.
-            if 'environment_variables' in config_from_disk:
-                env.update(config_from_disk['environment_variables'])
-
-            # Overwrite with stage variables next.
-            if 'stages' in config_from_disk:
-                if chalice_stage_name in config_from_disk['stages']:
-                    if 'environment_variables' in config_from_disk['stages'][chalice_stage_name]:
-                        env.update(config_from_disk['stages'][chalice_stage_name]['environment_variables'])
+            self._handle_environment_variables(
+                chalice_stage_name, config_from_disk, env
+            )
 
         app_obj = self.load_chalice_app()
         user_provided_params['chalice_app'] = app_obj
@@ -134,6 +128,20 @@ class CLIFactory(object):
                         config_from_disk=config_from_disk,
                         default_params=default_params)
         return config
+
+    def _handle_environment_variables(stage,
+                                      config,
+                                      env):
+        # Import Global Variables First.
+        if 'environment_variables' in config:
+            env.update(config['environment_variables'])
+
+        # Overwrite with stage variables next.
+        if 'stages' in config:
+            if stage in config['stages']:
+                if 'environment_variables' in config['stages'][stage]:
+                    env.update(
+                        config['stages'][stage]['environment_variables'])
 
     def _validate_config_from_disk(self, config):
         # type: (Dict[str, Any]) -> None

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -5,7 +5,7 @@ import importlib
 import logging
 
 from botocore.session import Session
-from typing import Any, Optional, Dict  # noqa
+from typing import Any, Optional, Dict, MutableMapping   # noqa
 
 from chalice import __version__ as chalice_version
 from chalice.awsclient import TypedAWSClient
@@ -91,7 +91,7 @@ class CLIFactory(object):
                           autogen_policy=None,
                           api_gateway_stage=None,
                           env=None):
-        # type: (str, Optional[bool], str) -> Config
+        # type: (str, Optional[bool], str, MutableMapping) -> Config
         user_provided_params = {}  # type: Dict[str, Any]
         default_params = {'project_dir': self.project_dir,
                           'api_gateway_stage': DEFAULT_APIGATEWAY_STAGE_NAME,
@@ -133,6 +133,7 @@ class CLIFactory(object):
                                       stage,
                                       config,
                                       env):
+        # type: (str, MutableMapping, MutableMapping) -> None
         # Import Global Variables First.
         if 'environment_variables' in config:
             env.update(config['environment_variables'])

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -110,7 +110,7 @@ class CLIFactory(object):
         # We will load the chalice app after loading the config
         # so we can set any env vars needed here, before importing
         # the app.
-        if env is not None:
+        if env is None:
             env=os.environ
         self._handle_environment_variables(
             chalice_stage_name, config_from_disk, env

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -12,7 +12,6 @@ from chalice.cli import factory
 from chalice.deploy.deployer import Deployer
 from chalice.config import Config
 from chalice.utils import record_deployed_values
-from chalice import local
 from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 
 

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -311,22 +311,6 @@ def test_can_generate_pipeline_for_all(runner):
             assert "Outputs" in template
 
 
-def test_env_vars_set_in_local(runner, mock_cli_factory,
-                               monkeypatch):
-    local_server = mock.Mock(spec=local.LocalDevServer)
-    mock_cli_factory.create_local_server.return_value = local_server
-    mock_cli_factory.create_config_obj.return_value = Config.create(
-        project_dir='.', environment_variables={'foo': 'bar'})
-    actual_env = {}
-    monkeypatch.setattr(os, 'environ', actual_env)
-    with runner.isolated_filesystem():
-        cli.create_new_project_skeleton('testproject')
-        os.chdir('testproject')
-        _run_cli_command(runner, cli.local, [],
-                         cli_factory=mock_cli_factory)
-        assert actual_env['foo'] == 'bar'
-
-
 def test_can_specify_profile_for_logs(runner, mock_cli_factory):
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -22,6 +22,7 @@ def setup_chalice_dir(app_dir, config={}):
     chalice_dir = app_dir.mkdir('.chalice')
     chalice_dir.join('config.json').write(config)
 
+
 @fixture
 def setup_app_dir(tmpdir):
     appdir = tmpdir.mkdir('app')
@@ -139,7 +140,7 @@ def test_can_create_config_obj_with_global_and_stage_env_vars(setup_app_dir):
     assert isinstance(obj, Config)
 
 
-def test_can_create_config_obj_with_and_stage_overrides_global_env_vars(setup_app_dir):
+def test_create_config_with_stage_overriding_global_env_vars(setup_app_dir):
     config = {
         "version": "2.0",
         "app_name": "replaceme",

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -17,10 +17,10 @@ def test_run_local_server():
     local_server = mock.Mock(spec=LocalDevServer)
     factory.create_local_server.return_value = local_server
     cli.run_local_server(factory, '127.0.0.1', 8000, local_stage_test, env)
-    assert env['foo'] == 'bar'
+
     local_server.serve_forever.assert_called_with()
     factory.create_config_obj.assert_called_with(
-        chalice_stage_name=local_stage_test)
+        chalice_stage_name=local_stage_test, env={})
 
 
 def test_cannot_run_local_mode_with_trailing_slash_route():


### PR DESCRIPTION
The current implementation [cli/__init__.py#L97](https://github.com/aws/chalice/blob/master/chalice/cli/__init__.py#L97) sets environment variables after [factory.create_config_obj()](https://github.com/aws/chalice/blob/master/chalice/cli/factory.py#L90) is called, which happs to call [self.load_chalice_app()](https://github.com/aws/chalice/blob/master/chalice/cli/factory.py#L108) before `run_local_server()` [calls it as well](https://github.com/aws/chalice/blob/master/chalice/cli/__init__.py#L98).

The pull request resolves issue #584 by configuring the environment in the factory, prior to calling `self.load_chalice_app()` in such a way that it is only done when running *local* but ensures that the environment is properly configured as expected.

