### PR TITLE
Add github source and buildspec extraction to generate-pipeline

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -296,10 +296,18 @@ def package(ctx, single_file, stage, out):
                     "'codecommit' will create a CodeCommit repository "
                     "for you.  The 'github' value allows you to "
                     "reference an existing GitHub repository."))
+@click.option('-b', '--buildspec-file',
+              help=("Specify path for buildspec.yml file. "
+                    "By default, the build steps are included in the "
+                    "generated cloudformation template.  If this option "
+                    "is provided, a buildspec.yml will be generated "
+                    "as a separate file and not included in the cfn "
+                    "template.  This file should be named 'buildspec.yml'"
+                    "and placed in the root directory of your app."))
 @click.argument('filename')
 @click.pass_context
-def generate_pipeline(ctx, codebuild_image, source, filename):
-    # type: (click.Context, str, str, str) -> None
+def generate_pipeline(ctx, codebuild_image, source, buildspec_file, filename):
+    # type: (click.Context, str, str, str, str) -> None
     """Generate a cloudformation template for a starter CD pipeline.
 
     This command will write a starter cloudformation template to
@@ -326,6 +334,11 @@ def generate_pipeline(ctx, codebuild_image, source, filename):
         code_source=source,
     )
     output = p.create_template(params)
+    if buildspec_file:
+        extractor = pipeline.BuildSpecExtractor()
+        buildspec_contents = extractor.extract_buildspec(output)
+        with open(buildspec_file, 'w') as f:
+            f.write(buildspec_contents)
     with open(filename, 'w') as f:
         f.write(serialize_to_json(output))
 

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -302,8 +302,11 @@ def package(ctx, single_file, stage, out):
                     "generated cloudformation template.  If this option "
                     "is provided, a buildspec.yml will be generated "
                     "as a separate file and not included in the cfn "
-                    "template.  This file should be named 'buildspec.yml'"
-                    "and placed in the root directory of your app."))
+                    "template.  This allows you to make changes to how "
+                    "the project is built without having to redeploy "
+                    "a CloudFormation template. This file should be "
+                    "named 'buildspec.yml' and placed in the root "
+                    "directory of your app."))
 @click.argument('filename')
 @click.pass_context
 def generate_pipeline(ctx, codebuild_image, source, buildspec_file, filename):

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -290,10 +290,16 @@ def package(ctx, single_file, stage, out):
               help=("Specify default codebuild image to use.  "
                     "This option must be provided when using a python "
                     "version besides 2.7."))
+@click.option('-s', '--source', default='codecommit',
+              type=click.Choice(['codecommit', 'github']),
+              help=("Specify the input source.  The default value of "
+                    "'codecommit' will create a CodeCommit repository "
+                    "for you.  The 'github' value allows you to "
+                    "reference an existing GitHub repository."))
 @click.argument('filename')
 @click.pass_context
-def generate_pipeline(ctx, codebuild_image, filename):
-    # type: (click.Context, str, str) -> None
+def generate_pipeline(ctx, codebuild_image, source, filename):
+    # type: (click.Context, str, str, str) -> None
     """Generate a cloudformation template for a starter CD pipeline.
 
     This command will write a starter cloudformation template to
@@ -317,6 +323,7 @@ def generate_pipeline(ctx, codebuild_image, filename):
         app_name=config.app_name,
         lambda_python_version=config.lambda_python_version,
         codebuild_image=codebuild_image,
+        code_source=source,
     )
     output = p.create_template(params)
     with open(filename, 'w') as f:

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -531,3 +531,12 @@ class CodePipeline(BaseResource):
                 }
             }
         }
+
+
+class BuildSpecExtractor(object):
+    def extract_buildspec(self, template):
+        # type: (Dict[str, Any]) -> str
+        source = template['Resources']['AppPackageBuild'][
+            'Properties']['Source']
+        buildspec = source.pop('BuildSpec')
+        return buildspec

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -15,11 +15,13 @@ class InvalidCodeBuildPythonVersion(Exception):
 
 
 class PipelineParameters(object):
-    def __init__(self, app_name, lambda_python_version, codebuild_image=None):
-        # type: (str, str, Optional[str]) -> None
+    def __init__(self, app_name, lambda_python_version,
+                 codebuild_image=None, code_source='codecommit'):
+        # type: (str, str, Optional[str], str) -> None
         self.app_name = app_name
         self.lambda_python_version = lambda_python_version
         self.codebuild_image = codebuild_image
+        self.code_source = code_source
 
 
 class CreatePipelineTemplate(object):
@@ -54,9 +56,14 @@ class CreatePipelineTemplate(object):
         params['CodeBuildImage']['Default'] = self._get_codebuild_image(
             pipeline_params)
 
-        resources = [SourceRepository, CodeBuild, CodePipeline]
-        for resource_cls in resources:
-            resource_cls().add_to_template(t)
+        resources = []  # type: List[BaseResource]
+        if pipeline_params.code_source == 'github':
+            resources.append(GithubSource())
+        else:
+            resources.append(CodeCommitSourceRepository())
+        resources.extend([CodeBuild(), CodePipeline()])
+        for resource in resources:
+            resource.add_to_template(t, pipeline_params)
         return t
 
     def _get_codebuild_image(self, params):
@@ -71,14 +78,14 @@ class CreatePipelineTemplate(object):
 
 
 class BaseResource(object):
-    def add_to_template(self, template):
-        # type: (Dict[str, Any]) -> None
+    def add_to_template(self, template, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         raise NotImplementedError("add_to_template")
 
 
-class SourceRepository(BaseResource):
-    def add_to_template(self, template):
-        # type: (Dict[str, Any]) -> None
+class CodeCommitSourceRepository(BaseResource):
+    def add_to_template(self, template, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         resources = template.setdefault('Resources', {})
         resources['SourceRepository'] = {
             "Type": "AWS::CodeCommit::Repository",
@@ -98,9 +105,32 @@ class SourceRepository(BaseResource):
         }
 
 
+class GithubSource(BaseResource):
+    def add_to_template(self, template, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
+        # For the github source, we don't create a github repo,
+        # we just wire it up in the code pipeline.  The
+        # only thing we add to the template are parameters
+        # we reference in other resources later.
+        p = template.setdefault('Parameters', {})
+        p['GithubOwner'] = {
+            'Type': 'String',
+            'Description': 'The github owner or org name of the repository.',
+        }
+        p['GithubRepoName'] = {
+            'Type': 'String',
+            'Description': 'The name of the github repository.',
+        }
+        p['GithubPersonalToken'] = {
+            'Type': 'String',
+            'Description': 'Personal access token for the github repo.',
+            'NoEcho': True,
+        }
+
+
 class CodeBuild(BaseResource):
-    def add_to_template(self, template):
-        # type: (Dict[str, Any]) -> None
+    def add_to_template(self, template, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         resources = template.setdefault('Resources', {})
         outputs = template.setdefault('Outputs', {})
         # Used to store the application source when the SAM
@@ -217,11 +247,11 @@ class CodeBuild(BaseResource):
 
 
 class CodePipeline(BaseResource):
-    def add_to_template(self, template):
-        # type: (Dict[str, Any]) -> None
+    def add_to_template(self, template, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         resources = template.setdefault('Resources', {})
         outputs = template.setdefault('Outputs', {})
-        self._add_pipeline(resources)
+        self._add_pipeline(resources, pipeline_params)
         self._add_bucket_store(resources, outputs)
         self._add_codepipeline_role(resources, outputs)
         self._add_cfn_deploy_role(resources, outputs)
@@ -268,8 +298,8 @@ class CodePipeline(BaseResource):
             }
         }
 
-    def _add_pipeline(self, resources):
-        # type: (Dict[str, Any]) -> None
+    def _add_pipeline(self, resources, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         properties = {
             'Name': {
                 'Fn::Sub': '${ApplicationName}Pipeline'
@@ -281,26 +311,26 @@ class CodePipeline(BaseResource):
             'RoleArn': {
                 'Fn::GetAtt': 'CodePipelineRole.Arn',
             },
-            'Stages': self._create_pipeline_stages(),
+            'Stages': self._create_pipeline_stages(pipeline_params),
         }
         resources['AppPipeline'] = {
             'Type': 'AWS::CodePipeline::Pipeline',
             'Properties': properties
         }
 
-    def _create_pipeline_stages(self):
-        # type: () -> List[Dict[str, Any]]
+    def _create_pipeline_stages(self, pipeline_params):
+        # type: (PipelineParameters) -> List[Dict[str, Any]]
         # The goal is to eventually allow a user to configure
         # the various stages they want created. For now, there's
         # a fixed list.
-        stages = [
-            self._create_source_stage(),
-            self._create_build_stage(),
-            self._create_beta_stage(),
-        ]
+        stages = []
+        source = self._create_source_stage(pipeline_params)
+        if source:
+            stages.append(source)
+        stages.extend([self._create_build_stage(), self._create_beta_stage()])
         return stages
 
-    def _create_source_stage(self):
+    def _code_commit_source(self):
         # type: () -> Dict[str, Any]
         return {
             "Name": "Source",
@@ -327,6 +357,37 @@ class CodePipeline(BaseResource):
                     "Name": "Source"
                 }
             ]
+        }
+
+    def _create_source_stage(self, pipeline_params):
+        # type: (PipelineParameters) -> Dict[str, Any]
+        if pipeline_params.code_source == 'codecommit':
+            return self._code_commit_source()
+        return self._github_source()
+
+    def _github_source(self):
+        # type: () -> Dict[str, Any]
+        return {
+            'Name': 'Source',
+            'Actions': [{
+                "ActionTypeId": {
+                    "Category": "Source",
+                    "Owner": "ThirdParty",
+                    "Version": 1,
+                    "Provider": "GitHub"
+                },
+                'RunOrder': 1,
+                'OutputArtifacts': {
+                    'Name': 'SourceRepo',
+                },
+                'Configuration': {
+                    'Owner': {'Ref': 'GithubOwner'},
+                    'Repo': {'Ref': 'GithubRepoName'},
+                    'OAuthToken': {'Ref': 'GithubPersonalToken'},
+                    'Branch': 'master',
+                    'PollForSourceChanges': True,
+                }
+            }],
         }
 
     def _create_build_stage(self):

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -349,6 +349,24 @@ def test_can_configure_github(runner):
             assert 'GithubRepoName' in template['Parameters']
 
 
+def test_can_extract_buildspec_yaml(runner):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        result = _run_cli_command(
+            runner, cli.generate_pipeline,
+            ['--buildspec-file', 'buildspec.yml',
+             '-i', 'python:3.6.1',
+             'pipeline.json'])
+        assert result.exit_code == 0, result.output
+        assert os.path.isfile('buildspec.yml')
+        with open('buildspec.yml') as f:
+            data = f.read()
+            # The contents of this file are tested elsewhere,
+            # we just want a basic sanity check here.
+            assert 'chalice package' in data
+
+
 def test_env_vars_set_in_local(runner, mock_cli_factory,
                                monkeypatch):
     local_server = mock.Mock(spec=local.LocalDevServer)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -328,6 +328,27 @@ def test_no_errors_if_override_codebuild_image(runner):
             assert image == 'python:3.6.1'
 
 
+def test_can_configure_github(runner):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        # The -i option is provided so we don't have to skip this
+        # test on python3.6
+        result = _run_cli_command(
+            runner, cli.generate_pipeline,
+            ['--source', 'github', '-i' 'python:3.6.1', 'pipeline.json'])
+        assert result.exit_code == 0, result.output
+        assert os.path.isfile('pipeline.json')
+        with open('pipeline.json', 'r') as f:
+            template = json.load(f)
+            # The template is already tested in the unit tests
+            # for template generation.  We just want a basic
+            # sanity check to make sure things are mapped
+            # properly.
+            assert 'GithubOwner' in template['Parameters']
+            assert 'GithubRepoName' in template['Parameters']
+
+
 def test_env_vars_set_in_local(runner, mock_cli_factory,
                                monkeypatch):
     local_server = mock.Mock(spec=local.LocalDevServer)

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -158,3 +158,22 @@ def test_can_generate_github_source(pipeline_params):
     cfn_params = template['Parameters']
     assert set(cfn_params) == set(['GithubOwner', 'GithubRepoName',
                                    'GithubPersonalToken'])
+
+
+def test_build_extractor():
+    template = {
+        'Resources': {
+            'AppPackageBuild': {
+                'Properties': {
+                    'Source': {
+                        'BuildSpec': 'foobar'
+                    }
+                }
+            }
+        }
+    }
+    extract = pipeline.BuildSpecExtractor()
+    extracted = extract.extract_buildspec(template)
+    assert extracted == 'foobar'
+    assert 'BuildSpec' not in template[
+        'Resources']['AppPackageBuild']['Properties']['Source']

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -9,6 +9,11 @@ def pipeline_gen():
     return pipeline.CreatePipelineTemplate()
 
 
+@pytest.fixture
+def pipeline_params():
+    return pipeline.PipelineParameters('appname', 'python2.7')
+
+
 class TestPipelineGen(object):
 
     def setup_method(self):
@@ -16,11 +21,12 @@ class TestPipelineGen(object):
 
     def generate_template(self, app_name='appname',
                           lambda_python_version='python2.7',
-                          codebuild_image=None):
+                          codebuild_image=None, code_source='codecommit'):
         params = PipelineParameters(
             app_name=app_name,
             lambda_python_version=lambda_python_version,
-            codebuild_image=codebuild_image
+            codebuild_image=codebuild_image,
+            code_source=code_source,
         )
         template = self.pipeline_gen.create_template(params)
         return template
@@ -50,10 +56,40 @@ class TestPipelineGen(object):
         default_image = template['Parameters']['CodeBuildImage']['Default']
         assert default_image == 'python:3.6.1'
 
+    def test_no_source_resource_when_using_github(self):
+        template = self.generate_template(code_source='github')
+        resources = template['Resources']
+        assert 'SourceRepository' not in set(resources)
 
-def test_source_repo_resource():
+    def test_can_add_github_as_source_stage(self):
+        template = self.generate_template(code_source='github')
+        resources = template['Resources']
+        source_stage = resources['AppPipeline']['Properties']['Stages'][0]
+        assert source_stage['Name'] == 'Source'
+        actions = source_stage['Actions']
+        assert len(actions) == 1
+        action = actions[0]
+        assert action['ActionTypeId'] == {
+            'Category': 'Source',
+            'Provider': 'GitHub',
+            'Owner': 'ThirdParty',
+            'Version': 1,
+        }
+        assert action['RunOrder'] == 1
+        assert action['OutputArtifacts'] == {'Name': 'SourceRepo'}
+        assert action['Configuration'] == {
+            'Owner': {'Ref': 'GithubOwner'},
+            'Repo': {'Ref': 'GithubRepoName'},
+            'OAuthToken': {'Ref': 'GithubPersonalToken'},
+            'Branch': 'master',
+            'PollForSourceChanges': True,
+        }
+
+
+def test_source_repo_resource(pipeline_params):
     template = {}
-    pipeline.SourceRepository().add_to_template(template)
+    pipeline.CodeCommitSourceRepository().add_to_template(
+        template, pipeline_params)
     assert template == {
         "Resources": {
             "SourceRepository": {
@@ -78,9 +114,9 @@ def test_source_repo_resource():
     }
 
 
-def test_codebuild_resource():
+def test_codebuild_resource(pipeline_params):
     template = {}
-    pipeline.CodeBuild().add_to_template(template)
+    pipeline.CodeBuild().add_to_template(template, pipeline_params)
     resources = template['Resources']
     assert 'ApplicationBucket' in resources
     assert 'CodeBuildRole' in resources
@@ -92,9 +128,9 @@ def test_codebuild_resource():
     }
 
 
-def test_codepipeline_resource():
+def test_codepipeline_resource(pipeline_params):
     template = {}
-    pipeline.CodePipeline().add_to_template(template)
+    pipeline.CodePipeline().add_to_template(template, pipeline_params)
     resources = template['Resources']
     assert 'AppPipeline' in resources
     assert 'ArtifactBucketStore' in resources
@@ -107,9 +143,18 @@ def test_codepipeline_resource():
     resources['CFNDeployRole']['Type'] == 'AWS::IAM::Role'
 
 
-def test_install_requirements_in_buildspec():
+def test_install_requirements_in_buildspec(pipeline_params):
     template = {}
-    pipeline.CodeBuild().add_to_template(template)
+    pipeline.CodeBuild().add_to_template(template, pipeline_params)
     build = template['Resources']['AppPackageBuild']
     build_spec = build['Properties']['Source']['BuildSpec']
     assert 'pip install -r requirements.txt' in build_spec
+
+
+def test_can_generate_github_source(pipeline_params):
+    template = {}
+    pipeline_params.code_source = 'github'
+    pipeline.GithubSource().add_to_template(template, pipeline_params)
+    cfn_params = template['Parameters']
+    assert set(cfn_params) == set(['GithubOwner', 'GithubRepoName',
+                                   'GithubPersonalToken'])


### PR DESCRIPTION
This PR adds two options to the `generate-pipeline` command:

* The ability to specify a github source via `--source github`.  CFN template params are injected that require you to specify the owner and repo name when this option is provided.
* The ability to write the CodeBuild buildspec file to a separate file.  The default behavior is to include the contents as part of the cloudformation template.