### PR TITLE
Fix hanging fixture/failure in integration test

### DIFF
--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -12,10 +12,11 @@ from chalice.config import Config
 
 
 class ThreadedLocalServer(Thread):
-    def __init__(self, port):
+    def __init__(self, port, host='localhost'):
         super(ThreadedLocalServer, self).__init__()
         self._app_object = None
         self._config = None
+        self._host = host
         self._port = port
         self._server = None
         self._server_ready = Event()
@@ -26,14 +27,14 @@ class ThreadedLocalServer(Thread):
 
     def run(self):
         self._server = LocalDevServer(
-            self._app_object, self._config, self._port)
+            self._app_object, self._config, self._host, self._port)
         self._server_ready.set()
         self._server.serve_forever()
 
     def make_call(self, method, path, port, timeout=0.5):
         self._server_ready.wait()
-        return method('http://localhost:{port}{path}'.format(
-            path=path, port=port), timeout=timeout)
+        return method('http://{host}:{port}{path}'.format(
+            path=path, host=self._host, port=port), timeout=timeout)
 
     def shutdown(self):
         if self._server is not None:


### PR DESCRIPTION
The local server integration test seemed to hang endlessly. Disabling pytest's output capture explained why:

```
============================================================ test session starts =============================================================
platform linux -- Python 3.6.0, pytest-3.0.7, py-1.4.33, pluggy-0.4.0  
rootdir: /home/niko/local_source/chalice, inifile:                     
plugins: cov-2.4.0, hypothesis-3.8.2                                   
collected 3 items                  

tests/integration/test_local.py Exception in thread Thread-1:          
Traceback (most recent call last): 
      File "/home/niko/.pyenv/versions/3.6.0/lib/python3.6/threading.py", line 916, in _bootstrap_inner                                           
          self.run()                     
        File "/home/niko/local_source/chalice/tests/integration/test_local.py", line 29, in run                                                     
          self._app_object, self._config, self._port)                        
      TypeError: __init__() missing 1 required positional argument: 'port'   


```
See awslabs/chalice@a73e4de