### PR TITLE
Adding support for Token Validation in custom authorizer

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -187,11 +187,12 @@ class CustomAuthorizer(Authorizer):
     _AUTH_TYPE = 'custom'
 
     def __init__(self, name, authorizer_uri, ttl_seconds=300,
-                 header='Authorization'):
+                 header='Authorization', token_validation=''):
         self.name = name
         self._header = header
         self._authorizer_uri = authorizer_uri
         self._ttl_seconds = ttl_seconds
+        self._token_validation = token_validation
 
     def to_swagger(self):
         return {
@@ -203,6 +204,7 @@ class CustomAuthorizer(Authorizer):
                 'type': 'token',
                 'authorizerUri': self._authorizer_uri,
                 'authorizerResultTtlInSeconds': self._ttl_seconds,
+                'identityValidationExpression': self._token_validation,
             }
         }
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -307,7 +307,8 @@ def test_can_use_authorizer_object(sample_app, swagger_gen):
         'x-amazon-apigateway-authorizer': {
             'authorizerUri': 'auth-uri',
             'type': 'token',
-            'authorizerResultTtlInSeconds': 300
+            'authorizerResultTtlInSeconds': 300,
+            'identityValidationExpression': '',
         }
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -793,7 +793,8 @@ def test_typecheck_list_type():
 
 def test_can_serialize_custom_authorizer():
     auth = app.CustomAuthorizer(
-        'Name', 'myuri', ttl_seconds=10, header='NotAuth'
+        'Name', 'myuri', ttl_seconds=10, header='NotAuth',
+        token_validation='regex'
     )
     assert auth.to_swagger() == {
         'in': 'header',
@@ -804,6 +805,7 @@ def test_can_serialize_custom_authorizer():
             'type': 'token',
             'authorizerUri': 'myuri',
             'authorizerResultTtlInSeconds': 10,
+            'identityValidationExpression': 'regex',
         }
     }
 


### PR DESCRIPTION
User can can use it as following:

```
auth0 = CustomAuthorizer(
    name='jwt-rsa-custom-authorizer',
    header='Authorization',
    ttl_seconds=3600,
    token_validation='^Bearer [-0-9a-zA-z\.]*$',
    authorizer_uri=('uri'
    )
)
```

close #642 