### PR TITLE
Implement Resource Deletion

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -182,6 +182,9 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
 @click.pass_context
 def delete_new(ctx, profile, stage):
     # type: (click.Context, str, str) -> None
+    # TODO: We should consolidate the logic here with
+    # deploy_new, there's similar logic in both functions
+    # that can be shared.
     factory = ctx.obj['factory']  # type: CLIFactory
     factory.profile = profile
     config = factory.create_config_obj(chalice_stage_name=stage)

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -175,6 +175,23 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
             config.project_dir, '.chalice', 'deployed.json'))
 
 
+@cli.command('delete-new')
+@click.option('--profile', help='Override profile at deploy time.')
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+              help='Name of the Chalice stage to delete.')
+@click.pass_context
+def delete_new(ctx, profile, stage):
+    # type: (click.Context, str, str) -> None
+    factory = ctx.obj['factory']  # type: CLIFactory
+    factory.profile = profile
+    config = factory.create_config_obj(chalice_stage_name=stage)
+    session = factory.create_botocore_session()
+    d = factory.create_deletion_deployer(session=session)
+    deployed_values = d.deploy(config, chalice_stage_name=stage)
+    record_deployed_values(deployed_values, os.path.join(
+        config.project_dir, '.chalice', 'deployed.json'))
+
+
 @cli.command('delete')
 @click.option('--profile', help='Override profile at deploy time.')
 @click.option('--stage', default=DEFAULT_STAGE_NAME,

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -98,6 +98,10 @@ class CLIFactory(object):
         # type: (Session) -> newdeployer.Deployer
         return newdeployer.create_default_deployer(session)
 
+    def create_deletion_deployer(self, session):
+        # type: (Session) -> newdeployer.Deployer
+        return newdeployer.create_deletion_deployer(TypedAWSClient(session))
+
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None,
                           api_gateway_stage=None):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -321,15 +321,19 @@ class Config(object):
 class DeployedResources2(object):
     def __init__(self, deployed_values):
         # type: (Dict[str, Any]) -> None
-        self._deployed_values = deployed_values
+        self._deployed_values = deployed_values['resources']
+        self._deployed_values_by_name = {
+            resource['name']: resource
+            for resource in deployed_values['resources']
+        }
 
     def resource_values(self, name):
         # type: (str) -> Dict[str, str]
-        return self._deployed_values['resources'][name]
+        return self._deployed_values_by_name[name]
 
     def resource_names(self):
         # type: () -> List[str]
-        return list(self._deployed_values['resources'])
+        return [r['name'] for r in self._deployed_values]
 
 
 class DeployedResources(object):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -31,18 +31,12 @@ class RecordResource(Instruction):
 
 
 @attrs(frozen=True)
-class RecordResourceVariable(Instruction):
-    resource_type = attrib()
-    resource_name = attrib()
-    name = attrib()
+class RecordResourceVariable(RecordResource):
     variable_name = attrib()
 
 
 @attrs(frozen=True)
-class RecordResourceValue(Instruction):
-    resource_type = attrib()
-    resource_name = attrib()
-    name = attrib()
+class RecordResourceValue(RecordResource):
     value = attrib()
 
 

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -46,7 +46,7 @@ class RecordResource(Instruction):
         ...
 
 
-class RecordResourceVariable(Instruction):
+class RecordResourceVariable(RecordResource):
     resource_type = ...  # type: str
     resource_name = ...  # type: str
     name = ...  # type: str
@@ -62,7 +62,7 @@ class RecordResourceVariable(Instruction):
         ...
 
 
-class RecordResourceValue(Instruction):
+class RecordResourceValue(RecordResource):
     resource_type = ...  # type: str
     resource_name = ...  # type: str
     name = ...  # type: str

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -95,7 +95,7 @@ from chalice.deploy.packager import LambdaDeploymentPackager
 from chalice.deploy.packager import PipRunner, SubprocessPip
 from chalice.deploy.packager import DependencyBuilder as PipDependencyBuilder
 from chalice.deploy.planner import PlanStage, Variable, RemoteState
-from chalice.deploy.planner import UnreferencedResourcePlanner
+from chalice.deploy.planner import UnreferencedResourcePlanner, NoopPlanner
 from chalice.policy import AppPolicyGenerator
 from chalice.constants import LAMBDA_TRUST_POLICY
 from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
@@ -141,18 +141,13 @@ def create_default_deployer(session):
     )
 
 
-# TODO: come back to this.
-def create_deletion_deployer(session):
-    # type: (Session) -> Deployer
-    client = TypedAWSClient(session)
-    osutils = OSUtils()
+def create_deletion_deployer(client):
+    # type: (TypedAWSClient) -> Deployer
     return Deployer(
         application_builder=ApplicationGraphBuilder(),
         deps_builder=DependencyBuilder(),
         build_stage=BuildStage(steps=[]),
-        plan_stage=PlanStage(
-            osutils=osutils, remote_state=RemoteState(client),
-        ),
+        plan_stage=NoopPlanner(),
         sweeper=UnreferencedResourcePlanner(),
         executor=Executor(client),
     )

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -62,8 +62,6 @@ class RemoteState(object):
 
 class UnreferencedResourcePlanner(object):
 
-    # Add support for IAM roles
-    # get deps order correct.
     def execute(self, plan, config):
         # type: (List[models.Instruction], Config) -> None
         marked = set(self._mark_resources(plan))
@@ -258,6 +256,16 @@ class PlanStage(object):
             document = json.loads(
                 self._osutils.get_file_contents(resource.filename))
         return document
+
+
+class NoopPlanner(PlanStage):
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def execute(self, resources):
+        # type: (List[models.Model]) -> List[models.Instruction]
+        return []
 
 
 class Variable(object):

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -96,8 +96,11 @@ class UnreferencedResourcePlanner(object):
                 )
                 plan.append(apicall)
             elif resource_values['resource_type'] == 'iam_role':
-                # TODO: add the role_name to the deployed.json?
+                # TODO: Consider adding the role_name to the deployed.json.
                 # This is a separate value than the 'name' of the resource.
+                # For now we have to parse out the role name from the role_arn
+                # and it would be better if we could get the role name
+                # directly.
                 v = resource_values['role_arn'].rsplit('/')[1]
                 apicall = models.APICall(
                     method_name='delete_role',

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -57,7 +57,7 @@ def remove_stage_from_deployed_values(key, filename):
 
 
 def record_deployed_values(deployed_values, filename):
-    # type: (Dict[str, str], str) -> None
+    # type: (Dict[str, Any], str) -> None
     """Record deployed values to a JSON file.
 
     This allows subsequent deploys to lookup previously deployed values.

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -7,7 +7,8 @@ import pytest
 from pytest import fixture
 
 from chalice.cli import factory
-from chalice.deploy.deployer import Deployer
+from chalice.deploy.deployer import Deployer as OldDeployer
+from chalice.deploy.newdeployer import Deployer
 from chalice.config import Config
 from chalice import local
 
@@ -67,6 +68,12 @@ def test_can_create_botocore_session_cli_factory(clifactory):
 def test_can_create_default_deployer(clifactory):
     session = clifactory.create_botocore_session()
     deployer = clifactory.create_default_deployer(session, None)
+    assert isinstance(deployer, OldDeployer)
+
+
+def test_can_create_deletion_deployer(clifactory):
+    session = clifactory.create_botocore_session()
+    deployer = clifactory.create_deletion_deployer(session)
     assert isinstance(deployer, Deployer)
 
 

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -594,10 +594,11 @@ class TestExecutor(object):
             name='myfunction_arn',
         )
         self.executor.execute([call, record_instruction])
-        assert self.executor.resource_values['myfunction'] == {
+        assert self.executor.resource_values == [{
+            'name': 'myfunction',
             'myfunction_arn': 'function:arn',
             'resource_type': 'lambda_function',
-        }
+        }]
 
     def test_can_reference_varname(self):
         self.mock_client.create_function.return_value = 'function:arn'
@@ -611,12 +612,11 @@ class TestExecutor(object):
                 variable_name='myvarname',
             ),
         ])
-        assert self.executor.resource_values == {
-            'myfunction': {
-                'resource_type': 'lambda_function',
-                'myfunction_arn': 'function:arn',
-            }
-        }
+        assert self.executor.resource_values == [{
+            'name': 'myfunction',
+            'resource_type': 'lambda_function',
+            'myfunction_arn': 'function:arn',
+        }]
 
     def test_can_record_value_directly(self):
         self.executor.execute([
@@ -627,12 +627,11 @@ class TestExecutor(object):
                 value='arn:foo',
             )
         ])
-        assert self.executor.resource_values == {
-            'myfunction': {
-                'resource_type': 'lambda_function',
-                'myfunction_arn': 'arn:foo',
-            }
-        }
+        assert self.executor.resource_values == [{
+            'name': 'myfunction',
+            'resource_type': 'lambda_function',
+            'myfunction_arn': 'arn:foo',
+        }]
 
     def test_validates_no_unresolved_deploy_vars(self):
         function = create_function_resource('myfunction')

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -14,6 +14,7 @@ from chalice.deploy import packager
 from chalice.config import Config
 from chalice.app import Chalice
 from chalice.deploy.newdeployer import create_default_deployer
+from chalice.deploy.newdeployer import create_deletion_deployer
 from chalice.deploy.newdeployer import Deployer
 from chalice.deploy.newdeployer import BaseDeployStep
 from chalice.deploy.newdeployer import BuildStage
@@ -741,4 +742,10 @@ class TestDeployer(unittest.TestCase):
 def test_can_create_default_deployer():
     session = botocore.session.get_session()
     deployer = create_default_deployer(session)
+    assert isinstance(deployer, Deployer)
+
+
+def test_can_create_deletion_deployer():
+    session = botocore.session.get_session()
+    deployer = create_deletion_deployer(TypedAWSClient(session))
     assert isinstance(deployer, Deployer)

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -365,12 +365,12 @@ class TestUnreferencedResourcePlanner(object):
     def function_resource(self):
         return create_function_resource('myfunction')
 
-    def one_deployed_lambda_function(name='myfunction', arn='arn'):
+    def one_deployed_lambda_function(self, name='myfunction', arn='arn'):
         return {
             'resources': [{
-                'name': 'myfunction',
+                'name': name,
                 'resource_type': 'lambda_function',
-                'lambda_arn': 'arn',
+                'lambda_arn': arn,
             }]
         }
 
@@ -384,7 +384,7 @@ class TestUnreferencedResourcePlanner(object):
             )
         ]
         original_plan = plan[:]
-        deployed = self.one_deployed_lambda_function()
+        deployed = self.one_deployed_lambda_function(name='myfunction')
         config = FakeConfig(deployed)
         sweeper.execute(plan, config)
         # We shouldn't add anything to the list.


### PR DESCRIPTION
### Implement resource deletion

This PR adds a `delete-new` command, similar to the `deploy-new` command.

The basic idea is to rely on the sweeper code to handle deletions.
Conceptually this is similar to creating an empty chalice app
and running `chalice deploy`.

The other alternative was create a new planner type that specifically
handled deletions.  The reason for leveraging the sweeper for deploys
is two fold:

1. We have to write sweeper logic anyways.  This was originally to
   handle the case where you remove resources from your app.py and
   rerun `chalice deploy`.  This logic has to stay regardless of what's
   decided for deletion.
2. A deletion planner would unnecessarily have to take into account
   what's currently specified in your app.py along with the remote state
   (stuff that's already been deployed).  This is unnecessary
   complication.  For deletion we only care about what exists
   remotely.

Another benefit of (2) is that we handle an edge case where you
remove resources from your app.py but don't run `chalice deploy`.
In the old deployer code, we base deletion based on your app.py
so we'd essentially leak a resource.  This is now handled by this
new deletion code because it's always based on the deployed.json
file.

As part of this change, the first commit is a change to the deployed.json
structure.  Instead of a dictionary of deployed values, the `resources`
key is now a list.  This list is the order in which the resources were
deployed by the executor.  The sweeper is updated to always iterate
through the resources in reverse order so we always delete resources
in the reversed order they were created (even in the case of deletions
for a redeploy).


### Example Test

From a new project, we have two lambda functions, with
explicit policies defined:


```
 $ cat app.py
from chalice import Chalice

app = Chalice(app_name='test-deletes')


@app.lambda_function()
def foo(event, context):
    return {'hello': 'foo'}


@app.lambda_function()
def bar(event, context):
    return {'hello': 'bar'}


$ cat .chalice/config.json
{
  "stages": {
    "dev": {
      "api_gateway_stage": "api",
      "lambda_functions": {
        "foo": {"iam_policy_file": "policy-one.json", "autogen_policy": false},
        "bar": {"iam_policy_file": "policy-two.json", "autogen_policy": false}
      }
    }
  },
  "version": "2.0",
  "app_name": "test-deletes"
}

$ ls -la .chalice/
total 24
Dec 20 15:34 .
Dec 20 15:32 ..
Dec 20 15:33 config.json
Dec 20 15:33 policy-one.json
Dec 20 15:33 policy-two.json
```

Now the initial deploy will create 4 resources:


```
$ chalice deploy-new
Creating deployment package.
(chalice) /tmp/test-deletes $ cat .chalice/deployed.json
{
  "stages": {
    "dev": {
      "resources": [
        {
          "role_arn": "arn:aws:iam::1:role/test-deletes-dev-foo",
          "name": "role-foo",
          "resource_type": "iam_role"
        },
        {
          "lambda_arn": "arn:aws:lambda:us-west-2:1:function:test-deletes-dev-foo",
          "name": "foo",
          "resource_type": "lambda_function"
        },
        {
          "role_arn": "arn:aws:iam::1:role/test-deletes-dev-bar",
          "name": "role-bar",
          "resource_type": "iam_role"
        },
        {
          "lambda_arn": "arn:aws:lambda:us-west-2:1:function:test-deletes-dev-bar",
          "name": "bar",
          "resource_type": "lambda_function"
        }
      ]
    }
  },
  "schema_version": "2.0"
}
```

We can verify the functions are created remotely:

```
$ aws lambda list-functions --query 'Functions[?starts_with(@.FunctionName, `test-deletes`)].FunctionName'
[
    "test-deletes-dev-foo",
    "test-deletes-dev-bar"
]
```

Same for roles:

```
$ aws iam list-roles --query 'Roles[?starts_with(@.RoleName, `test-deletes`)].RoleName'
[
    "test-deletes-dev-bar",
    "test-deletes-dev-foo"
]
```

And finally, we can delete the app:


```
$ chalice delete-new
(chalice) /tmp/test-deletes $ cat .chalice/deployed.json
{
  "stages": {
    "dev": {
      "resources": []
    }
  },
  "schema_version": "2.0"
}
```

And the resources don't exist remotely:

```
(chalice) /tmp/test-deletes $ aws lambda list-functions --query 'Functions[?starts_with(@.FunctionName, `test-deletes`)].FunctionName'
[]
(chalice) /tmp/test-deletes $ aws iam list-roles --query 'Roles[?starts_with(@.RoleName, `test-deletes`)].RoleName'
[]
```