### PR TITLE
Properly handle async functions in the analyzer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Next Release (TBD)
   (`#565 <https://github.com/aws/chalice/issues/565>`__)
 * Fix `chalice local` handling of browser requests
   (`#565 <https://github.com/aws/chalice/issues/628>`__)
+* Support async/await syntax in automatic policy generation
+  (`#565 <https://github.com/aws/chalice/issues/646>`__)
 
 
 1.1.0

--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -530,6 +530,12 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
         else:
             self._symbol_table.register_ast_node_for_symbol(node.name, node)
 
+    def visit_AsyncFunctionDef(self, node):
+        # type: (ast.FunctionDef) -> None
+        # this type is actually wrong but we can't use the actual type as it's
+        # not available in python 2
+        self.visit_FunctionDef(node)
+
     def visit_ClassDef(self, node):
         # type: (ast.ClassDef) -> None
         # Not implemented yet.  We want to ensure we don't

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -1,3 +1,6 @@
+import sys
+import pytest
+
 from textwrap import dedent
 
 from chalice import analyzer
@@ -616,6 +619,21 @@ def test_can_handle_dict_comp_ifs():
          for y in d.update_table()\
          if d.list_tables()}
     """) == {'dynamodb': set(['list_tables', 'create_table', 'update_table'])}
+
+
+@pytest.mark.skipif(sys.version[0] == '2', reason=(
+    'Async await syntax is not in Python 2'
+))
+def test_can_handle_async_await():
+    assert aws_calls("""\
+        import boto3
+        import asyncio
+        async def test():
+            d = boto3.client('dynamodb')
+            d.list_tables()
+            await asyncio.sleep(1)
+        test()
+    """) == {'dynamodb': set(['list_tables'])}
 
 
 # def test_tuple_assignment():


### PR DESCRIPTION
Fixes #646 

Not sure what to do for the typing here as `ast.AsyncFunctionDef` isn't available on python 2 which is what we use for type checking.