### PR TITLE
Support for OpenAPI parameters in @app.route.

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -364,7 +364,7 @@ class RouteEntry(object):
 
     def __init__(self, view_function, view_name, path, method,
                  api_key_required=None, content_types=None,
-                 cors=False, authorizer=None):
+                 cors=False, authorizer=None, parameters=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
@@ -385,6 +385,7 @@ class RouteEntry(object):
             cors = None
         self.cors = cors
         self.authorizer = authorizer
+        self.parameters = parameters
 
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
@@ -550,6 +551,7 @@ class Chalice(object):
         api_key_required = kwargs.pop('api_key_required', None)
         content_types = kwargs.pop('content_types', ['application/json'])
         cors = kwargs.pop('cors', False)
+        parameters = kwargs.pop('parameters', None)
         if not isinstance(content_types, list):
             raise ValueError('In view function "%s", the content_types '
                              'value must be a list, not %s: %s'
@@ -569,7 +571,7 @@ class Chalice(object):
                 )
             entry = RouteEntry(view_func, name, path, method,
                                api_key_required, content_types,
-                               cors, authorizer)
+                               cors, authorizer, parameters)
             self.routes[path][method] = entry
 
     def __call__(self, event, context):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -88,13 +88,15 @@ class RouteEntry(object):
     content_types = ... # type: List[str]
     view_args = ... # type: List[str]
     cors = ... # type: CORSConfig
+    parameters = ... # type: List[Dict[str, Any]]
 
     def __init__(self, view_function: Callable[..., Any],
                  view_name: str, path: str, methods: List[str],
                  authorizer_name: str=None,
                  api_key_required: bool=None,
                  content_types: List[str]=None,
-                 cors: Union[bool, CORSConfig]=False) -> None: ...
+                 cors: Union[bool, CORSConfig]=False,
+                 parameters: List[Dict[str, Any]]=None) -> None: ...
 
     def _parse_view_args(self) -> List[str]: ...
 

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -139,6 +139,8 @@ class SwaggerGenerator(object):
                 {view.authorizer.name: []})
         if view.view_args:
             self._add_view_args(current, view.view_args)
+        if view.parameters:
+            self._add_parameters(current, view.parameters)
         return current
 
     def _generate_precanned_responses(self):
@@ -183,6 +185,12 @@ class SwaggerGenerator(object):
             {'name': name, 'in': 'path', 'required': True, 'type': 'string'}
             for name in view_args
         ]
+
+    def _add_parameters(self, single_method, parameters):
+        # type: (Dict[str, Any], List[Dict[str, Any]]) -> None
+        tmp = single_method.get('parameters') or []
+        tmp.extend(parameters)
+        single_method['parameters'] = tmp
 
     def _add_preflight_request(self, cors, methods, swagger_for_path):
         # type: (CORSConfig, List[str], Dict[str, Any]) -> None

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -70,6 +70,21 @@ def test_can_add_url_captures_to_params(sample_app, swagger_gen):
     ]
 
 
+def test_can_add_openapi_parameters_to_params(sample_app, swagger_gen):
+    param = {
+        'in': 'query', 'name': 'param', 'type': 'string', 'required': False
+    }
+
+    @sample_app.route('/path', parameters=[param])
+    def foo():
+        return {}
+
+    doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/path']['get']
+    assert 'parameters' in single_method
+    assert single_method['parameters'] == [param]
+
+
 def test_can_add_multiple_http_methods(sample_app, swagger_gen):
     @sample_app.route('/multimethod', methods=['GET', 'POST'])
     def multiple_methods():

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -97,6 +97,12 @@ def sample_app():
     def name(name):
         return {'provided-name': name}
 
+    @demo.route('/params', methods=['GET'], parameters=[{
+        'in': 'query', 'type': 'string', 'name': 'myparam', 'required': False
+    }])
+    def params():
+        return {'hello': 'params'}
+
     return demo
 
 
@@ -243,6 +249,12 @@ def test_will_pass_captured_params_to_view(sample_app, create_event):
     response = sample_app(event, context=None)
     response = json_response_body(response)
     assert response == {'provided-name': 'james'}
+
+
+def test_will_accept_openapi_params_declaration(sample_app, create_event):
+    event = create_event('/params', 'GET', {})
+    response = sample_app(event, context=None)
+    assert_response_body_is(response, {'hello': 'params'})
 
 
 def test_error_on_unsupported_method(sample_app, create_event):


### PR DESCRIPTION
This modification adds support for providing OpenAPI 3.0 Parameter Objects in the `@app.route` decorator, so that they are included in the swagger document that is embedded in the `sam.json` document generated during application packaging. This simplifies generating clients for the application using the swagger spec directly exported from the AWS console without additional modifications.