### PR TITLE
Hey, I just met you, and this is crazy, but lets put routes in a module... Blueprints maybe?

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -543,6 +543,25 @@ class Chalice(object):
             return view_func
         return _register_view
 
+    def register_blueprint(self, blueprint, url_prefix=None):
+        def urljoin(*args):
+            return "/".join(map(lambda x: str(x).rstrip('/'), args))
+
+        for blueprint_route in blueprint.routes:
+            if url_prefix is None:
+                blueprint_route_path = blueprint_route[0]
+            else:
+                blueprint_route_path = urljoin(
+                    url_prefix,
+                    blueprint_route[0].lstrip('/')
+                )
+
+            self._add_route(
+                blueprint_route_path,  # Calculated path
+                blueprint_route[1],  # view_func
+                **blueprint_route[2],  # kwargs
+            )
+
     def _add_route(self, path, view_func, **kwargs):
         name = kwargs.pop('name', view_func.__name__)
         methods = kwargs.pop('methods', ['GET'])

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -51,7 +51,7 @@ def _matches_content_type(content_type, valid_content_types):
 
 
 def naive_urljoin(*args):
-    return "/".join(map(lambda x: str(x).rstrip('/'), args))
+    return "/".join([str(x).rstrip('/') for x in args])
 
 
 class ChaliceError(Exception):
@@ -561,12 +561,12 @@ class Chalice(object):
                 )
 
             view_name = kwargs.pop('name', view_func.__name__)
+            kwargs['name'] = '.'.join([blueprint.name, view_name])
 
             self._add_route(
                 constructed_path,
                 view_func,
-                **kwargs,
-                name='.'.join([blueprint.name, view_name]),
+                **kwargs
             )
 
         blueprint.REGISTERED_APP = self

--- a/chalice/blueprint.py
+++ b/chalice/blueprint.py
@@ -7,6 +7,21 @@ class Blueprint:
         self.name = name
         self.routes = []
 
+    def url_for(self, view_name):
+        if view_name.startswith('{}.'.format(self.name)):
+            pass
+        else:
+            view_name = '{}.{}'.format(self.name, view_name.lstrip('.'))
+
+        if self.REGISTERED_APP is None:
+            raise RuntimeError('Blueprint must be registered first!')
+        for path, methods in self.REGISTERED_APP.routes.items():
+            for method in methods.keys():
+                if self.REGISTERED_APP.routes[path][method].view_name == view_name:
+                    return path
+
+        raise LookupError('No url found for {}'.format(view_name))
+
     @property
     def current_request(self):
         if self.REGISTERED_APP is None:

--- a/chalice/blueprint.py
+++ b/chalice/blueprint.py
@@ -1,13 +1,17 @@
+from typing import Any, Callable, List  # noqa
 
-class Blueprint:
+from chalice.app import Request  # noqa
+
+
+class Blueprint(object):
 
     REGISTERED_APP = None
 
-    def __init__(self, name):
-        self.name = name
-        self.routes = []
+    def __init__(self, name):  # type: (str) -> None
+        self.name = name  # type: str
+        self.routes = []  # type: List
 
-    def url_for(self, view_name):
+    def url_for(self, view_name):  # type: (str) -> str
         if view_name.startswith('{}.'.format(self.name)):
             pass
         else:
@@ -17,19 +21,20 @@ class Blueprint:
             raise RuntimeError('Blueprint must be registered first!')
         for path, methods in self.REGISTERED_APP.routes.items():
             for method in methods.keys():
-                if self.REGISTERED_APP.routes[path][method].view_name == view_name:
+                found_name = self.REGISTERED_APP.routes[path][method].view_name
+                if found_name == view_name:
                     return path
 
         raise LookupError('No url found for {}'.format(view_name))
 
     @property
-    def current_request(self):
+    def current_request(self):  # type: () -> Request
         if self.REGISTERED_APP is None:
             raise RuntimeError('Blueprint must be registered first!')
         return self.REGISTERED_APP.current_request
 
-    def route(self, path, **kwargs):
-        def _register_view(view_func):
+    def route(self, path, **kwargs):  # type: (str, **Any) -> Callable
+        def _register_view(view_func):  # type: (Callable) -> Callable
             self.routes.append((path, view_func, kwargs))
             return view_func
         return _register_view

--- a/chalice/blueprint.py
+++ b/chalice/blueprint.py
@@ -1,9 +1,17 @@
 
 class Blueprint:
 
+    REGISTERED_APP = None
+
     def __init__(self, name):
         self.name = name
         self.routes = []
+
+    @property
+    def current_request(self):
+        if self.REGISTERED_APP is None:
+            raise RuntimeError('Blueprint must be registered first!')
+        return self.REGISTERED_APP.current_request
 
     def route(self, path, **kwargs):
         def _register_view(view_func):

--- a/chalice/blueprint.py
+++ b/chalice/blueprint.py
@@ -1,0 +1,12 @@
+
+class Blueprint:
+
+    def __init__(self, name):
+        self.name = name
+        self.routes = []
+
+    def route(self, path, **kwargs):
+        def _register_view(view_func):
+            self.routes.append((path, view_func, kwargs))
+            return view_func
+        return _register_view

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -6,7 +6,7 @@ import json
 import pytest
 from pytest import fixture
 import hypothesis.strategies as st
-from hypothesis import given, assume
+from hypothesis import given, assume, settings
 import six
 
 
@@ -1295,6 +1295,7 @@ def test_raw_body_is_none_if_body_is_none():
 
 
 @given(http_request_kwargs=HTTP_REQUEST)
+@settings(suppress_health_check=(3))
 def test_http_request_to_dict_is_json_serializable(http_request_kwargs):
     # We have to do some slight pre-preocessing here
     # to maintain preconditions.  If the


### PR DESCRIPTION
# Use case

I have been working on a chalice based app lately that is growing a bit beyond having all routes set up in `app.py`.

Being heavily influenced by [Flask](http://flask.pocoo.org/)'s API, I figured [Blueprints](http://flask.pocoo.org/docs/0.12/blueprints/) might be a welcome addition for Chalice.

# Status of this PR

This is mostly intended as a provisional or "Request for Comment" PR. If the maintainers of Chalice like this approach, I'd be happy to continue work on adding tests and documentation for this :)

Currently only very basic functionality exists:

  - Construct a `chalice.blueprint.Blueprint` object
  - Add routes to your `chalice.blueprint.Blueprint` instance with the `route` decorator, which _should_ accept all the same Keyword Arguments as a vanilla `Chalice.route`... though i'm not sure if they'll all work :)
  - Support for `current_request` access in `Blueprint` routes
  - Support for `url_for` in `Blueprint` routes.

# Example!

## `/app.py`
```py
from chalice import Chalice

from chalicelib.blueprint import foo

app = Chalice(app_name="helloworld")
app.debug = True

@app.route("/")
def index():
    return {"hello": "world"}

app.register_blueprint(foo, url_prefix='/foo/')
```

## `/chalicelib/blueprint.py`
```py
from chalice.blueprint import Blueprint

foo = Blueprint('foo')

@foo.route('/bar', methods=["GET", "POST"])
def bar():
    request = foo.current_request
    return {"result": "bar!", "method": request.method}

@foo.route('/baz')
def baz():
    return {"result": foo.url_for('bar')}
```

## Demo!

```sh
blueprintsmaybe ewdurbin$ chalice local > /dev/null 2>&1 &
[1] 10084
blueprintsmaybe ewdurbin$ curl -w "\n" http://localhost:8000/
{"hello": "world"}
blueprintsmaybe ewdurbin$ curl -w "\n" http://localhost:8000/foo/bar
{"result": "bar!", "method": "GET"}
blueprintsmaybe ewdurbin$ curl -w "\n" -XPOST http://localhost:8000/foo/bar
{"result": "bar!", "method": "POST"}
blueprintsmaybe ewdurbin$ curl -w "\n" http://localhost:8000/foo/baz
{"result": "/foo/bar"}
```