### PR TITLE
attempt to build a wheel for packages installed from local directories

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -588,8 +588,12 @@ class SubprocessPip(object):
             osutils = OSUtils()
         self._osutils = osutils
 
-    def main(self, args, env_vars=None, shim=None):
-        # type: (List[str], EnvVars, OptStr) -> Tuple[int, Optional[bytes]]
+    def main(self,
+             args,           # List[str]
+             env_vars=None,  # EnvVars
+             shim=None       # OptStr
+             ):
+        # type: (...) -> Tuple[int, OptBytes, OptBytes]
         if env_vars is None:
             env_vars = self._osutils.environ()
         if shim is None:
@@ -601,9 +605,9 @@ class SubprocessPip(object):
         p = subprocess.Popen(invoke_pip,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              env=env_vars)
-        _, err = p.communicate()
+        out, err = p.communicate()
         rc = p.returncode
-        return rc, err
+        return rc, err, out
 
 
 class PipRunner(object):
@@ -615,13 +619,18 @@ class PipRunner(object):
         self._wrapped_pip = pip
         self._osutils = osutils
 
-    def _execute(self, command, args, env_vars=None, shim=None):
-        # type: (str, List[str], EnvVars, OptStr) -> Tuple[int, OptBytes]
+    def _execute(self,
+                 command,        # type: str
+                 args,           # type: List[str]
+                 env_vars=None,  # type: EnvVars
+                 shim=None       # type: OptStr
+                 ):
+        # type: (...) -> Tuple[int, OptBytes, OptBytes]
         """Execute a pip command with the given arguments."""
         main_args = [command] + args
-        rc, err = self._wrapped_pip.main(main_args, env_vars=env_vars,
-                                         shim=shim)
-        return rc, err
+        rc, err, out = self._wrapped_pip.main(main_args, env_vars=env_vars,
+                                              shim=shim)
+        return rc, err, out
 
     def build_wheel(self, wheel, directory, compile_c=True):
         # type: (str, str, bool) -> None
@@ -642,7 +651,7 @@ class PipRunner(object):
         # type: (str, str) -> None
         """Download all dependencies as sdist or wheel."""
         arguments = ['-r', requirements_filename, '--dest', directory]
-        rc, err = self._execute('download', arguments)
+        rc, err, out = self._execute('download', arguments)
         # When downloading all dependencies we expect to get an rc of 0 back
         # since we are casting a wide net here letting pip have options about
         # what to download. If a package is not found it is likely because it
@@ -659,6 +668,15 @@ class PipRunner(object):
                 package_name = match.group(1)
                 raise NoSuchPackageError(str(package_name))
             raise PackageDownloadError(error)
+        if out is None:
+            out = b'Unknown output'
+        stdout = out.decode()
+        match = re.search(("Processing (.+?)\n"
+                           "  Link is a directory, "
+                           "ignoring download_dir"), stdout)
+        if match:
+            download_dir = match.group(1).decode()
+            self.build_wheel(download_dir.encode(), directory)
 
     def download_manylinux_wheels(self, packages, directory):
         # type: (List[str], str) -> None

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -104,7 +104,7 @@ class FakePip(object):
                 side_effect.execute(args)
         except IndexError:
             pass
-        return 0, b''
+        return 0, b'', b''
 
     def packages_to_download(self, expected_args, packages, whl_contents=None):
         side_effects = [PipSideEffect(pkg,
@@ -763,7 +763,7 @@ def test_will_create_outdir_if_needed(tmpdir):
 class TestSubprocessPip(object):
     def test_can_invoke_pip(self):
         pip = SubprocessPip()
-        rc, err = pip.main(['--version'])
+        rc, err, _ = pip.main(['--version'])
         # Simple assertion that we can execute pip and it gives us some output
         # and nothing on stderr.
         assert rc == 0
@@ -771,7 +771,7 @@ class TestSubprocessPip(object):
 
     def test_does_error_code_propagate(self):
         pip = SubprocessPip()
-        rc, err = pip.main(['badcommand'])
+        rc, err, _ = pip.main(['badcommand'])
         assert rc != 0
         # Don't want to depend on a particular error message from pip since it
         # may change if we pin a differnet version to Chalice at some point.

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -24,8 +24,8 @@ class FakePip(object):
         self._calls.append(FakePipCall(args, env_vars, shim))
         if self._returns:
             return self._returns.pop(0)
-        # Return an rc of 0 and an empty stderr
-        return 0, b''
+        # Return an rc of 0 and an empty stderr and stdout
+        return 0, b'', b''
 
     def add_return(self, return_pair):
         self._returns.append(return_pair)
@@ -194,7 +194,7 @@ class TestPipRunner(object):
     def test_raise_no_such_package_error(self, pip_factory):
         pip, runner = pip_factory()
         pip.add_return((1, (b'Could not find a version that satisfies the '
-                            b'requirement BadPackageName ')))
+                            b'requirement BadPackageName '), b''))
         with pytest.raises(NoSuchPackageError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
         assert str(einfo.value) == ('Could not satisfy the requirement: '
@@ -202,14 +202,14 @@ class TestPipRunner(object):
 
     def test_raise_other_unknown_error_during_downloads(self, pip_factory):
         pip, runner = pip_factory()
-        pip.add_return((1, b'SomeNetworkingError: Details here.'))
+        pip.add_return((1, b'SomeNetworkingError: Details here.', b''))
         with pytest.raises(PackageDownloadError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
         assert str(einfo.value) == 'SomeNetworkingError: Details here.'
 
     def test_inject_unknown_error_if_no_stderr(self, pip_factory):
         pip, runner = pip_factory()
-        pip.add_return((1, None))
+        pip.add_return((1, None, None))
         with pytest.raises(PackageDownloadError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
         assert str(einfo.value) == 'Unknown error'


### PR DESCRIPTION
# Use case

I've been working on a project that uses both [apex](https://apex.run) and chalice in a single repository. Many of the packaged lambda functions will require access to a shared library that we don't intend to publish to an index... since the whole sum of the "raw" Lambda functions we're deploying via apex and the Lambda/API Gateway endpoints we're deploying via chalice will be versioned and deployed simultaneously.

# Status of this PR

This is mostly intended as a provisional or "Request for Comment" PR. If the maintainers of Chalice like this approach, I'd be happy to continue work on adding tests and documentation for this :)

Basically the run down is that if the `pip download` step fails, we just blindly try to build a wheel and it will either be picked up if it passes the `_is_compatible_wheel_filename` test, or we'll get an error I think (needs tests).

Again I'm mostly looking for feedback here on if an approach like this is acceptable before working on tests and docs :)

# Example!

```sh
$ tree
├── my-app-http
│   ├── app.py
│   └── requirements.txt
├── my-app-lambda
│   ├── functions
│   │   └── hello
│   │       ├── event.json
│   │       ├── function.json
│   │       ├── lambda.pth
│   │       ├── main.py
│   │       └── requirements.txt
│   └── project.json
└── lib
    ├── my-app
    │   ├── __init__.py
    │   ├── encryption
    │   │   └── __init__.py
    │   └── lambda_helpers
    │       ├── __init__.py
    │       └── kms.py
    ├── setup.py
    └── tests
        ├── __init__.py
        ├── context.py
        ├── encryption
        │   ├── __init__.py
        │   └── test_encryption.py
        └── lambda_helpers
            ├── __init__.py
            └── test_kms.py
```

Here, we have a directory structure containing a chalice application `my-app-http` as well as an apex function named `hello` that lives in an apex project named `my-app-lambda`.

### `my-app-http/requirements.txt`

```
../lib
```

### `my-app-lambda/functions/hello/requirements.txt`

```
../../../lib
```

This PR allows for `chalice deploy` to work in this scenario! Normally it silently passes over the error from `pip download` like

```
$ pip download -r requirements.txt 
Processing /Users/ewdurbin/codez/my-app/lib
  Link is a directory, ignoring download_dir
```

which does _not_ raise a non-zero status code.