### PR TITLE
RFC: use `tox` for running CI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .coverage
 chalice.egg-info/
 .hypothesis/
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,11 @@ language: python
 sudo: false
 env: HYPOTHESIS_PROFILE=ci
 matrix:
-  include:
-  - python: "3.6"
-    env: TEST_TYPE=prcheck
-  - python: "2.7"
-    env: TEST_TYPE=prcheck-py2
+  - TOXENV=py27
+  - TOXENV=py36
 install:
-  - pip install -r requirements-dev.txt -r requirements-docs.txt
-  - pip install -e .
+  - pip install tox
 script:
-  - make $TEST_TYPE
+  - tox
 after_success:
-  - if [[ $TEST_TYPE == 'coverage' ]]; then pip install codecov==2.0.5 && codecov; fi
+  - if [[ $TEST_TYPE == 'coverage' ]]; tox -e coverage; fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,91 @@
+[tox]
+skipsdist=True
+envlist = py27,py36
+
+[testenv]
+whitelist_externals = make
+
+setenv =
+    PYTHONDONTWRITEBYTECODE = 1
+    TESTS={env:TESTS:tests/unit tests/functional}
+
+deps =
+    venv-update
+
+commands =
+venv_update =
+    venv-update \
+       venv= {envdir} \
+       install= -r {toxinidir}/requirements-dev.txt -r {toxinidir}/requirements-docs.txt -e {toxinidir}
+
+check =
+    ###### FLAKE8 #####
+    # No unused imports, no undefined vars,
+    flake8 --ignore=E731,W503 --exclude chalice/__init__.py,chalice/compat.py --max-complexity 10 chalice/
+    flake8 --ignore=E731,W503,F401 --max-complexity 10 chalice/compat.py
+    flake8 tests/unit/ tests/functional/ tests/integration
+    # Proper docstring conventions according to pep257
+    pydocstyle --add-ignore=D100,D101,D102,D103,D104,D105,D204,D301 chalice/
+
+pylint =
+    ###### PYLINT ######
+    pylint --rcfile .pylintrc chalice
+    # Run our custom linter on test code.
+    pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
+
+test =
+    py.test -v {env:TESTS}
+
+typecheck =
+    mypy --py2 --ignore-missing-imports --follow-imports=skip -p chalice --disallow-untyped-defs --strict-optional --warn-no-return
+
+coverage =
+    py.test --cov chalice --cov-report term-missing {env:TESTS}
+
+coverage-unit =
+    py.test --cov chalice --cov-report term-missing tests/unit
+
+htmlcov =
+    py.test --cov chalice --cov-report html {env:TESTS}
+    rm -rf /tmp/htmlcov && mv htmlcov /tmp/
+    open /tmp/htmlcov/index.html
+
+doccheck =
+    ##### DOC8 ######
+    # Correct rst formatting for documentation
+    #
+    ##
+    doc8 docs/source --ignore-path docs/source/topics/multifile.rst
+    #
+    #
+    # Verify we have no broken external links
+    # as well as no undefined internal references.
+    make -C docs linkcheck
+    # Verify we can build the docs.  The
+    # treat warnings as errors flag is enabled
+    # so any sphinx-build warnings will fail the build.
+    make -C docs html
+
+
+[testenv:py27]
+commands =
+    {[testenv]venv_update}
+    {[testenv]check}
+    {[testenv]pylint}
+    {[testenv]coverage}
+    {[testenv]doccheck}
+
+[testenv:py36]
+commands = 
+    {[testenv]venv_update}
+    {[testenv]check}
+    {[testenv]pylint}
+    {[testenv]coverage}
+    {[testenv]doccheck}
+    {[testenv]typecheck}
+
+[testenv:coverage]
+deps=
+    codecov==2.0.5
+commands =
+    codecov


### PR DESCRIPTION
I got cuddly with chalice over the weekend as you may have seen in #651 and #653, and along the way kept getting a bit frustrated with setting up a local dev env for `chalice`.

This is a Request for Comment on the possibility of moving from the venerable `make` to [`tox`](http://tox.readthedocs.io/en/latest/index.html) for tests.

The biggest benefit is someone who wants to contribute to chalice can simply run:

```shell
pip install --user tox
git clone https://github.com/aws/chalice.git
cd chalice
tox
```

To run all the CI tests locally without any additional setup.

I'm happy to help update this to suite the needs and the desires of chalice's codebase and maintainers, just holler :)