### PR TITLE
Automatic reload on code change (#316)

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -83,7 +83,8 @@ def cli(ctx, project_dir, debug=False):
 def local(ctx, host='127.0.0.1', port=8000, stage=DEFAULT_STAGE_NAME):
     # type: (click.Context, str, int, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
-    run_local_server(factory, host, port, stage, os.environ)
+    from werkzeug._reloader import run_with_reloader
+    run_with_reloader(lambda: run_local_server(factory, host, port, stage, os.environ))
 
 
 def run_local_server(factory, host, port, stage, env):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 coverage==4.3.4
 flake8==3.3.0
 tox==2.2.1
+werkzeug==0.14.1
 wheel==0.26.0
 doc8==0.7.0
 # Pylint will fail on py3.  Locking to a commit on master


### PR DESCRIPTION
Added werkzeug reloader for automatic restart of local development server on code change.