### PR TITLE
Add better support for browsers in local mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Next Release (TBD)
   (`#344 <https://github.com/aws/chalice/issues/344>`__)
 * Fix IAM role creation issue
   (`#565 <https://github.com/aws/chalice/issues/565>`__)
+* Fix `chalice local` handling of browser requests
+  (`#565 <https://github.com/aws/chalice/issues/628>`__)
 
 
 1.1.0

--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -111,3 +111,32 @@ def test_can_accept_multiple_options_request(config, sample_app,
     assert response.headers['Content-Length'] == '0'
     assert response.headers['Access-Control-Allow-Methods'] == 'POST,OPTIONS'
     assert response.text == ''
+
+
+def test_can_accept_multiple_connections(config, sample_app,
+                                         local_server_factory):
+    # When a GET request is made to Chalice from a browser, it will send the
+    # connection keep-alive header in order to hold the connection open and
+    # reuse it for subsequent requests. If the conncetion close header is sent
+    # back by the server the connection will be closed, but the browser will
+    # reopen a new connection just in order to have it ready when needed.
+    # In this case, since it does not send any content we do not have the
+    # opportunity to send a connection close header back in a response to
+    # force it to close the socket.
+    # This is an issue in Chalice since the single threaded local server will
+    # now be blocked waiting for IO from the browser socket. If a request from
+    # any other source is made it will be blocked until the browser sends
+    # another request through, giving us a chance to read from another socket.
+    local_server, port = local_server_factory(sample_app, config)
+    # We create a socket here to emulate a browser's open connection and then
+    # make a request. The request should succeed.
+    socket.create_connection(('localhost', port), timeout=1)
+    try:
+        response = local_server.make_call(requests.get, '/', port)
+    except requests.exceptions.ReadTimeout:
+        assert False, (
+            'Read timeout occured, the socket is blocking the next request '
+            'from going though.'
+        )
+    assert response.status_code == 200
+    assert response.text == '{"hello": "world"}'


### PR DESCRIPTION
Browsers tend to hold open sockets for future use. In the default single
threaded model that Python SimpleHTTPServer uses this causes the server
to become blocked permanently. This change adds a threading mixin to
the local server to prevent it from becoming blocked.

fixes #628 
  