### PR TITLE
Feature For Issue #254

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -745,6 +745,7 @@ class Chalice(object):
                 body = stack_trace
                 headers['Content-Type'] = 'text/plain'
             else:
+                self.log.error("%s", traceback.format_exc())
                 body = {'Code': 'InternalServerError',
                         'Message': 'An internal server error occurred.'}
             response = Response(body=body, headers=headers, status_code=500)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -745,7 +745,8 @@ class Chalice(object):
                 body = stack_trace
                 headers['Content-Type'] = 'text/plain'
             else:
-                self.log.error("%s", traceback.format_exc())
+                self.log.error("Internal Error for %s", view_function,
+                               exc_info=True)
                 body = {'Code': 'InternalServerError',
                         'Message': 'An internal server error occurred.'}
             response = Response(body=body, headers=headers, status_code=500)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1314,6 +1314,21 @@ def test_debug_mode_changes_log_level():
     assert test_app.log.getEffectiveLevel() == logging.DEBUG
 
 
+def test_internal_exception_debug_false(capsys, create_event):
+    test_app = app.Chalice('logger-test-5', debug=False)
+
+    @test_app.route('/error')
+    def error():
+        raise Exception('Something bad happened')
+
+    event = create_event('/error', 'GET', {})
+    test_app(event, context=None)
+    out, err = capsys.readouterr()
+    assert 'logger-test-5' in out
+    assert 'Internal Error' in out
+    assert 'Something bad happened' in out
+
+
 def test_raw_body_is_none_if_body_is_none():
     misc_kwargs = {
         'query_params': {},


### PR DESCRIPTION
This pull request is for the feature specified in issue [#254](https://github.com/aws/chalice/issues/254). 

Below is a example of the old an new logging behaviors for an `app.py` of:
```python
from chalice import Chalice

app = Chalice(app_name='logging')

@app.route('/')
def index():
    a = {}
    a['hello']
    return {'hello': 'world'}
```
New behavior:
```bash
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a START RequestId: cc7738dc-f32e-11e7-85d1-9fae6c22151c Version: $LATEST
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a logging - ERROR - Traceback (most recent call last):
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a   File "/var/task/chalice/app.py", line 659, in _get_view_function_response
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a     response = view_function(**function_args)
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a   File "/var/task/app.py", line 9, in index
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a     a['hello']
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a KeyError: 'hello'
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a END RequestId: cc7738dc-f32e-11e7-85d1-9fae6c22151c
2018/01/06/[$LATEST]28c82b8ae895449c9e162a6d897b856a REPORT RequestId: cc7738dc-f32e-11e7-85d1-9fae6c22151c	Duration: 5.73 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 20 MB
```

Old behavior:
```bash
2018/01/06/[$LATEST]a1a18b8f83ea4903b66f184cfb31eaf8 START RequestId: e4238386-f32d-11e7-90a5-517950142513 Version: $LATEST
2018/01/06/[$LATEST]a1a18b8f83ea4903b66f184cfb31eaf8 END RequestId: e4238386-f32d-11e7-90a5-517950142513
2018/01/06/[$LATEST]a1a18b8f83ea4903b66f184cfb31eaf8 REPORT RequestId: e4238386-f32d-11e7-90a5-517950142513	Duration: 0.35 ms	Billed Duration: 100 ms 	Memory Size: 128 MB	Max Memory Used: 20 MB
```

Let me know if you would like anything changed, thanks!
