### PR TITLE
Fix python3 compatibility

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -300,7 +300,7 @@ class Request(object):
     def json_body(self):
         if self.headers.get('content-type', '').startswith('application/json'):
             if self._json_body is None:
-                self._json_body = json.loads(self.raw_body)
+                self._json_body = json.loads(self.raw_body.decode('utf-8'))
             return self._json_body
 
     def to_dict(self):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -289,7 +289,7 @@ def _get_raw_body_from_response_stream(handler):
 
 def _get_body_from_response_stream(handler):
     body = _get_raw_body_from_response_stream(handler)
-    return json.loads(body)
+    return json.loads(body.decode('utf-8'))
 
 
 def set_current_request(handler, method, path, headers=None):


### PR DESCRIPTION
Just a couple minor hiccups when running tests with python3...

  % virtualenv -p python3 venv-chalice
  % source venv-chalice/bin/activate
  % pip install -r requirements-dev.txt

  % py.test tests/unit/
  platform linux -- Python 3.5.2, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
  rootdir: /home/local/ANT/damiajoh/chalice, inifile:
  plugins: cov-2.4.0, hypothesis-3.8.2
  collected 438 items

  tests/unit/test_analyzer.py ......................................................
  tests/unit/test_app.py .....................F.FF....................FF.....................................................
  tests/unit/test_config.py ......................................
  tests/unit/test_local.py F.FF....FFFFFF.F................................................................
  tests/unit/test_logs.py ......
  tests/unit/test_package.py ...................
  tests/unit/test_pipeline.py .............
  tests/unit/test_policy.py ........
  tests/unit/test_utils.py .....
  tests/unit/cli/test_cli.py ..
  tests/unit/deploy/test_deployer.py ..........................................................................
  tests/unit/deploy/test_packager.py ....................
  tests/unit/deploy/test_swagger.py ...................
  ...