### PR TITLE
Shut down 'chalice local' with ctrl+c

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -606,6 +606,8 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     the browswer will simply open another one and sit on it.
     """
 
+    daemon_threads = True
+
 
 class LocalDevServer(object):
     def __init__(self, app_object, config, host, port,


### PR DESCRIPTION
Interesting. Our ThreadingMixIn actually makes shutdown a bit easier than our
previous HTTPServer.

If our local server has handled a request then ThreadingMixIn will have a
spawned thread waiting on socket.recv. To avoid hanging flagging these as
daemon threads so they don't block interpreter shutdown when serve_forever()
is done.

For the previous patch for shutting down a single threaded HTTPServer see
https://github.com/aws/chalice/pull/675.

This should fix https://github.com/aws/chalice/issues/601