### PR TITLE
Add IOpipe to Related Projects section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1151,3 +1151,5 @@ Related Projects
 * `Domovoi <https://github.com/kislyuk/domovoi>`_ - An extension to Chalice that
   handles a variety of AWS Lambda event sources such as SNS push notifications,
   S3 events, and Step Functions state machines.
+* `IOpipe <https://github.com/iopipe/iopipe-python#chalice>`_ An analytics,
+  monitoring and distributed tracing agent that supports Chalice.


### PR DESCRIPTION
We're big fans of Chalice at IOpipe and our agent supports the framework out-of-the-box.

We were also excited to announce Chalice support in our 1.0 release:
http://read.iopipe.com/whats-new-python-agent-1-0-fbc10a85362a