### PR TITLE
Improve support for Cognito Authorization in Local mode

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -306,15 +306,15 @@ class LocalGatewayAuthorizer(object):
         # APIGateway validated request
         if isinstance(authorizer, CognitoUserPoolAuthorizer):
             if ("headers" in lambda_event and
-                        "authorization" in lambda_event["headers"]):
+                "authorization" in lambda_event["headers"]):
                 token = lambda_event["headers"]["authorization"]
                 token = token.replace("bearer=", "")
                 token = token.replace("Bearer ", "")
                 claims = jwt.decode(token, verify=False)
                 auth_result = {"context": {"claims": claims},
-                    "principalId": claims["cognito:username"]}
+                               "principalId": claims["cognito:username"]}
                 lambda_event = self._update_lambda_event(lambda_event,
-                                                            auth_result)
+                                                         auth_result)
         if not isinstance(authorizer, ChaliceAuthorizer):
             # Currently the only supported local authorizer is the
             # BuiltinAuthConfig type. Anything else we will err on the side of

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -306,7 +306,7 @@ class LocalGatewayAuthorizer(object):
         # APIGateway validated request
         if isinstance(authorizer, CognitoUserPoolAuthorizer):
             if ("headers" in lambda_event and
-                "authorization" in lambda_event["headers"]):
+                    "authorization" in lambda_event["headers"]):
                 token = lambda_event["headers"]["authorization"]
                 token = token.replace("bearer=", "")
                 token = token.replace("Bearer ", "")

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -10,6 +10,7 @@ import uuid
 import base64
 import functools
 import warnings
+import jwt
 from collections import namedtuple
 
 from six.moves.BaseHTTPServer import HTTPServer
@@ -20,6 +21,7 @@ from typing import List, Any, Dict, Tuple, Callable, Optional, Union  # noqa
 from chalice.app import Chalice  # noqa
 from chalice.app import CORSConfig  # noqa
 from chalice.app import ChaliceAuthorizer  # noqa
+from chalice.app import CognitoUserPoolAuthorizer
 from chalice.app import RouteEntry  # noqa
 from chalice.app import Request  # noqa
 from chalice.app import AuthResponse  # noqa
@@ -300,6 +302,15 @@ class LocalGatewayAuthorizer(object):
         authorizer = route_entry.authorizer
         if not authorizer:
             return lambda_event, lambda_context
+        #If authorizer is Cognito then try to parse the JWT and simulate an APIGateway validated request
+        if isinstance(authorizer, CognitoUserPoolAuthorizer):
+            if ("headers" in lambda_event and "authorization" in lambda_event["headers"]):
+                token = lambda_event["headers"]["authorization"]
+                token = token.replace("bearer=", "")
+                token = token.replace("Bearer ", "")
+                claims = jwt.decode(token, verify=False)
+                auth_result = {"context": {"claims":claims}, "principalId": claims["cognito:username"]}
+                lambda_event = self._update_lambda_event(lambda_event, auth_result)
         if not isinstance(authorizer, ChaliceAuthorizer):
             # Currently the only supported local authorizer is the
             # BuiltinAuthConfig type. Anything else we will err on the side of

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -10,8 +10,8 @@ import uuid
 import base64
 import functools
 import warnings
-import jwt
 from collections import namedtuple
+import jwt
 
 from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -302,15 +302,19 @@ class LocalGatewayAuthorizer(object):
         authorizer = route_entry.authorizer
         if not authorizer:
             return lambda_event, lambda_context
-        #If authorizer is Cognito then try to parse the JWT and simulate an APIGateway validated request
+        # If authorizer is Cognito then try to parse the JWT and simulate an
+        # APIGateway validated request
         if isinstance(authorizer, CognitoUserPoolAuthorizer):
-            if ("headers" in lambda_event and "authorization" in lambda_event["headers"]):
+            if ("headers" in lambda_event and
+                        "authorization" in lambda_event["headers"]):
                 token = lambda_event["headers"]["authorization"]
                 token = token.replace("bearer=", "")
                 token = token.replace("Bearer ", "")
                 claims = jwt.decode(token, verify=False)
-                auth_result = {"context": {"claims":claims}, "principalId": claims["cognito:username"]}
-                lambda_event = self._update_lambda_event(lambda_event, auth_result)
+                auth_result = {"context": {"claims": claims},
+                    "principalId": claims["cognito:username"]}
+                lambda_event = self._update_lambda_event(lambda_event,
+                                                            auth_result)
         if not isinstance(authorizer, ChaliceAuthorizer):
             # Currently the only supported local authorizer is the
             # BuiltinAuthConfig type. Anything else we will err on the side of

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'botocore>=1.5.40,<2.0.0',
     'typing==3.5.3.0',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<10'
+    'pip>=9,<10',
+    'PyJWT==1.5.3',
+    'cryptography==2.1.4'
 ]
 
 setup(


### PR DESCRIPTION
When running locally all CognitoUserPoolAuthorizer tagged routes are just set to allow requests, which is fine for local mode.  However, if application logic needs to use something from the authorizer context then that code will break in local mode, even if a valid Cognito token is passed.  This is because the content of app.current_request.context["authorizer"]["claims"] is passed in from API Gateway.  This might be the case if you use the Cognito username to link objects in a database to the requesting user.

This PR seeks to add better support for local development when using CognitoUserPoolAuthorizer by parsing the AWS JWT and populating app.current_request.context["authorizer"]["claims"] with the claims in the token.

Some notes:
- The token is not validated or checked against AWS.  Nothing about the signature of the token is checked.  This seems fine since we're just dealing with local mode and the requests are allowed anyway.
- In order to parse JWT tokens we have to add new dependencies on PyJWT and cryptography.  Since we only need this for local mode, could we just add this to requirements-dev.txt and ask users to install those for local development?  This would keep the production deployment package smaller, right?
- I didn't add tests for this case but made sure all existing tests pass.