### PR TITLE
Adding image/jpeg as a default binary content type

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -412,6 +412,7 @@ class APIGateway(object):
         'audio/webm',
         'image/png',
         'image/jpg',
+        'image/jpeg',
         'image/gif',
         'video/ogg',
         'video/mpeg',


### PR DESCRIPTION
I am working on a small scale image processing API and I need to support both content types - `image/jpg` and `image/jpeg` while Chalice allows me to use `image/jpg` only.
This PR adds exactly one line - the new content type with the `e`.