### PR TITLE
Custom JSONEncoder per application

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -36,7 +36,7 @@ class DefaultJSONEncoder(json.JSONEncoder):
         # to support that as well.
         if isinstance(o, decimal.Decimal):
             return float(o)
-        return super().default(o)
+        return super(DefaultJSONEncoder, self).default(o)
 
 
 def error_response(message, error_code, http_status_code):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -315,7 +315,8 @@ class Request(object):
 
 
 class Response(object):
-    def __init__(self, body, headers=None, status_code=200, json_encoder=DefaultJSONEncoder):
+    def __init__(self, body, headers=None, status_code=200,
+                 json_encoder=DefaultJSONEncoder):
         self.body = body
         if headers is None:
             headers = {}
@@ -432,7 +433,8 @@ class Chalice(object):
 
     FORMAT_STRING = '%(name)s - %(levelname)s - %(message)s'
 
-    def __init__(self, app_name, debug=False, configure_logs=True, env=None, json_encoder=DefaultJSONEncoder):
+    def __init__(self, app_name, debug=False, configure_logs=True, env=None,
+                 json_encoder=DefaultJSONEncoder):
         self.app_name = app_name
         self.api = APIGateway()
         self.routes = defaultdict(dict)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -31,12 +31,12 @@ except NameError:
 
 
 class DefaultJSONEncoder(json.JSONEncoder):
-    def default(self, obj):  # pylint: disable=E0202
+    def default(self, o):  # pylint: disable=E0202
         # Lambda will automatically serialize decimals so we need
         # to support that as well.
-        if isinstance(obj, decimal.Decimal):
-            return float(obj)
-        return super().default(obj)
+        if isinstance(o, decimal.Decimal):
+            return float(o)
+        return super().default(o)
 
 
 def error_response(message, error_code, http_status_code):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,6 +42,23 @@ Chalice
          app = Chalice(app_name="appname")
          app.debug = True
 
+    .. attribute:: json_encoder
+
+      A subclass of DefaultJSONEncoder that controls how JSON will be encoded.  By default, this value is
+      ``DefaultJSONEncoder``. Example usage:
+
+      .. code-block:: python
+
+          from chalice import Chalice, DefaultJSONEncoder
+
+          class BetterJsonEncoder(DefaultJSONEncoder):
+            def default(self, o):
+              if isinstance(o, Model): # Complex object that has a to_dict method
+                return o.to_dict()
+              return super().default(o)
+
+         app = Chalice(app_name="appname", json_encoder=BetterJsonEncoder)
+
    .. method:: route(path, \*\*options)
 
       Register a view function for a particular URI path.  This method

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -12,7 +12,7 @@ import six
 
 from chalice import app
 from chalice import NotFoundError
-from chalice.app import APIGateway, Request, Response, handle_decimals
+from chalice.app import APIGateway, Request, Response, DefaultJSONEncoder
 from chalice import __version__ as chalice_version
 
 
@@ -1316,7 +1316,7 @@ def test_http_request_to_dict_is_json_serializable(http_request_kwargs):
     request_dict = request.to_dict()
     # We should always be able to dump the request dict
     # to JSON.
-    assert json.dumps(request_dict, default=handle_decimals)
+    assert json.dumps(request_dict, cls=DefaultJSONEncoder)
 
 
 @given(body=st.text(), headers=STR_MAP,


### PR DESCRIPTION
We are using a homemade ORM to access DynamoDB, and we needed a way to simply return a Model in a view to get it's JSON representation. 

Working with the existent `JSONEncoder` (That only adds Decimal encoding) wasn't very helpful for us. As a workaround we made it possible to plug a custom `JSONEncoder` when creating the application.