### PR TITLE
Fix the example code of error handling in docs

### DIFF
--- a/docs/source/topics/views.rst
+++ b/docs/source/topics/views.rst
@@ -131,7 +131,7 @@ for errors.  For example:
 
     @app.route('/badrequest')
     def badrequest():
-        return Response(message='Plain text error message',
+        return Response(body='Plain text error message',
                         headers={'Content-Type': 'text/plain'},
                         status_code=400)
 


### PR DESCRIPTION
The example code of error handling is written as follows:

```python
return Response(message='Plain text error message',
                headers={'Content-Type': 'text/plain'},
                status_code=400)
```

However, the implementation is:

```python
class Response(object):
    def __init__(self, body, headers=None, status_code=200):
```

There is a difference between document and code, correct name of the first parameter is `body`.