### PR TITLE
Add support for scheduled events in newdeployer

### DIFF
--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -133,3 +133,14 @@ class LambdaFunction(ManagedModel):
 
     def dependencies(self):
         return [self.role, self.deployment_package]
+
+
+@attrs
+class ScheduledEvent(ManagedModel):
+    resource_type = 'scheduled_event'
+    rule_name = attrib()
+    schedule_expression = attrib()
+    lambda_function = attrib()
+
+    def dependencies(self):
+        return [self.lambda_function]

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -210,3 +210,18 @@ class LambdaFunction(ManagedModel):
                  ):
         # type: (...) -> None
         ...
+
+
+class ScheduledEvent(ManagedModel):
+    rule_name = ... # type: str
+    schedule_expression = ... # type: str
+    lambda_function = ... # type: LambdaFunction
+
+    def __init__(self,
+                 resource_name,          # type: str
+                 rule_name,              # type: str
+                 schedule_expression,    # type: str
+                 lambda_function,        # type: LambdaFunction
+                 ):
+        # type: (...) -> None
+        ...

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -276,6 +276,54 @@ class TestPlanLambdaFunction(BasePlannerTests):
         assert role_arn.name == 'myrole-dev_role_arn'
 
 
+class TestPlanScheduledEvent(BasePlannerTests):
+    def test_can_plan_scheduled_event(self):
+        function = create_function_resource('function_name')
+        event = models.ScheduledEvent(
+            resource_name='bar',
+            rule_name='myrulename',
+            schedule_expression='rate(5 minutes)',
+            lambda_function=function,
+        )
+        plan = self.determine_plan(event)
+        assert len(plan) == 5
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='get_or_create_rule_arn',
+                params={
+                    'rule_name': 'myrulename',
+                    'schedule_expression': 'rate(5 minutes)',
+                }
+            )
+        )
+        assert plan[1] == models.StoreValue('rule-arn')
+        self.assert_apicall_equals(
+            plan[2],
+            models.APICall(
+                method_name='connect_rule_to_lambda',
+                params={'rule_name': 'myrulename',
+                        'function_arn': Variable('function_name_lambda_arn')}
+            )
+        )
+        self.assert_apicall_equals(
+            plan[3],
+            models.APICall(
+                method_name='add_permission_for_scheduled_event',
+                params={
+                    'rule_arn': Variable('rule-arn'),
+                    'function_arn': Variable('function_name_lambda_arn'),
+                },
+            )
+        )
+        assert plan[4] == models.RecordResourceValue(
+            resource_type='cloudwatch_event',
+            resource_name='bar',
+            name='rule_name',
+            value='myrulename',
+        )
+
+
 class TestRemoteState(object):
     def setup_method(self):
         self.client = mock.Mock(spec=TypedAWSClient)
@@ -485,4 +533,23 @@ class TestUnreferencedResourcePlanner(object):
             {'function_name': 'my:arn'},
             {'name': 'myrole2'},
             {'name': 'myrole'},
+        ]
+
+    def test_can_delete_scheduled_event(self, sweeper):
+        plan = []
+        deployed = {
+            'resources': [{
+                'name': 'index-event',
+                'resource_type': 'cloudwatch_event',
+                'rule_name': 'app-dev-index-event',
+            }]
+        }
+        config = FakeConfig(deployed)
+        sweeper.execute(plan, config)
+        assert plan == [
+            models.APICall(
+                method_name='delete_rule',
+                params={'rule_name': 'app-dev-index-event'},
+                resource=None,
+            )
         ]


### PR DESCRIPTION
The only significant change from the existing deployer
is that the old deployer treated a scheduled event as
a single resource whereas the new deployer treats it as
two separate resources: a lambda function and a cloudwatch
event.  The main benefit of this approach is that you can
reuse existing logic for building/planning a lambda
function.

Just to give you an idea of what the `deployed.json` looks like,
given this app:

```python
from chalice import Chalice

app = Chalice(app_name='james7')


@app.schedule('rate(100 hours)')
def index(event):
    return {'hello': 'world'}
```

You get this `deployed.json` file:

```json
{
  "stages": {
    "dev": {
      "resources": [
        {
          "role_arn": "arn:aws:iam::123:role/james7-dev",
          "name": "default-role",
          "resource_type": "iam_role"
        },
        {
          "lambda_arn": "arn:aws:lambda:us-west-2:123:function:james7-dev-index",
          "name": "index",
          "resource_type": "lambda_function"
        },
        {
          "rule_name": "james7-dev-index-event",
          "name": "index-event",
          "resource_type": "cloudwatch_event"
        }
      ]
    }
  },
  "schema_version": "2.0"
}
```