### PR TITLE
[new-deployer] Add support for deploying rest APIs

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -387,8 +387,8 @@ class TypedAWSClient(object):
 
     def add_permission_for_apigateway_if_needed(self, function_name,
                                                 region_name, account_id,
-                                                rest_api_id, random_id):
-        # type: (str, str, str, str, str) -> None
+                                                rest_api_id, random_id=None):
+        # type: (str, str, str, str, Optional[str]) -> None
         """Authorize API gateway to invoke a lambda function is needed.
 
         This method will first check if API gateway has permission to call
@@ -396,6 +396,8 @@ class TypedAWSClient(object):
         ``self.add_permission_for_apigateway(...).
 
         """
+        if random_id is None:
+            random_id = self._random_id()
         policy = self.get_function_policy(function_name)
         source_arn = self._build_source_arn_str(region_name, account_id,
                                                 rest_api_id)

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -169,7 +169,8 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
         api_gateway_stage=api_gateway_stage,
     )
     session = factory.create_botocore_session()
-    d = factory.create_new_default_deployer(session=session)
+    d = factory.create_new_default_deployer(session=session,
+                                            config=config)
     deployed_values = d.deploy(config, chalice_stage_name=stage)
     if deployed_values['stages'][stage].get('resources'):
         record_deployed_values(deployed_values, os.path.join(

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -94,9 +94,9 @@ class CLIFactory(object):
         return deployer.create_default_deployer(
             session=session, ui=ui)
 
-    def create_new_default_deployer(self, session):
-        # type: (Session) -> newdeployer.Deployer
-        return newdeployer.create_default_deployer(session)
+    def create_new_default_deployer(self, session, config):
+        # type: (Session, Config) -> newdeployer.Deployer
+        return newdeployer.create_default_deployer(session, config)
 
     def create_deletion_deployer(self, session):
         # type: (Session) -> newdeployer.Deployer

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -24,6 +24,11 @@ class StoreValue(Instruction):
 
 
 @attrs(frozen=True)
+class LoadValue(Instruction):
+    varname = attrib()
+
+
+@attrs(frozen=True)
 class RecordResource(Instruction):
     resource_type = attrib()
     resource_name = attrib()
@@ -53,6 +58,12 @@ class Pop(Instruction):
 @attrs(frozen=True)
 class JPSearch(Instruction):
     expression = attrib()
+
+
+@attrs(frozen=True)
+class BuiltinFunction(Instruction):
+    function_name = attrib()
+    args = attrib()
 
 
 class Model(object):
@@ -140,6 +151,17 @@ class ScheduledEvent(ManagedModel):
     resource_type = 'scheduled_event'
     rule_name = attrib()
     schedule_expression = attrib()
+    lambda_function = attrib()
+
+    def dependencies(self):
+        return [self.lambda_function]
+
+
+@attrs
+class RestAPI(ManagedModel):
+    resource_type = 'rest_api'
+    swagger_doc = attrib()
+    api_gateway_stage = attrib()
     lambda_function = attrib()
 
     def dependencies(self):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -14,16 +14,19 @@ class Instruction(object):
 class APICall(Instruction):
     method_name = attrib()
     params = attrib()
+    output_var = attrib(default=None)
 
 
 @attrs(frozen=True)
 class StoreValue(Instruction):
     name = attrib()
+    value = attrib()
 
 
 @attrs(frozen=True)
-class LoadValue(Instruction):
-    varname = attrib()
+class CopyVariable(Instruction):
+    from_var = attrib()
+    to_var = attrib()
 
 
 @attrs(frozen=True)
@@ -44,24 +47,17 @@ class RecordResourceValue(RecordResource):
 
 
 @attrs(frozen=True)
-class Push(Instruction):
-    value = attrib()
-
-
-@attrs(frozen=True)
-class Pop(Instruction):
-    pass
-
-
-@attrs(frozen=True)
 class JPSearch(Instruction):
     expression = attrib()
+    input_var = attrib()
+    output_var = attrib()
 
 
 @attrs(frozen=True)
 class BuiltinFunction(Instruction):
     function_name = attrib()
     args = attrib()
+    output_var = attrib()
 
 
 class Model(object):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -15,7 +15,6 @@ class Instruction(object):
 class APICall(Instruction):
     method_name = attrib()
     params = attrib()
-    resource = attrib(default=None)
 
 
 @attrs(frozen=True)

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -4,7 +4,6 @@ from attr import attrs, attrib
 
 class Placeholder(enum.Enum):
     BUILD_STAGE = 'build_stage'
-    DEPLOY_STAGE = 'deploy_stage'
 
 
 class Instruction(object):
@@ -119,7 +118,6 @@ class PreCreatedIAMRole(IAMRole):
 @attrs
 class ManagedIAMRole(IAMRole, ManagedModel):
     resource_type = 'iam_role'
-    role_arn = attrib()
     role_name = attrib()
     trust_policy = attrib()
     policy = attrib()

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -32,6 +32,17 @@ class StoreValue(Instruction):
         # type: (...) -> None
         ...
 
+
+class LoadValue(Instruction):
+    varname = ...  # type: str
+
+    def __init__(self,
+                 varname,  # type: str
+                 ):
+        # type: (...) -> None
+        ...
+
+
 class RecordResource(Instruction):
     resource_type = ...  # type: str
     resource_name = ...  # type: str
@@ -92,6 +103,13 @@ class JPSearch(Instruction):
     expression = ...  # type: str
 
     def __init__(self, expression: str) -> None: ...
+
+
+class BuiltinFunction(Instruction):
+    function_name = ... # type: str
+    args = ... # type: List[Any]
+
+    def __init__(self, function_name: str, args: List[Any]) -> None: ...
 
 
 T = TypeVar('T')
@@ -221,6 +239,21 @@ class ScheduledEvent(ManagedModel):
                  resource_name,          # type: str
                  rule_name,              # type: str
                  schedule_expression,    # type: str
+                 lambda_function,        # type: LambdaFunction
+                 ):
+        # type: (...) -> None
+        ...
+
+
+class RestAPI(ManagedModel):
+    swagger_doc = ... # type: Dict[str, Any]
+    api_gateway_stage = ... # type: str
+    lambda_function = ... # type: LambdaFunction
+
+    def __init__(self,
+                 resource_name,          # type: str
+                 swagger_doc,            # type: DV[Dict[str, Any]]
+                 api_gateway_stage,      # type: str
                  lambda_function,        # type: LambdaFunction
                  ):
         # type: (...) -> None

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -12,10 +12,12 @@ class Instruction:
 class APICall(Instruction):
     method_name = ...  # type: str
     params = ...  # type: Dict[str, Any]
+    output_var = ...  # type: Optional[str]
 
     def __init__(self,
                  method_name,           # type: str
                  params,                # type: Dict[str, Any]
+                 output_var=None,       # type: Optional[str]
                  ):
         # type: (...) -> None
         ...
@@ -23,19 +25,23 @@ class APICall(Instruction):
 
 class StoreValue(Instruction):
     name = ...  # type: str
+    value = ...  # type: Any
 
     def __init__(self,
-                 name,  # type: str
+                 name,   # type: str
+                 value,  # type: Any
                  ):
         # type: (...) -> None
         ...
 
 
-class LoadValue(Instruction):
-    varname = ...  # type: str
+class CopyVariable(Instruction):
+    from_var = ...  # type: str
+    to_var = ...  # type: str
 
     def __init__(self,
-                 varname,  # type: str
+                 from_var,  # type: str
+                 to_var,    # type: str
                  ):
         # type: (...) -> None
         ...
@@ -99,15 +105,30 @@ class Pop(Instruction):
 
 class JPSearch(Instruction):
     expression = ...  # type: str
+    input_var = ...  # type: str
+    output_var = ...  # type: str
 
-    def __init__(self, expression: str) -> None: ...
+    def __init__(self,
+                 expression,    # type: str
+                 input_var,     # type: str
+                 output_var,    # type: str
+                 ):
+        # type: (...) -> None
+        ...
 
 
 class BuiltinFunction(Instruction):
     function_name = ... # type: str
     args = ... # type: List[Any]
+    output_var = ...  # type: str
 
-    def __init__(self, function_name: str, args: List[Any]) -> None: ...
+    def __init__(self,
+                 function_name,  # type: str
+                 args,           # type: List[Any]
+                 output_var,     # type: str
+                 ):
+        # type: (...) -> None
+        ...
 
 
 T = TypeVar('T')

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -3,7 +3,6 @@ import enum
 
 class Placeholder(enum.Enum):
     BUILD_STAGE = 'build_stage'
-    DEPLOY_STAGE = 'deploy_stage'
 
 
 class Instruction:
@@ -186,14 +185,12 @@ class PreCreatedIAMRole(IAMRole):
 
 
 class ManagedIAMRole(IAMRole, ManagedModel):
-    role_arn = ... # type: DV[str]
     role_name = ... # type: str
     trust_policy = ... # type: Dict[str, Any]
     policy = ... # type: IAMPolicy
 
     def __init__(self,
                  resource_name,  # type: str
-                 role_arn,       # type: DV[str]
                  role_name,      # type: str
                  trust_policy,   # type: Dict[str, Any]
                  policy,         # type: IAMPolicy

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -13,15 +13,14 @@ class Instruction:
 class APICall(Instruction):
     method_name = ...  # type: str
     params = ...  # type: Dict[str, Any]
-    resource = ...  # type: Optional[ManagedModel]
 
     def __init__(self,
                  method_name,           # type: str
                  params,                # type: Dict[str, Any]
-                 resource=None,         # type: Optional[ManagedModel]
                  ):
         # type: (...) -> None
         ...
+
 
 class StoreValue(Instruction):
     name = ...  # type: str

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -223,10 +223,10 @@ class ApplicationGraphBuilder(object):
         resources = []  # type: List[models.Model]
         deployment = models.DeploymentPackage(models.Placeholder.BUILD_STAGE)
         for function in config.chalice_app.pure_lambda_functions:
-            resource = self._create_lambda_model(config, deployment,
-                                                 function.name,
-                                                 function.handler_string,
-                                                 stage_name)
+            resource = self._create_lambda_model(
+                config=config, deployment=deployment,
+                name=function.name, handler_name=function.handler_string,
+                stage_name=stage_name)
             resources.append(resource)
         for event_source in config.chalice_app.event_sources:
             scheduled_event = self._create_event_model(
@@ -247,8 +247,8 @@ class ApplicationGraphBuilder(object):
         # type: (...) -> models.RestAPI
         resource_name = config.app_name
         lambda_function = self._create_lambda_model(
-            config, deployment, resource_name,
-            'app.app', stage_name
+            config=config, deployment=deployment, name=resource_name,
+            handler_name='app.app', stage_name=stage_name
         )
         return models.RestAPI(
             resource_name='rest_api',
@@ -265,8 +265,8 @@ class ApplicationGraphBuilder(object):
                             ):
         # type: (...) -> models.ScheduledEvent
         lambda_function = self._create_lambda_model(
-            config, deployment, event_source.name,
-            event_source.handler_string, stage_name
+            config=config, deployment=deployment, name=event_source.name,
+            handler_name=event_source.handler_string, stage_name=stage_name
         )
         # Resource names must be unique across a chalice app.
         # However, in the original deployer code, the cloudwatch

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -365,7 +365,6 @@ class ApplicationGraphBuilder(object):
                 document=models.Placeholder.BUILD_STAGE)
         return models.ManagedIAMRole(
             resource_name=resource_name,
-            role_arn=models.Placeholder.DEPLOY_STAGE,
             role_name=role_name,
             trust_policy=LAMBDA_TRUST_POLICY,
             policy=policy,

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -594,6 +594,9 @@ class Executor(object):
                 'account_id': parts[4],
             }
             self.stack.append(result)
+        else:
+            raise ValueError("Unknown builtin function: %s"
+                             % instruction.function_name)
 
     def _resolve_variables(self, api_call):
         # type: (models.APICall) -> Dict[str, Any]

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -185,7 +185,6 @@ class PlanStage(object):
                 models.APICall(
                     method_name='create_function',
                     params=params,
-                    resource=resource,
                 ),
                 models.StoreValue(name=varname),
                 models.RecordResourceVariable(
@@ -212,7 +211,6 @@ class PlanStage(object):
             models.APICall(
                 method_name='update_function',
                 params=params,
-                resource=resource,
             ),
             models.JPSearch('FunctionArn'),
             models.StoreValue(name=varname),
@@ -236,7 +234,6 @@ class PlanStage(object):
                     params={'name': resource.role_name,
                             'trust_policy': resource.trust_policy,
                             'policy': document},
-                    resource=resource
                 ),
                 models.StoreValue(varname),
                 models.RecordResourceVariable(
@@ -257,7 +254,6 @@ class PlanStage(object):
                 params={'role_name': resource.role_name,
                         'policy_name': resource.role_name,
                         'policy_document': document},
-                resource=resource
             ),
             models.RecordResourceValue(
                 resource_type='iam_role',

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -98,15 +98,9 @@ class UnreferencedResourcePlanner(object):
                     params={'function_name': resource_values['lambda_arn']},)
                 plan.append(apicall)
             elif resource_values['resource_type'] == 'iam_role':
-                # TODO: Consider adding the role_name to the deployed.json.
-                # This is a separate value than the 'name' of the resource.
-                # For now we have to parse out the role name from the role_arn
-                # and it would be better if we could get the role name
-                # directly.
-                v = resource_values['role_arn'].rsplit('/')[1]
                 apicall = models.APICall(
                     method_name='delete_role',
-                    params={'name': v},
+                    params={'name': resource_values['role_name']},
                 )
                 plan.append(apicall)
             elif resource_values['resource_type'] == 'cloudwatch_event':
@@ -225,6 +219,12 @@ class PlanStage(object):
                     resource_name=resource.resource_name,
                     name='role_arn',
                     variable_name=varname,
+                ),
+                models.RecordResourceValue(
+                    resource_type='iam_role',
+                    resource_name=resource.resource_name,
+                    name='role_name',
+                    value=resource.role_name,
                 )
             ]
         role_arn = self._remote_state.resource_deployed_values(
@@ -243,6 +243,12 @@ class PlanStage(object):
                 resource_name=resource.resource_name,
                 name='role_arn',
                 variable_name=varname,
+            ),
+            models.RecordResourceValue(
+                resource_type='iam_role',
+                resource_name=resource.resource_name,
+                name='role_name',
+                value=resource.role_name,
             )
         ]
 

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -226,6 +226,10 @@ class SwaggerGenerator(object):
 
 
 class CFNSwaggerGenerator(SwaggerGenerator):
+    def __init__(self):
+        # type: () -> None
+        pass
+
     def _uri(self, lambda_arn=None):
         # type: (Optional[str]) -> Any
         # TODO: Does this have to be return type Any?

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -26,7 +26,7 @@ def create_app_packager(config):
         # We're add place holder values that will be filled in once the
         # lambda function is deployed.
         SAMTemplateGenerator(
-            CFNSwaggerGenerator('{region}', {}),
+            CFNSwaggerGenerator(),
             ApplicationPolicyHandler(
                 osutils, AppPolicyGenerator(osutils))),
         LambdaDeploymentPackager(

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -15,6 +15,15 @@ from chalice.awsclient import DeploymentPackageTooLargeError
 from chalice.awsclient import LambdaClientError
 
 
+class RandomIDTypedAWSClient(TypedAWSClient):
+    def __init__(self, session, random_id):
+        super(RandomIDTypedAWSClient, self).__init__(session)
+        self._fixed_random_id = random_id
+
+    def _random_id(self):
+        return self._fixed_random_id
+
+
 def test_region_name_is_exposed(stubbed_session):
     assert TypedAWSClient(stubbed_session).region_name == 'us-west-2'
 
@@ -941,11 +950,11 @@ class TestAddPermissionsForAPIGateway(object):
             'function_name', 'us-west-2', '123', 'rest-api-id')
         stubbed_session.verify_stubs()
 
-    def should_call_add_permission(self, lambda_stub):
+    def should_call_add_permission(self, lambda_stub, random_id='random-id'):
         lambda_stub.add_permission(
             Action='lambda:InvokeFunction',
             FunctionName='name',
-            StatementId='random-id',
+            StatementId=random_id,
             Principal='apigateway.amazonaws.com',
             SourceArn='arn:aws:execute-api:us-west-2:123:rest-api-id/*',
         ).returns({})
@@ -959,6 +968,16 @@ class TestAddPermissionsForAPIGateway(object):
         client = TypedAWSClient(stubbed_session)
         client.add_permission_for_apigateway_if_needed(
             'name', 'us-west-2', '123', 'rest-api-id', 'random-id')
+        stubbed_session.verify_stubs()
+
+    def test_can_add_permission_random_id_optional(self, stubbed_session):
+        lambda_stub = stubbed_session.stub('lambda')
+        lambda_stub.get_policy(FunctionName='name').returns({'Policy': '{}'})
+        self.should_call_add_permission(lambda_stub, 'my-random-id')
+        stubbed_session.activate_stubs()
+        client = RandomIDTypedAWSClient(stubbed_session, 'my-random-id')
+        client.add_permission_for_apigateway_if_needed(
+            'name', 'us-west-2', '123', 'rest-api-id')
         stubbed_session.verify_stubs()
 
     def test_can_add_permission_for_apigateway_not_needed(self,

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -15,9 +15,9 @@ from chalice.awsclient import DeploymentPackageTooLargeError
 from chalice.awsclient import LambdaClientError
 
 
-class RandomIDTypedAWSClient(TypedAWSClient):
+class FixedIDTypedAWSClient(TypedAWSClient):
     def __init__(self, session, random_id):
-        super(RandomIDTypedAWSClient, self).__init__(session)
+        super(FixedIDTypedAWSClient, self).__init__(session)
         self._fixed_random_id = random_id
 
     def _random_id(self):
@@ -950,11 +950,12 @@ class TestAddPermissionsForAPIGateway(object):
             'function_name', 'us-west-2', '123', 'rest-api-id')
         stubbed_session.verify_stubs()
 
-    def should_call_add_permission(self, lambda_stub, random_id='random-id'):
+    def should_call_add_permission(self, lambda_stub,
+                                   statement_id='random-id'):
         lambda_stub.add_permission(
             Action='lambda:InvokeFunction',
             FunctionName='name',
-            StatementId=random_id,
+            StatementId=statement_id,
             Principal='apigateway.amazonaws.com',
             SourceArn='arn:aws:execute-api:us-west-2:123:rest-api-id/*',
         ).returns({})
@@ -975,7 +976,7 @@ class TestAddPermissionsForAPIGateway(object):
         lambda_stub.get_policy(FunctionName='name').returns({'Policy': '{}'})
         self.should_call_add_permission(lambda_stub, 'my-random-id')
         stubbed_session.activate_stubs()
-        client = RandomIDTypedAWSClient(stubbed_session, 'my-random-id')
+        client = FixedIDTypedAWSClient(stubbed_session, 'my-random-id')
         client.add_permission_for_apigateway_if_needed(
             'name', 'us-west-2', '123', 'rest-api-id')
         stubbed_session.verify_stubs()

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -291,10 +291,12 @@ def test_can_delete_app(tmpdir):
                 'resources': [
                     {'name': 'role-index',
                      'resource_type': 'iam_role',
+                     'role_name': 'testapp-dev-index',
                      'role_arn': 'arn:aws:iam::1:role/testapp-dev-index'},
                     {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-index',
                      'name': 'index', 'resource_type': 'lambda_function'},
                     {'name': 'role-james', 'resource_type': 'iam_role',
+                     'role_name': 'testapp-dev-foo',
                      'role_arn': 'arn:aws:iam::1:role/testapp-dev-foo'},
                     {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-foo',
                      'name': 'james', 'resource_type': 'lambda_function'}

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -665,7 +665,7 @@ class TestExecutor(object):
     def test_can_return_created_resources(self):
         function = create_function_resource('myfunction')
         params = {}
-        call = APICall('create_function', params, resource=function)
+        call = APICall('create_function', params)
         self.mock_client.create_function.return_value = 'function:arn'
         record_instruction = RecordResource(
             resource_type='lambda_function',
@@ -715,8 +715,7 @@ class TestExecutor(object):
     def test_validates_no_unresolved_deploy_vars(self):
         function = create_function_resource('myfunction')
         params = {'zip_contents': models.Placeholder.BUILD_STAGE}
-        call = APICall('create_function', params,
-                       resource=function)
+        call = APICall('create_function', params)
         self.mock_client.create_function.return_value = 'function:arn'
         # We should raise an exception because a param has
         # a models.Placeholder.BUILD_STAGE value which should have

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -801,6 +801,15 @@ class TestExecutor(object):
              'service': 'lambda'}
         ]
 
+    def test_errors_out_on_unknown_function(self):
+        with pytest.raises(ValueError):
+            self.executor.execute([
+                BuiltinFunction(
+                    function_name='unknown_foo',
+                    args=[]
+                )
+            ])
+
 
 def test_build_stage():
     first = mock.Mock(spec=BaseDeployStep)

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -710,6 +710,49 @@ class TestExecutor(object):
             'myfunction_arn': 'arn:foo',
         }]
 
+    def test_can_aggregate_multiple_resource_values(self):
+        self.executor.execute([
+            RecordResourceValue(
+                resource_type='lambda_function',
+                resource_name='myfunction',
+                name='key1',
+                value='value1',
+            ),
+            RecordResourceValue(
+                resource_type='lambda_function',
+                resource_name='myfunction',
+                name='key2',
+                value='value2',
+            )
+        ])
+        assert self.executor.resource_values == [{
+            'name': 'myfunction',
+            'resource_type': 'lambda_function',
+            'key1': 'value1',
+            'key2': 'value2',
+        }]
+
+    def test_new_keys_override_old_keys(self):
+        self.executor.execute([
+            RecordResourceValue(
+                resource_type='lambda_function',
+                resource_name='myfunction',
+                name='key1',
+                value='OLD',
+            ),
+            RecordResourceValue(
+                resource_type='lambda_function',
+                resource_name='myfunction',
+                name='key1',
+                value='NEW',
+            )
+        ])
+        assert self.executor.resource_values == [{
+            'name': 'myfunction',
+            'resource_type': 'lambda_function',
+            'key1': 'NEW',
+        }]
+
     def test_validates_no_unresolved_deploy_vars(self):
         params = {'zip_contents': models.Placeholder.BUILD_STAGE}
         call = APICall('create_function', params)

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -247,7 +247,6 @@ class TestApplicationGraphBuilder(object):
         assert isinstance(role, models.ManagedIAMRole)
         assert role == models.ManagedIAMRole(
             resource_name='default-role',
-            role_arn=models.Placeholder.DEPLOY_STAGE,
             role_name='lambda-only-dev',
             trust_policy=LAMBDA_TRUST_POLICY,
             policy=models.AutoGenIAMPolicy(models.Placeholder.BUILD_STAGE),
@@ -663,7 +662,6 @@ class TestExecutor(object):
         )
 
     def test_can_return_created_resources(self):
-        function = create_function_resource('myfunction')
         params = {}
         call = APICall('create_function', params)
         self.mock_client.create_function.return_value = 'function:arn'
@@ -713,7 +711,6 @@ class TestExecutor(object):
         }]
 
     def test_validates_no_unresolved_deploy_vars(self):
-        function = create_function_resource('myfunction')
         params = {'zip_contents': models.Placeholder.BUILD_STAGE}
         call = APICall('create_function', params)
         self.mock_client.create_function.return_value = 'function:arn'

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -516,6 +516,16 @@ class TestRemoteState(object):
         with pytest.raises(ValueError):
             remote_state.resource_deployed_values(rest_api)
 
+    def test_unknown_model_type_raises_error(self):
+
+        @attr.attrs
+        class Foo(models.ManagedModel):
+            resource_type = 'foo'
+
+        foo = Foo(resource_name='myfoo')
+        with pytest.raises(ValueError):
+            self.remote_state.resource_exists(foo)
+
 
 class TestUnreferencedResourcePlanner(object):
     def setup_method(self):

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -90,7 +90,6 @@ class BasePlannerTests(object):
         # compared.
         assert expected.method_name == actual_api_call.method_name
         assert expected.params == actual_api_call.params
-        assert expected.resource == actual_api_call.resource
 
     def determine_plan(self, resource):
         planner = PlanStage(self.remote_state, self.osutils)
@@ -114,7 +113,6 @@ class TestPlanManagedRole(BasePlannerTests):
             params={'name': 'myrole',
                     'trust_policy': {'trust': 'policy'},
                     'policy': {'iam': 'policy'}},
-            resource=resource
         )
         self.assert_apicall_equals(plan[0], expected)
 
@@ -134,7 +132,6 @@ class TestPlanManagedRole(BasePlannerTests):
             params={'name': 'myrole',
                     'trust_policy': {'trust': 'policy'},
                     'policy': {'iam': 'policy'}},
-            resource=resource,
         )
         self.assert_apicall_equals(plan[0], expected)
 
@@ -155,7 +152,6 @@ class TestPlanManagedRole(BasePlannerTests):
                 params={'role_name': 'myrole',
                         'policy_name': 'myrole',
                         'policy_document': {'role': 'policy'}},
-                resource=role,
             )
         )
         assert plan[-1].value == 'myrole:arn'
@@ -178,7 +174,6 @@ class TestPlanManagedRole(BasePlannerTests):
                 params={'role_name': 'myrole',
                         'policy_name': 'myrole',
                         'policy_document': {'iam': 'policy'}},
-                resource=role,
             )
         )
 
@@ -207,7 +202,6 @@ class TestPlanManagedRole(BasePlannerTests):
                 params={'role_name': 'myrole',
                         'policy_name': 'myrole',
                         'policy_document': {'role': 'policy'}},
-                resource=role,
             )
         )
 
@@ -230,7 +224,6 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'timeout': 60,
                 'memory_size': 128,
             },
-            resource=function,
         )
         self.assert_apicall_equals(plan[0], expected)
 
@@ -254,7 +247,6 @@ class TestPlanLambdaFunction(BasePlannerTests):
         expected_params = dict(memory_size=256, **existing_params)
         expected = models.APICall(
             method_name='update_function',
-            resource=function,
             params=expected_params,
         )
         self.assert_apicall_equals(plan[0], expected)
@@ -272,7 +264,6 @@ class TestPlanLambdaFunction(BasePlannerTests):
         plan = self.determine_plan(function)
         call = plan[0]
         assert call.method_name == 'create_function'
-        assert call.resource == function
         # The params are verified in test_can_create_function,
         # we just care about how the role_arn Variable is constructed.
         role_arn = call.params['role_arn']
@@ -718,7 +709,6 @@ class TestUnreferencedResourcePlanner(object):
             models.APICall(
                 method_name='delete_rule',
                 params={'rule_name': 'app-dev-index-event'},
-                resource=None,
             )
         ]
 
@@ -737,6 +727,5 @@ class TestUnreferencedResourcePlanner(object):
             models.APICall(
                 method_name='delete_rest_api',
                 params={'rest_api_id': 'my_rest_api_id'},
-                resource=None,
             )
         ]

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -161,7 +161,8 @@ class TestPlanManagedRole(BasePlannerTests):
                         'policy_document': {'role': 'policy'}},
             )
         )
-        assert plan[-1].variable_name == 'myrole_role_arn'
+        assert plan[-2].variable_name == 'myrole_role_arn'
+        assert plan[-1].value == 'myrole'
 
     def test_can_update_file_based_policy(self):
         role = models.ManagedIAMRole(
@@ -612,6 +613,7 @@ class TestUnreferencedResourcePlanner(object):
             'resources': [{
                 'name': 'myrole',
                 'resource_type': 'iam_role',
+                'role_name': 'myrole',
                 'role_arn': 'arn:role/myrole',
             }]
         }
@@ -632,11 +634,13 @@ class TestUnreferencedResourcePlanner(object):
                 {
                     'name': 'myrole',
                     'resource_type': 'iam_role',
+                    'role_name': 'myrole',
                     'role_arn': 'arn:role/myrole',
                 },
                 {
                     'name': 'myrole2',
                     'resource_type': 'iam_role',
+                    'role_name': 'myrole2',
                     'role_arn': 'arn:role/myrole2',
                 },
                 {

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -476,10 +476,7 @@ def test_will_default_to_function_name_for_auth(sample_app):
 
 
 def test_will_custom_auth_with_cfn(sample_app):
-    swagger_gen = CFNSwaggerGenerator(
-        region='us-west-2',
-        deployed_resources={}
-    )
+    swagger_gen = CFNSwaggerGenerator()
 
     # No "name=" kwarg provided should default
     # to a name of "auth".


### PR DESCRIPTION
This adds a new RestAPI model as well as the needed
code to deploy/update/delete an API Gateway RestAPI.

I had to add new opcodes to get this working:

* BuiltinFunction - needed to parse ARNs
* LoadValue - set a value to a var name

Additionally, I expanded the variable substitution to crawl nested structures.
This was needed because the Swagger generation needs a reference to the lambda
arn in a deeply nested structure in the swagger doc.  I also added a new type
of variable, "StringFormat", which accepts a list of variables and renders a
string based on a format string.

This is really just a shorthand.  It's possible to implement this in
terms of a `BuiltinFunction` with the result being stored as a var.

As an example, given this app:

```python
from chalice import Chalice

app = Chalice(app_name='james19')


@app.route('/')
def index():
    return {'hello': 'world'}

```

You'll get this new deployed.json file:

```json
{
  "stages": {
    "dev": {
      "resources": [
        {
          "role_arn": "arn:aws:iam::1234:role/james19-dev",
          "name": "default-role",
          "resource_type": "iam_role"
        },
        {
          "lambda_arn": "arn:aws:lambda:us-west-2:1234:function:james19-dev-james19",
          "name": "james19",
          "resource_type": "lambda_function"
        },
        {
          "rest_api_id": "my_rest_api_id",
          "name": "rest_api",
          "resource_type": "rest_api"
        }
      ]
    }
  },
  "schema_version": "2.0"
}
```

NOTE: If you're trying this out locally, the UI hasn't been plumbed back in, so it won't print out the full URL to test.  This will be a future PR.