### PR TITLE
[new-deployer] Update integ tests to use new deployer

### DIFF
--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -245,9 +245,8 @@ class ApplicationGraphBuilder(object):
                                stage_name,    # type: str
                                ):
         # type: (...) -> models.RestAPI
-        resource_name = config.app_name
         lambda_function = self._create_lambda_model(
-            config=config, deployment=deployment, name=resource_name,
+            config=config, deployment=deployment, name='api_handler',
             handler_name='app.app', stage_name=stage_name
         )
         authorizers = []

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -146,8 +146,7 @@ def _deploy_app(temp_dirname):
         autogen_policy=True
     )
     session = factory.create_botocore_session()
-    d = factory.create_new_default_deployer(
-        factory.create_botocore_session(), config)
+    d = factory.create_new_default_deployer(session, config)
     region = session.get_config_variable('region')
     deployed_stages = _deploy_with_retries(d, config)
     deployed = deployed_stages['stages']['dev']

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -12,6 +12,7 @@ import requests
 from chalice.cli.factory import CLIFactory
 from chalice.utils import record_deployed_values, OSUtils
 from chalice.deploy.deployer import ChaliceDeploymentError
+from chalice.config import DeployedResources2
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -42,29 +43,29 @@ class SmokeTestApplication(object):
     # Seconds to wait between poll attempts after redeploy.
     _POLLING_DELAY = 5
 
-    def __init__(self, url, deployed_values, stage_name, app_name,
-                 app_dir):
-        if url.endswith('/'):
-            url = url[:-1]
-        self.url = url
-        self._deployed_values = deployed_values
+    def __init__(self, deployed_values, stage_name, app_name,
+                 app_dir, region):
+        self._deployed_resources = DeployedResources2(deployed_values)
         self.stage_name = stage_name
         self.app_name = app_name
         # The name of the tmpdir where the app is copied.
         self.app_dir = app_dir
         self._has_redeployed = False
+        self._region = region
+
+    @property
+    def url(self):
+        return (
+            "https://{rest_api_id}.execute-api.{region}.amazonaws.com/"
+            "{api_gateway_stage}".format(rest_api_id=self.rest_api_id,
+                                         region=self._region,
+                                         api_gateway_stage='api')
+        )
 
     @property
     def rest_api_id(self):
-        return self._deployed_values['rest_api_id']
-
-    @property
-    def region_name(self):
-        return self._deployed_values['region_name']
-
-    @property
-    def api_handler_arn(self):
-        return self._deployed_values['api_handler_arn']
+        return self._deployed_resources.resource_values(
+            'rest_api')['rest_api_id']
 
     def get_json(self, url):
         if not url.startswith('/'):
@@ -123,7 +124,7 @@ def smoke_test_app(tmpdir_factory):
     _inject_app_name(tmpdir)
     application = _deploy_app(tmpdir)
     yield application
-    _delete_app(application)
+    _delete_app(application, tmpdir)
     os.environ.pop('APP_NAME')
 
 
@@ -144,15 +145,14 @@ def _deploy_app(temp_dirname):
         chalice_stage_name='dev',
         autogen_policy=True
     )
-    d = factory.create_default_deployer(
-        factory.create_botocore_session(), None)
+    session = factory.create_botocore_session()
+    d = factory.create_new_default_deployer(
+        factory.create_botocore_session(), config)
+    region = session.get_config_variable('region')
     deployed_stages = _deploy_with_retries(d, config)
-    deployed = deployed_stages['dev']
-    url = (
-        "https://{rest_api_id}.execute-api.{region}.amazonaws.com/"
-        "{api_gateway_stage}/".format(**deployed))
+    deployed = deployed_stages['stages']['dev']
     application = SmokeTestApplication(
-        url=url,
+        region=region,
         deployed_values=deployed,
         stage_name='dev',
         app_name=RANDOM_APP_NAME,
@@ -168,7 +168,7 @@ def _deploy_app(temp_dirname):
 @retry(max_attempts=10, delay=20)
 def _deploy_with_retries(deployer, config):
     try:
-        deployed_stages = deployer.deploy(config)
+        deployed_stages = deployer.deploy(config, 'dev')
         return deployed_stages
     except ChaliceDeploymentError as e:
         # API Gateway aggressively throttles deployments.
@@ -186,22 +186,15 @@ def _get_error_code_from_exception(exception):
     return error_response.get('Error', {}).get('Code')
 
 
-def _delete_app(application):
-    s = botocore.session.get_session()
-    lambda_client = s.create_client('lambda')
-    # You can use either the function name of the function ARN
-    # for this argument, despite the name being FunctionName.
-    lambda_client.delete_function(FunctionName=application.api_handler_arn)
-
-    iam = s.create_client('iam')
-    role_name = application.app_name + '-' + application.stage_name
-    policies = iam.list_role_policies(RoleName=role_name)
-    for name in policies['PolicyNames']:
-        iam.delete_role_policy(RoleName=role_name, PolicyName=name)
-    iam.delete_role(RoleName=role_name)
-
-    apig = s.create_client('apigateway')
-    apig.delete_rest_api(restApiId=application.rest_api_id)
+def _delete_app(application, temp_dirname):
+    factory = CLIFactory(temp_dirname)
+    config = factory.create_config_obj(
+        chalice_stage_name='dev',
+        autogen_policy=True
+    )
+    session = factory.create_botocore_session()
+    d = factory.create_deletion_deployer(session)
+    _deploy_with_retries(d, config)
 
 
 def test_returns_simple_response(smoke_test_app):

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -277,7 +277,7 @@ class TestApplicationGraphBuilder(object):
         assert isinstance(rest_api, models.RestAPI)
         assert rest_api.resource_name == 'rest_api'
         assert rest_api.api_gateway_stage == 'api'
-        assert rest_api.lambda_function.resource_name == 'rest-api-app'
+        assert rest_api.lambda_function.resource_name == 'api_handler'
         # The swagger document is validated elsewhere so we just
         # make sure it looks right.
         assert rest_api.swagger_doc == models.Placeholder.BUILD_STAGE

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -400,6 +400,13 @@ class TestPlanRestAPI(BasePlannerTests):
                         'account_id': Variable('account_id'),
                         'rest_api_id': Variable('rest_api_id')},
             ),
+            models.APICall(
+                method_name='add_permission_for_apigateway_if_needed',
+                params={'rest_api_id': Variable("rest_api_id"),
+                        'region_name': Variable("region_name"),
+                        'account_id': Variable("account_id"),
+                        'function_name': 'appname-dev-function_name'},
+                output_var=None)
         ]
 
 


### PR DESCRIPTION
As part of this change, I also had to make a fix to the built in
auths because the permissions weren't being updated appropriately.

The integ tests now pass.

```
$ py.test tests/integration/
================================================================================ test session starts ================================================================================
platform darwin -- Python 2.7.14, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: ./, inifile:
plugins: cov-2.4.0, hypothesis-3.8.2
collected 37 items

tests/integration/test_cli.py .
tests/integration/test_features.py ..............................
tests/integration/test_local.py ....
tests/integration/test_package.py ..
```