### PR TITLE
[new-deployer] Add back print statements during deploy

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -170,7 +170,8 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
     )
     session = factory.create_botocore_session()
     d = factory.create_new_default_deployer(session=session,
-                                            config=config)
+                                            config=config,
+                                            ui=UI())
     deployed_values = d.deploy(config, chalice_stage_name=stage)
     if deployed_values['stages'][stage].get('resources'):
         record_deployed_values(deployed_values, os.path.join(
@@ -191,7 +192,7 @@ def delete_new(ctx, profile, stage):
     factory.profile = profile
     config = factory.create_config_obj(chalice_stage_name=stage)
     session = factory.create_botocore_session()
-    d = factory.create_deletion_deployer(session=session)
+    d = factory.create_deletion_deployer(session=session, ui=UI())
     deployed_values = d.deploy(config, chalice_stage_name=stage)
     record_deployed_values(deployed_values, os.path.join(
         config.project_dir, '.chalice', 'deployed.json'))

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -94,13 +94,14 @@ class CLIFactory(object):
         return deployer.create_default_deployer(
             session=session, ui=ui)
 
-    def create_new_default_deployer(self, session, config):
-        # type: (Session, Config) -> newdeployer.Deployer
-        return newdeployer.create_default_deployer(session, config)
+    def create_new_default_deployer(self, session, config, ui):
+        # type: (Session, Config, UI) -> newdeployer.Deployer
+        return newdeployer.create_default_deployer(session, config, ui)
 
-    def create_deletion_deployer(self, session):
-        # type: (Session) -> newdeployer.Deployer
-        return newdeployer.create_deletion_deployer(TypedAWSClient(session))
+    def create_deletion_deployer(self, session, ui):
+        # type: (Session, UI) -> newdeployer.Deployer
+        return newdeployer.create_deletion_deployer(
+            TypedAWSClient(session), ui)
 
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None,

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -10,6 +10,12 @@ class Instruction(object):
     pass
 
 
+@attrs
+class Plan(object):
+    instructions = attrib(default=Factory(list))
+    messages = attrib(default=Factory(dict))
+
+
 @attrs(frozen=True)
 class APICall(Instruction):
     method_name = attrib()

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -12,11 +12,11 @@ class Instruction:
 
 class Plan:
     instructions = ...  # type: List[Instruction]
-    messages = ...  # type: Dict[Instruction, str]
+    messages = ...  # type: Dict[int, str]
 
     def __init__(self,
                  instructions,  # type: List[Instruction]
-                 messages,      # type: Dict[Instruction, str]
+                 messages,      # type: Dict[int, str]
                  ):
         # type: (...) -> None
         ...

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -1,12 +1,25 @@
 from typing import List, Dict, Any, TypeVar, Union, Optional
 import enum
 
+
 class Placeholder(enum.Enum):
     BUILD_STAGE = 'build_stage'
 
 
 class Instruction:
     pass
+
+
+class Plan:
+    instructions = ...  # type: List[Instruction]
+    messages = ...  # type: Dict[Instruction, str]
+
+    def __init__(self,
+                 instructions,  # type: List[Instruction]
+                 messages,      # type: Dict[Instruction, str]
+                 ):
+        # type: (...) -> None
+        ...
 
 
 class APICall(Instruction):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -512,9 +512,9 @@ class Executor(object):
         self._resource_value_index = {}  # type: Dict[str, Any]
         self._variable_resolver = VariableResolver()
 
-    def execute(self, api_calls):
-        # type: (List[models.Instruction]) -> None
-        for instruction in api_calls:
+    def execute(self, plan):
+        # type: (models.Plan) -> None
+        for instruction in plan.instructions:
             # TODO: Don't error out on unknown instruction
             getattr(self, '_do_%s' % instruction.__class__.__name__.lower(),
                     lambda x: None)(instruction)

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -105,8 +105,8 @@ from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
 from chalice.awsclient import TypedAWSClient
 
 
-def create_default_deployer(session, config):
-    # type: (Session, Config) -> Deployer
+def create_default_deployer(session, config, ui):
+    # type: (Session, Config, UI) -> Deployer
     client = TypedAWSClient(session)
     osutils = OSUtils()
     pip_runner = PipRunner(pip=SubprocessPip(osutils=osutils),
@@ -143,19 +143,19 @@ def create_default_deployer(session, config):
                 client, config.deployed_resources(config.chalice_stage)),
         ),
         sweeper=UnreferencedResourcePlanner(),
-        executor=Executor(client),
+        executor=Executor(client, ui),
     )
 
 
-def create_deletion_deployer(client):
-    # type: (TypedAWSClient) -> Deployer
+def create_deletion_deployer(client, ui):
+    # type: (TypedAWSClient, UI) -> Deployer
     return Deployer(
         application_builder=ApplicationGraphBuilder(),
         deps_builder=DependencyBuilder(),
         build_stage=BuildStage(steps=[]),
         plan_stage=NoopPlanner(),
         sweeper=UnreferencedResourcePlanner(),
-        executor=Executor(client),
+        executor=Executor(client, ui),
     )
 
 
@@ -502,9 +502,10 @@ class BuildStage(object):
 
 
 class Executor(object):
-    def __init__(self, client):
-        # type: (TypedAWSClient) -> None
+    def __init__(self, client, ui):
+        # type: (TypedAWSClient, UI) -> None
         self._client = client
+        self._ui = ui
         # A mapping of variables that's populated as API calls
         # are made.  These can be used in subsequent API calls.
         self.variables = {}  # type: Dict[str, Any]
@@ -514,8 +515,12 @@ class Executor(object):
 
     def execute(self, plan):
         # type: (models.Plan) -> None
+        messages = plan.messages
         for instruction in plan.instructions:
             # TODO: Don't error out on unknown instruction
+            message = messages.get(id(instruction))
+            if message is not None:
+                self._ui.write(message)
             getattr(self, '_do_%s' % instruction.__class__.__name__.lower(),
                     lambda x: None)(instruction)
 

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -104,7 +104,7 @@ class UnreferencedResourcePlanner(object):
                     method_name='delete_function',
                     params={'function_name': resource_values['lambda_arn']},)
                 messages[id(apicall)] = (
-                    "Deleting function: %s" % resource_values['lambda_arn'])
+                    "Deleting function: %s\n" % resource_values['lambda_arn'])
                 plan.append(apicall)
             elif resource_values['resource_type'] == 'iam_role':
                 apicall = models.APICall(
@@ -112,7 +112,7 @@ class UnreferencedResourcePlanner(object):
                     params={'name': resource_values['role_name']},
                 )
                 messages[id(apicall)] = (
-                    "Deleting IAM role: %s" % resource_values['role_name'])
+                    "Deleting IAM role: %s\n" % resource_values['role_name'])
                 plan.append(apicall)
             elif resource_values['resource_type'] == 'cloudwatch_event':
                 apicall = models.APICall(
@@ -127,7 +127,7 @@ class UnreferencedResourcePlanner(object):
                     params={'rest_api_id': rest_api_id}
                 )
                 messages[id(apicall)] = (
-                    "Deleting Rest API: %s" % resource_values['rest_api_id'])
+                    "Deleting Rest API: %s\n" % resource_values['rest_api_id'])
                 plan.append(apicall)
 
 

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -147,14 +147,22 @@ class PlanStage(object):
             if handler is not None:
                 result = handler(resource)
                 if result:
-                    for single in result:
-                        if isinstance(single, tuple):
-                            instruction, message = single
-                            plan.append(instruction)
-                            messages[id(instruction)] = message
-                        else:
-                            plan.append(single)
+                    self._add_result_to_plan(result, plan, messages)
         return models.Plan(plan, messages)
+
+    def _add_result_to_plan(self,
+                            result,    # type: Sequence[_INSTRUCTION_MSG]
+                            plan,      # type: List[models.Instruction]
+                            messages,  # type: Dict[int, str]
+                            ):
+        # type: (...) -> None
+        for single in result:
+            if isinstance(single, tuple):
+                instruction, message = single
+                plan.append(instruction)
+                messages[id(instruction)] = message
+            else:
+                plan.append(single)
 
     # TODO: This code will likely be refactored and pulled into
     # per-resource classes so the PlanStage object doesn't need

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -11,6 +11,7 @@ from chalice.deploy.deployer import Deployer as OldDeployer
 from chalice.deploy.newdeployer import Deployer
 from chalice.config import Config
 from chalice import local
+from chalice.utils import UI
 
 
 @fixture
@@ -73,7 +74,7 @@ def test_can_create_default_deployer(clifactory):
 
 def test_can_create_deletion_deployer(clifactory):
     session = clifactory.create_botocore_session()
-    deployer = clifactory.create_deletion_deployer(session)
+    deployer = clifactory.create_deletion_deployer(session, UI())
     assert isinstance(deployer, Deployer)
 
 

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -306,7 +306,8 @@ def test_can_delete_app(tmpdir):
     }
     appdir.join('.chalice', 'deployed.json').write(json.dumps(deployed_json))
     mock_client = mock.Mock(spec=TypedAWSClient)
-    d = newdeployer.create_deletion_deployer(mock_client)
+    ui = mock.Mock(spec=chalice.utils.UI)
+    d = newdeployer.create_deletion_deployer(mock_client, ui)
 
     config = Config(
         chalice_stage='dev',

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -120,7 +120,7 @@ class TestPlanManagedRole(BasePlannerTests):
                     'policy': {'iam': 'policy'}},
         )
         self.assert_apicall_equals(plan[0], expected)
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Creating IAM role: myrole\n'
         ]
 
@@ -141,7 +141,7 @@ class TestPlanManagedRole(BasePlannerTests):
                     'policy': {'iam': 'policy'}},
         )
         self.assert_apicall_equals(plan[0], expected)
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Creating IAM role: myrole\n'
         ]
 
@@ -168,7 +168,7 @@ class TestPlanManagedRole(BasePlannerTests):
         )
         assert plan[-2].variable_name == 'myrole_role_arn'
         assert plan[-1].value == 'myrole'
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Updating policy for IAM role: myrole\n'
         ]
 
@@ -220,7 +220,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
             },
         )
         self.assert_apicall_equals(plan[0], expected)
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Creating lambda function: appname-dev-function_name\n'
         ]
 
@@ -247,7 +247,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
             params=expected_params,
         )
         self.assert_apicall_equals(plan[0], expected)
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Updating lambda function: appname-dev-function_name\n'
         ]
 
@@ -374,7 +374,7 @@ class TestPlanRestAPI(BasePlannerTests):
                 }
             )
         ]
-        assert self.last_plan.messages.values() == [
+        assert list(self.last_plan.messages.values()) == [
             'Creating Rest API\n'
         ]
 


### PR DESCRIPTION
The basic idea is to update the planner to be a python object instead of a list
of instructions.  This allows us to add a `messages` attribute that contains of
mapping of instructions to messages to print.

The original plan was to just the instruction object directly as a key.
However, because it contains mutable attributes, the `id()` of the instruction
is used.  Not opposed to other alternative implementations.

The biggest thing that's missing right now is the formation of the Rest API URL at
the end of the deployment.  The old deployer did this, but I haven't plumbed
this back in.  I was to think about whether I should just be printing out a
more detailed overview of all the resources we created for you instead of just
the Rest API, especially as we add support for more resources.  This will be a
separate pull request.

### Alternatives considered:

* Separate PRINT instructions.  The reason against this is that is clutters the
  plan with unnecessary metadata.
* Have the Executor print every `APICall` instruction.  Too low level and not
  enough control over the contents of the message.