### PR TITLE
update README to specify newer version of boto3 requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -849,7 +849,7 @@ First, install boto3::
 
 Next, add ``boto3`` to your requirements.txt file::
 
-    $ echo 'boto3==1.3.1' >> requirements.txt
+    $ echo 'boto3==1.6.6' >> requirements.txt
 
 The requirements.txt file should be in the same directory that contains
 your ``app.py`` file.  Next, let's update our view code to use boto3:


### PR DESCRIPTION
Calling put_object() fails on boto3 version 1.3.3 due to a change in authorization mechanism requirements.  The error you will get is "Please use AWS4-HMAC-SHA256"