### PR TITLE
[new-deployer] Migrate old deployer format to new format

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -173,9 +173,13 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
                                             config=config,
                                             ui=UI())
     deployed_values = d.deploy(config, chalice_stage_name=stage)
+    deployed_dir = os.path.join(
+        config.project_dir, '.chalice', 'deployed')
+    if not os.path.isdir(deployed_dir):
+        os.makedirs(deployed_dir)
     if deployed_values['stages'][stage].get('resources'):
         record_deployed_values(deployed_values, os.path.join(
-            config.project_dir, '.chalice', 'deployed.json'))
+            deployed_dir, '%s.json' % stage))
 
 
 @cli.command('delete-new')

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -329,7 +329,10 @@ class DeployedResources2(object):
 
     def resource_values(self, name):
         # type: (str) -> Dict[str, str]
-        return self._deployed_values_by_name[name]
+        try:
+            return self._deployed_values_by_name[name]
+        except KeyError:
+            raise ValueError("Resource does not exist: %s" % name)
 
     def resource_names(self):
         # type: () -> List[str]

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -249,6 +249,12 @@ class ApplicationGraphBuilder(object):
             config=config, deployment=deployment, name='api_handler',
             handler_name='app.app', stage_name=stage_name
         )
+        # For backwards compatibility with the old deployer, the
+        # lambda function for the API handler doesn't have the
+        # resource_name appended to its complete function_name,
+        # it's just <app>-<stage>.
+        function_name = '%s-%s' % (config.app_name, config.chalice_stage)
+        lambda_function.function_name = function_name
         authorizers = []
         for auth in config.chalice_app.builtin_auth_handlers:
             auth_lambda = self._create_lambda_model(

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -245,6 +245,7 @@ class ApplicationGraphBuilder(object):
                                stage_name,    # type: str
                                ):
         # type: (...) -> models.RestAPI
+        # Need to mess with the function name for back-compat.
         lambda_function = self._create_lambda_model(
             config=config, deployment=deployment, name='api_handler',
             handler_name='app.app', stage_name=stage_name

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -304,7 +304,10 @@ def test_can_delete_app(tmpdir):
             }
         }
     }
-    appdir.join('.chalice', 'deployed.json').write(json.dumps(deployed_json))
+    deployed_dir = appdir.join('.chalice', 'deployed')
+    deployed_dir.mkdir()
+    deployed_dir.join('dev.json').write(
+        json.dumps(deployed_json))
     mock_client = mock.Mock(spec=TypedAWSClient)
     ui = mock.Mock(spec=chalice.utils.UI)
     d = newdeployer.create_deletion_deployer(mock_client, ui)

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 
 from chalice.cli.factory import CLIFactory
-from chalice.utils import record_deployed_values, OSUtils
+from chalice.utils import record_deployed_values, OSUtils, UI
 from chalice.deploy.deployer import ChaliceDeploymentError
 from chalice.config import DeployedResources2
 
@@ -146,7 +146,7 @@ def _deploy_app(temp_dirname):
         autogen_policy=True
     )
     session = factory.create_botocore_session()
-    d = factory.create_new_default_deployer(session, config)
+    d = factory.create_new_default_deployer(session, config, UI())
     region = session.get_config_variable('region')
     deployed_stages = _deploy_with_retries(d, config)
     deployed = deployed_stages['stages']['dev']
@@ -157,9 +157,12 @@ def _deploy_app(temp_dirname):
         app_name=RANDOM_APP_NAME,
         app_dir=temp_dirname,
     )
+    deploy_dir = os.path.join(temp_dirname, '.chalice', 'deployed')
+    if not os.path.isdir(deploy_dir):
+        os.makedirs(deploy_dir)
     record_deployed_values(
         deployed_stages,
-        os.path.join(temp_dirname, '.chalice', 'deployed.json')
+        os.path.join(deploy_dir, 'dev.json')
     )
     return application
 
@@ -192,7 +195,7 @@ def _delete_app(application, temp_dirname):
         autogen_policy=True
     )
     session = factory.create_botocore_session()
-    d = factory.create_deletion_deployer(session)
+    d = factory.create_deletion_deployer(session, UI())
     _deploy_with_retries(d, config)
 
 

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -278,6 +278,7 @@ class TestApplicationGraphBuilder(object):
         assert rest_api.resource_name == 'rest_api'
         assert rest_api.api_gateway_stage == 'api'
         assert rest_api.lambda_function.resource_name == 'api_handler'
+        assert rest_api.lambda_function.function_name == 'rest-api-app-dev'
         # The swagger document is validated elsewhere so we just
         # make sure it looks right.
         assert rest_api.swagger_doc == models.Placeholder.BUILD_STAGE


### PR DESCRIPTION
This PR changes the deployed.json file to be a file per stage in a new `.chalice/deployed` directory.  This allows us to automatically upgrade the deployed.json schema to the latest version automatically when you deploy with the new deployer.  The workflow is roughly:

1. Try to load `.chalice/deployed/<stage>.json`.  If the file exists and the schema matches what we expect, use that as the canonical deployed values for a given stage.
2. Otherwise try to load `.chalice/deployed.json`.  If that file exists, look up if there's a `<stage>` key.  If it is, upgrade the internal format to use the type needed by the new deployer `DeployedResources2`.

The only other thing that needed to change was the dynamically look up implicit deployed values, specifically the IAM role arn.  This was a resource that chalice creates but it isn't in the old `deployed.json`.  To account for this, the `RemoteState` object will try to dynamically look up objects if they're not in the deployed.json.  Once that succeeds, the rest of the deployment logic in the new deployer will ensure the IAM role is written out to the new `.chalice/deployed/<stage>.json`.