### PR TITLE
Lock to astroid 1.6.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ doc8==0.7.0
 # Pylint will fail on py3.  Locking to a commit on master
 # until pylint2 is released.
 -e git://github.com/PyCQA/pylint.git@7cb3ffddfd96f5e099ca697f6b1e30e727544627#egg=pylint
+astroid==1.6.1
 pytest-cov==2.4.0
 pydocstyle==2.0.0
 


### PR DESCRIPTION
Fixes failures for `make pylint`.

The latest 1.6.2 version of astroid released a few days ago introduces
false positives in `make pylint`:

```
$ make pylint
pylint --rcfile .pylintrc chalice
************* Module chalice.local
W: 15, 0: Relative import 'six.moves.BaseHTTPServer', should be 'BaseHTTPServer' (relative-import)
W: 16, 0: Relative import 'six.moves.BaseHTTPServer', should be 'BaseHTTPServer' (relative-import)
W: 17, 0: Relative import 'six.moves.socketserver', should be 'SocketServer' (relative-import)
```

Looks like astroid added supported to handle the `six.moves` magic but
it's not quite working correctly for us so this locks to the previous
version until it gets fixed.
