### PR TITLE
Add cleanups for post deployment processing

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -172,14 +172,7 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
     d = factory.create_new_default_deployer(session=session,
                                             config=config,
                                             ui=UI())
-    deployed_values = d.deploy(config, chalice_stage_name=stage)
-    deployed_dir = os.path.join(
-        config.project_dir, '.chalice', 'deployed')
-    if not os.path.isdir(deployed_dir):
-        os.makedirs(deployed_dir)
-    if deployed_values['stages'][stage].get('resources'):
-        record_deployed_values(deployed_values, os.path.join(
-            deployed_dir, '%s.json' % stage))
+    d.deploy(config, chalice_stage_name=stage)
 
 
 @cli.command('delete-new')
@@ -197,9 +190,7 @@ def delete_new(ctx, profile, stage):
     config = factory.create_config_obj(chalice_stage_name=stage)
     session = factory.create_botocore_session()
     d = factory.create_deletion_deployer(session=session, ui=UI())
-    deployed_values = d.deploy(config, chalice_stage_name=stage)
-    record_deployed_values(deployed_values, os.path.join(
-        config.project_dir, '.chalice', 'deployed.json'))
+    d.deploy(config, chalice_stage_name=stage)
 
 
 @cli.command('delete')

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -169,10 +169,13 @@ def deploy_new(ctx, autogen_policy, profile, api_gateway_stage, stage):
         api_gateway_stage=api_gateway_stage,
     )
     session = factory.create_botocore_session()
+    ui = UI()
     d = factory.create_new_default_deployer(session=session,
                                             config=config,
-                                            ui=UI())
-    d.deploy(config, chalice_stage_name=stage)
+                                            ui=ui)
+    deployed_values = d.deploy(config, chalice_stage_name=stage)
+    reporter = factory.create_deployment_reporter(ui=ui)
+    reporter.display_report(deployed_values)
 
 
 @cli.command('delete-new')

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -103,6 +103,10 @@ class CLIFactory(object):
         return newdeployer.create_deletion_deployer(
             TypedAWSClient(session), ui)
 
+    def create_deployment_reporter(self, ui):
+        # type: (UI) -> newdeployer.DeploymentReporter
+        return newdeployer.DeploymentReporter(ui=ui)
+
     def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
                           autogen_policy=None,
                           api_gateway_stage=None):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -292,9 +292,7 @@ class Config(object):
             return self._try_old_deployer_values(chalice_stage_name)
         schema_version = data.get('schema_version', '1.0')
         if schema_version == '2.0':
-            if chalice_stage_name not in data['stages']:
-                return None
-            return DeployedResources2(data['stages'][chalice_stage_name])
+            return DeployedResources2(data)
         return None
 
     def _try_old_deployer_values(self, chalice_stage_name):

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -208,11 +208,7 @@ class Deployer(object):
         self._sweeper.execute(plan, config)
         self._executor.execute(plan)
         deployed_values = {
-            'stages': {
-                chalice_stage_name: {
-                    'resources': self._executor.resource_values,
-                },
-            },
+            'resources': self._executor.resource_values,
             'schema_version': '2.0',
         }
         self._recorder.record_results(

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -597,7 +597,7 @@ class Executor(object):
 
     def _do_builtinfunction(self, instruction):
         # type: (models.BuiltinFunction) -> None
-        # Split this out to a separate class of built in functions
+        # TODO: Split this out to a separate class of built in functions
         # once we add more functions.
         if instruction.function_name == 'parse_arn':
             arg = instruction.args[0]
@@ -609,6 +609,11 @@ class Executor(object):
                 'account_id': parts[4],
             }
             self.variables[instruction.output_var] = result
+        elif instruction.function_name == 'string_format':
+            arg = {'arg': instruction.args[0]}
+            value = self._variable_resolver.resolve_variables(
+                arg, self.variables)['arg']
+            self.variables[instruction.output_var] = value
         else:
             raise ValueError("Unknown builtin function: %s"
                              % instruction.function_name)

--- a/chalice/deploy/newdeployer.py
+++ b/chalice/deploy/newdeployer.py
@@ -180,6 +180,9 @@ class UnresolvedValueError(Exception):
 
 
 class Deployer(object):
+
+    BACKEND_NAME = 'api'
+
     def __init__(self,
                  application_builder,  # type: ApplicationGraphBuilder
                  deps_builder,         # type: DependencyBuilder
@@ -210,6 +213,7 @@ class Deployer(object):
         deployed_values = {
             'resources': self._executor.resource_values,
             'schema_version': '2.0',
+            'backend': self.BACKEND_NAME,
         }
         self._recorder.record_results(
             deployed_values,

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -378,7 +378,22 @@ class PlanStage(object):
                         'region_name': Variable('region_name'),
                         'account_id': Variable('account_id'),
                         'rest_api_id': Variable('rest_api_id')},
-            )
+            ),
+            models.BuiltinFunction(
+                'string_format',
+                [StringFormat(
+                    'https://{rest_api_id}.execute-api.{region_name}'
+                    '.amazonaws.com/%s/' % resource.api_gateway_stage,
+                    ['rest_api_id', 'region_name'],
+                )],
+                output_var='rest_api_url',
+            ),
+            models.RecordResourceVariable(
+                resource_type='rest_api',
+                resource_name=resource.resource_name,
+                name='rest_api_url',
+                variable_name='rest_api_url',
+            ),
         ]  # type: List[_INSTRUCTION_MSG]
         for auth in resource.authorizers:
             shared_plan_epilogue.append(
@@ -495,3 +510,16 @@ class StringFormat(object):
         # type: (str, List[str]) -> None
         self.template = template
         self.variables = variables
+
+    def __repr__(self):
+        # type: () -> str
+        return 'StringFormat("%s")' % self.template
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        return (
+            isinstance(other, self.__class__) and
+            self.template == other.template and
+            self.variables == other.variables
+        )
+

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -522,4 +522,3 @@ class StringFormat(object):
             self.template == other.template and
             self.variables == other.variables
         )
-

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -8,7 +8,7 @@ from pytest import fixture
 
 from chalice.cli import factory
 from chalice.deploy.deployer import Deployer as OldDeployer
-from chalice.deploy.newdeployer import Deployer
+from chalice.deploy.newdeployer import Deployer, DeploymentReporter
 from chalice.config import Config
 from chalice import local
 from chalice.utils import UI
@@ -186,3 +186,9 @@ def test_can_create_local_server(clifactory):
     assert isinstance(server, local.LocalDevServer)
     assert server.host == '0.0.0.0'
     assert server.port == 8000
+
+
+def test_can_create_deployment_reporter(clifactory):
+    ui = UI()
+    reporter = clifactory.create_deployment_reporter(ui=ui)
+    assert isinstance(reporter, DeploymentReporter)

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -286,23 +286,19 @@ def test_can_delete_app(tmpdir):
     )
     deployed_json = {
         'schema_version': '2.0',
-        'stages': {
-            'dev': {
-                'resources': [
-                    {'name': 'role-index',
-                     'resource_type': 'iam_role',
-                     'role_name': 'testapp-dev-index',
-                     'role_arn': 'arn:aws:iam::1:role/testapp-dev-index'},
-                    {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-index',
-                     'name': 'index', 'resource_type': 'lambda_function'},
-                    {'name': 'role-james', 'resource_type': 'iam_role',
-                     'role_name': 'testapp-dev-foo',
-                     'role_arn': 'arn:aws:iam::1:role/testapp-dev-foo'},
-                    {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-foo',
-                     'name': 'james', 'resource_type': 'lambda_function'}
-                ]
-            }
-        }
+        'resources': [
+            {'name': 'role-index',
+                'resource_type': 'iam_role',
+                'role_name': 'testapp-dev-index',
+                'role_arn': 'arn:aws:iam::1:role/testapp-dev-index'},
+            {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-index',
+                'name': 'index', 'resource_type': 'lambda_function'},
+            {'name': 'role-james', 'resource_type': 'iam_role',
+                'role_name': 'testapp-dev-foo',
+                'role_arn': 'arn:aws:iam::1:role/testapp-dev-foo'},
+            {'lambda_arn': 'arn:aws:lambda:r:1:f:testapp-dev-foo',
+                'name': 'james', 'resource_type': 'lambda_function'}
+        ]
     }
     deployed_dir = appdir.join('.chalice', 'deployed')
     deployed_dir.mkdir()
@@ -324,7 +320,7 @@ def test_can_delete_app(tmpdir):
     returned_values = d.deploy(config, 'dev')
     assert returned_values == {
         'schema_version': '2.0',
-        'stages': {'dev': {'resources': []}}
+        'resources': [],
     }
     call = mock.call
     expected_calls = [

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -286,6 +286,7 @@ def test_can_delete_app(tmpdir):
     )
     deployed_json = {
         'schema_version': '2.0',
+        'backend': 'api',
         'resources': [
             {'name': 'role-index',
                 'resource_type': 'iam_role',
@@ -320,6 +321,7 @@ def test_can_delete_app(tmpdir):
     returned_values = d.deploy(config, 'dev')
     assert returned_values == {
         'schema_version': '2.0',
+        'backend': 'api',
         'resources': [],
     }
     call = mock.call

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 
 from chalice.cli.factory import CLIFactory
-from chalice.utils import record_deployed_values, OSUtils, UI
+from chalice.utils import OSUtils, UI
 from chalice.deploy.deployer import ChaliceDeploymentError
 from chalice.config import DeployedResources2
 
@@ -156,13 +156,6 @@ def _deploy_app(temp_dirname):
         stage_name='dev',
         app_name=RANDOM_APP_NAME,
         app_dir=temp_dirname,
-    )
-    deploy_dir = os.path.join(temp_dirname, '.chalice', 'deployed')
-    if not os.path.isdir(deploy_dir):
-        os.makedirs(deploy_dir)
-    record_deployed_values(
-        deployed_stages,
-        os.path.join(deploy_dir, 'dev.json')
     )
     return application
 

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -896,11 +896,7 @@ class TestDeployer(unittest.TestCase):
         self.executor.execute.assert_called_with(api_calls)
 
         expected_result = {
-            'stages': {
-                'dev': {
-                    'resources': {'foo': {'name': 'bar'}}
-                }
-            },
+            'resources': {'foo': {'name': 'bar'}},
             'schema_version': '2.0',
         }
 

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -8,7 +8,7 @@ import mock
 import botocore.session
 
 from chalice.awsclient import TypedAWSClient
-from chalice.utils import OSUtils, UI
+from chalice.utils import OSUtils, UI, serialize_to_json
 from chalice.deploy import models
 from chalice.deploy import packager
 from chalice.config import Config
@@ -24,6 +24,7 @@ from chalice.deploy.newdeployer import InjectDefaults, DeploymentPackager
 from chalice.deploy.newdeployer import PolicyGenerator, SwaggerBuilder
 from chalice.deploy.newdeployer import VariableResolver
 from chalice.deploy.newdeployer import TemplatedSwaggerGenerator
+from chalice.deploy.newdeployer import ResultsRecorder
 from chalice.deploy.swagger import SwaggerGenerator
 from chalice.deploy.planner import PlanStage, Variable
 from chalice.deploy.planner import UnreferencedResourcePlanner, StringFormat
@@ -860,6 +861,7 @@ class TestDeployer(unittest.TestCase):
         self.plan_stage = mock.Mock(spec=PlanStage)
         self.sweeper = mock.Mock(spec=UnreferencedResourcePlanner)
         self.executor = mock.Mock(spec=Executor)
+        self.recorder = mock.Mock(spec=ResultsRecorder)
 
     def create_deployer(self):
         return Deployer(
@@ -868,7 +870,8 @@ class TestDeployer(unittest.TestCase):
             self.build_stage,
             self.plan_stage,
             self.sweeper,
-            self.executor
+            self.executor,
+            self.recorder,
         )
 
     def test_deploy_delegates_properly(self):
@@ -882,7 +885,7 @@ class TestDeployer(unittest.TestCase):
         self.executor.resource_values = {'foo': {'name': 'bar'}}
 
         deployer = self.create_deployer()
-        config = Config.create()
+        config = Config.create(project_dir='.')
         result = deployer.deploy(config, 'dev')
 
         self.resource_builder.build.assert_called_with(config, 'dev')
@@ -892,7 +895,7 @@ class TestDeployer(unittest.TestCase):
         self.sweeper.execute.assert_called_with(api_calls, config)
         self.executor.execute.assert_called_with(api_calls)
 
-        assert result == {
+        expected_result = {
             'stages': {
                 'dev': {
                     'resources': {'foo': {'name': 'bar'}}
@@ -900,6 +903,10 @@ class TestDeployer(unittest.TestCase):
             },
             'schema_version': '2.0',
         }
+
+        self.recorder.record_results.assert_called_with(
+            expected_result, 'dev', '.')
+        assert result == expected_result
 
 
 def test_can_create_default_deployer():
@@ -1033,3 +1040,33 @@ def test_templated_swagger_with_auth_uri(rest_api_app):
         '/2015-03-31/functions/{myauth_lambda_arn}/invocations'
     )
     assert uri.variables == ['region_name', 'myauth_lambda_arn']
+
+
+class TestRecordResults(object):
+    def setup_method(self):
+        self.osutils = mock.Mock(spec=OSUtils)
+        self.recorder = ResultsRecorder(self.osutils)
+        self.deployed_values = {
+            'stages': {
+                'dev': {'resources': []},
+            },
+            'schema_version': '2.0',
+        }
+        self.osutils.joinpath = os.path.join
+        self.deployed_dir = os.path.join('.', '.chalice', 'deployed')
+
+    def test_can_record_results_initial_deploy(self):
+        expected_filename = os.path.join(self.deployed_dir, 'dev.json')
+        self.osutils.file_exists.return_value = False
+        self.osutils.directory_exists.return_value = False
+        self.recorder.record_results(
+            self.deployed_values, 'dev', '.',
+        )
+        expected_contents = serialize_to_json(self.deployed_values)
+        # Verify we created the deployed dir on an initial deploy.
+        self.osutils.makedirs.assert_called_with(self.deployed_dir)
+        self.osutils.set_file_contents.assert_called_with(
+            filename=expected_filename,
+            contents=expected_contents,
+            binary=False
+        )

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -813,6 +813,24 @@ class TestExecutor(object):
             'service': 'lambda'
         }
 
+    def test_can_call_string_format(self):
+        self.execute([
+            StoreValue(
+                name='foo',
+                value='foo-value'),
+            StoreValue(
+                name='bar',
+                value='bar-value'),
+            BuiltinFunction(
+                function_name='string_format',
+                args=[StringFormat('foo: {foo}, bar: {bar}',
+                                   ['foo', 'bar'])],
+                output_var='result',
+            )
+        ])
+        assert self.executor.variables['result'] == (
+            'foo: foo-value, bar: bar-value')
+
     def test_errors_out_on_unknown_function(self):
         with pytest.raises(ValueError):
             self.execute([

--- a/tests/unit/deploy/test_newdeployer.py
+++ b/tests/unit/deploy/test_newdeployer.py
@@ -898,6 +898,7 @@ class TestDeployer(unittest.TestCase):
         expected_result = {
             'resources': {'foo': {'name': 'bar'}},
             'schema_version': '2.0',
+            'backend': 'api',
         }
 
         self.recorder.record_results.assert_called_with(

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -8,6 +8,7 @@ from chalice.deploy import models
 from chalice.config import DeployedResources2
 from chalice.utils import OSUtils
 from chalice.deploy.planner import PlanStage, Variable, RemoteState
+from chalice.deploy.planner import StringFormat
 from chalice.deploy.planner import UnreferencedResourcePlanner
 
 
@@ -372,7 +373,21 @@ class TestPlanRestAPI(BasePlannerTests):
                     'account_id': Variable('account_id'),
                     'rest_api_id': Variable('rest_api_id'),
                 }
-            )
+            ),
+            models.BuiltinFunction(
+                function_name='string_format',
+                args=[StringFormat(
+                    'https://{rest_api_id}.execute-api.{region_name}'
+                    '.amazonaws.com/api/',
+                    ['rest_api_id', 'region_name'],
+                )],
+                output_var='rest_api_url'),
+            models.RecordResourceVariable(
+                resource_type='rest_api',
+                resource_name='rest_api',
+                name='rest_api_url',
+                variable_name='rest_api_url'
+            ),
         ]
         assert list(self.last_plan.messages.values()) == [
             'Creating Rest API\n'
@@ -425,7 +440,21 @@ class TestPlanRestAPI(BasePlannerTests):
                         'region_name': Variable("region_name"),
                         'account_id': Variable("account_id"),
                         'function_name': 'appname-dev-function_name'},
-                output_var=None)
+                output_var=None),
+            models.BuiltinFunction(
+                function_name='string_format',
+                args=[StringFormat(
+                    'https://{rest_api_id}.execute-api.{region_name}'
+                    '.amazonaws.com/api/',
+                    ['rest_api_id', 'region_name'],
+                )],
+                output_var='rest_api_url'),
+            models.RecordResourceVariable(
+                resource_type='rest_api',
+                resource_name='rest_api',
+                name='rest_api_url',
+                variable_name='rest_api_url'
+            ),
         ]
 
 


### PR DESCRIPTION
This PR cleans up the steps that happen once the deployer is finished.  This
has been broken down into separate commits, but here's a high level summary:

* Move the record of deployed values into the deployer itself.  Previously this
lived in the `deploy()/delete()` command in `chalice/cli/__init__.py` which was always
odd.  This removes duplication that lived in the `deploy/delete` command as
well as the integration tests.
* Add the `backend: api` key to the deployed JSON files.  This was in the
previous deployer and lets us know how these deployed values were generated.
This was done primarily for parity with the old deployer.
* Add the rest_api_url to the list of deployed values.  Previously the old
deployer knew how to construct the URL but it seems more appropriate for the
planner to construct this value.  In order to do this I needed to add a new
builtin function to handle string formatting.
* Add a `DeploymentReporter` to pretty print the relevant resources that were
deployed.  For now this is just lambda functions and the rest api.


Sample output:


```
$ chalice deploy-new
Creating deployment package.
Updating policy for IAM role: james2-dev
Updating lambda function: james2-dev-foo
Updating lambda function: james2-dev
Updating rest API
Resources deployed:
  - Lambda ARN: arn:aws:lambda:us-west-2:123:function:james2-dev-foo
  - Lambda ARN: arn:aws:lambda:us-west-2:123:function:james2-dev
  - Rest API URL: https://abcd.execute-api.us-west-2.amazonaws.com/api/
```
