### PR TITLE
Create empty deployed resources when no deployment exists

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -275,7 +275,7 @@ class Config(object):
         return clone
 
     def deployed_resources(self, chalice_stage_name):
-        # type: (str) -> Optional[DeployedResources]
+        # type: (str) -> DeployedResources
         """Return resources associated with a given stage.
 
         If a deployment to a given stage has never happened,
@@ -288,22 +288,23 @@ class Config(object):
             self.project_dir, '.chalice', 'deployed',
             '%s.json' % chalice_stage_name)
         data = self._load_json_file(deployed_file)
-        if data is None:
-            return self._try_old_deployer_values(chalice_stage_name)
-        schema_version = data.get('schema_version', '1.0')
-        if schema_version == '2.0':
+        if data is not None:
+            schema_version = data.get('schema_version', '1.0')
+            if schema_version != '2.0':
+                raise ValueError("Unsupported schema version (%s) in file: %s"
+                                 % (schema_version, deployed_file))
             return DeployedResources(data)
-        return None
+        return self._try_old_deployer_values(chalice_stage_name)
 
     def _try_old_deployer_values(self, chalice_stage_name):
-        # type: (str) -> Optional[DeployedResources]
+        # type: (str) -> DeployedResources
         # They are upgrading from v1.0 to v2.0 of the deployed.json
         # schema.  Attempt to auto convert for them.
         old_deployed_file = os.path.join(self.project_dir, '.chalice',
                                          'deployed.json')
         data = self._load_json_file(old_deployed_file)
         if data is None:
-            return None
+            return DeployedResources.empty()
         return self._upgrade_deployed_values(chalice_stage_name, data)
 
     def _load_json_file(self, deployed_file):
@@ -314,7 +315,7 @@ class Config(object):
             return json.load(f)
 
     def _upgrade_deployed_values(self, chalice_stage_name, data):
-        # type: (str, Any) -> Optional[DeployedResources]
+        # type: (str, Any) -> DeployedResources
         deployed = data[chalice_stage_name]
         prefix = '%s-%s-' % (self.app_name, chalice_stage_name)
         resources = []
@@ -334,7 +335,8 @@ class Config(object):
              'resource_type': 'rest_api',
              'rest_api_id': deployed['rest_api_id']},
         ])
-        return DeployedResources({'resources': resources})
+        return DeployedResources(
+            {'resources': resources, 'schema_version': '2.0'})
 
 
 class DeployedResources(object):
@@ -345,6 +347,11 @@ class DeployedResources(object):
             resource['name']: resource
             for resource in deployed_values['resources']
         }
+
+    @classmethod
+    def empty(cls):
+        # type: () -> DeployedResources
+        return cls({'resources': [], 'schema_version': '2.0'})
 
     def resource_values(self, name):
         # type: (str) -> Dict[str, str]

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -303,7 +303,7 @@ class Config(object):
         old_deployed_file = os.path.join(self.project_dir, '.chalice',
                                          'deployed.json')
         data = self._load_json_file(old_deployed_file)
-        if data is None:
+        if data is None or chalice_stage_name not in data:
             return DeployedResources.empty()
         return self._upgrade_deployed_values(chalice_stage_name, data)
 

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -14,7 +14,7 @@ _INSTRUCTION_MSG = Union[models.Instruction, Tuple[models.Instruction, str]]
 
 class RemoteState(object):
     def __init__(self, client, deployed_resources):
-        # type: (TypedAWSClient, Optional[DeployedResources]) -> None
+        # type: (TypedAWSClient, DeployedResources) -> None
         self._client = client
         self._cache = {}  # type: Dict[Tuple[str, str], bool]
         self._deployed_resources = deployed_resources
@@ -25,8 +25,6 @@ class RemoteState(object):
 
     def resource_deployed_values(self, resource):
         # type: (models.ManagedModel) -> Dict[str, str]
-        if self._deployed_resources is None:
-            raise ValueError("Resource is not deployed: %s" % resource)
         try:
             return self._deployed_resources.resource_values(
                 resource.resource_name)
@@ -75,10 +73,11 @@ class RemoteState(object):
 
     def _resource_exists_restapi(self, resource):
         # type: (models.RestAPI) -> bool
-        if self._deployed_resources is None:
+        try:
+            deployed_values = self._deployed_resources.resource_values(
+                resource.resource_name)
+        except ValueError:
             return False
-        deployed_values = self._deployed_resources.resource_values(
-            resource.resource_name)
         rest_api_id = deployed_values['rest_api_id']
         return self._client.rest_api_exists(rest_api_id)
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -42,6 +42,11 @@ def create_function_resource(name, function_name=None,
     )
 
 
+@pytest.fixture
+def no_deployed_values():
+    return DeployedResources({'resources': [], 'schema_version': '2.0'})
+
+
 class FakeConfig(object):
     def __init__(self, deployed_values):
         self._deployed_values = deployed_values
@@ -517,10 +522,10 @@ class TestRemoteState(object):
 
         assert self.client.lambda_function_exists.call_count == 1
 
-    def test_rest_api_exists_no_deploy(self):
+    def test_rest_api_exists_no_deploy(self, no_deployed_values):
         rest_api = self.create_rest_api_model()
         remote_state = RemoteState(
-            self.client, None)
+            self.client, no_deployed_values)
         assert not remote_state.resource_exists(rest_api)
         assert not self.client.rest_api_exists.called
 
@@ -563,8 +568,10 @@ class TestRemoteState(object):
         values = remote_state.resource_deployed_values(rest_api)
         assert values == {'name': 'rest_api', 'rest_api_id': 'foo'}
 
-    def test_value_error_raised_on_no_deployed_values(self):
-        remote_state = RemoteState(self.client, deployed_resources=None)
+    def test_value_error_raised_on_no_deployed_values(self,
+                                                      no_deployed_values):
+        remote_state = RemoteState(self.client,
+                                   deployed_resources=no_deployed_values)
         rest_api = self.create_rest_api_model()
         with pytest.raises(ValueError):
             remote_state.resource_deployed_values(rest_api)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -540,3 +540,7 @@ class TestUpgradeNewDeployer(object):
             'name': 'rest_api',
             'resource_type': 'rest_api',
         }
+
+    def test_upgrade_for_new_stage_gives_empty_values(self):
+        resources = self.config.deployed_resources('prod')
+        assert resources.resource_names() == []


### PR DESCRIPTION
Previously, we returned Optional[DeployedResources], which
made usage awkward because you always had to check if
deployed_resources was not None.  With this change, if there
has been no deployment, we just create an empty DeployedResources.
Consuming code now needs to catch a `ValueError` if they try
to access a resource that was not deployed.

This fixed a bug where `chalice deploy` immediately after a
`chalice delete` would fail.