### PR TITLE
Raise RuntimeError when unable to load IAM policy file

### DIFF
--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -475,8 +475,12 @@ class PlanStage(object):
             # Placholder[T] to T.
             document = cast(Dict[str, Any], resource.document)
         elif isinstance(resource, models.FileBasedIAMPolicy):
-            document = json.loads(
-                self._osutils.get_file_contents(resource.filename))
+            try:
+                document = json.loads(
+                    self._osutils.get_file_contents(resource.filename))
+            except IOError as e:
+                raise RuntimeError("Unable to load IAM policy file %s: %s"
+                                   % (resource.filename, e))
         return document
 
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -146,6 +146,19 @@ class TestPlanManagedRole(BasePlannerTests):
             'Creating IAM role: myrole\n'
         ]
 
+    def test_error_raised_when_filebased_policy_not_exist(self):
+        self.remote_state.declare_no_resources_exists()
+        resource = models.ManagedIAMRole(
+            resource_name='default-role',
+            role_name='myrole',
+            trust_policy={'trust': 'policy'},
+            policy=models.FileBasedIAMPolicy(filename='foo.json'),
+        )
+        self.osutils.get_file_contents.side_effect = IOError(
+            "File does not exist")
+        with pytest.raises(RuntimeError):
+            self.determine_plan(resource)
+
     def test_can_update_managed_role(self):
         role = models.ManagedIAMRole(
             resource_name='resource_name',


### PR DESCRIPTION
This gives parity with the old deployer's error messages
when we try to load a policy file that does not exist.

Repro:

  chalice deploy --no-autogen-policy

There's room for improvement for the error messages, but
for now this puts back the old deployer error message.