### PR TITLE
Add additional parity to old deployer

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -44,11 +44,15 @@ _REMOTE_CALL_ERRORS = (
 )
 
 
-class ResourceDoesNotExistError(Exception):
+class AWSClientError(Exception):
     pass
 
 
-class LambdaClientError(Exception):
+class ResourceDoesNotExistError(AWSClientError):
+    pass
+
+
+class LambdaClientError(AWSClientError):
     def __init__(self, original_error, context):
         # type: (Exception, LambdaErrorContext) -> None
         self.original_error = original_error

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -136,9 +136,9 @@ def deploy(ctx, autogen_policy, profile, api_gateway_stage, stage,
     session = factory.create_botocore_session(
         connection_timeout=connection_timeout)
     ui = UI()
-    d = factory.create_new_default_deployer(session=session,
-                                            config=config,
-                                            ui=ui)
+    d = factory.create_default_deployer(session=session,
+                                        config=config,
+                                        ui=ui)
     deployed_values = d.deploy(config, chalice_stage_name=stage)
     reporter = factory.create_deployment_reporter(ui=ui)
     reporter.display_report(deployed_values)

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -88,7 +88,7 @@ class CLIFactory(object):
                                        debug=self.debug,
                                        connection_timeout=connection_timeout)
 
-    def create_new_default_deployer(self, session, config, ui):
+    def create_default_deployer(self, session, config, ui):
         # type: (Session, Config, UI) -> deployer.Deployer
         return deployer.create_default_deployer(session, config, ui)
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -146,7 +146,7 @@ def _deploy_app(temp_dirname):
         autogen_policy=True
     )
     session = factory.create_botocore_session()
-    d = factory.create_new_default_deployer(session, config, UI())
+    d = factory.create_default_deployer(session, config, UI())
     region = session.get_config_variable('region')
     deployed = _deploy_with_retries(d, config)
     application = SmokeTestApplication(

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -12,7 +12,7 @@ from pytest import fixture
 
 from chalice.app import Chalice
 from chalice.app import CORSConfig
-from chalice.awsclient import LambdaClientError
+from chalice.awsclient import LambdaClientError, AWSClientError
 from chalice.awsclient import DeploymentPackageTooLargeError
 from chalice.awsclient import LambdaErrorContext
 from chalice.config import Config
@@ -1449,6 +1449,18 @@ class TestDeployer(unittest.TestCase):
         self.recorder.record_results.assert_called_with(
             expected_result, 'dev', '.')
         assert result == expected_result
+
+    def test_deploy_errors_raises_chalice_error(self):
+        app = mock.Mock(spec=models.Application)
+        resources = [mock.Mock(spec=models.Model)]
+        api_calls = [mock.Mock(spec=APICall)]
+
+        self.resource_builder.build.side_effect = AWSClientError()
+
+        deployer = self.create_deployer()
+        config = Config.create(project_dir='.')
+        with pytest.raises(ChaliceDeploymentError):
+            deployer.deploy(config, 'dev')
 
 
 def test_can_create_default_deployer():

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -1451,10 +1451,6 @@ class TestDeployer(unittest.TestCase):
         assert result == expected_result
 
     def test_deploy_errors_raises_chalice_error(self):
-        app = mock.Mock(spec=models.Application)
-        resources = [mock.Mock(spec=models.Model)]
-        api_calls = [mock.Mock(spec=APICall)]
-
         self.resource_builder.build.side_effect = AWSClientError()
 
         deployer = self.create_deployer()


### PR DESCRIPTION
1. Rename factory method to match old deployer factory method.
2. Raise `ChaliceDeploymentError` which gives you helpful error messages about lambda deployments failing.