### PR TITLE
Update package command to work with new deployer

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -278,12 +278,12 @@ def package(ctx, single_file, stage, out):
     if single_file:
         dirname = tempfile.mkdtemp()
         try:
-            packager.package_app(config, dirname)
+            packager.package_app(config, dirname, stage)
             create_zip_file(source_dir=dirname, outfile=out)
         finally:
             shutil.rmtree(dirname)
     else:
-        packager.package_app(config, out)
+        packager.package_app(config, out, stage)
 
 
 @cli.command('generate-pipeline')

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -94,7 +94,7 @@ class DeploymentPackage(Model):
 
 @attrs
 class IAMPolicy(Model):
-    pass
+    document = attrib()
 
 
 @attrs
@@ -104,7 +104,7 @@ class FileBasedIAMPolicy(IAMPolicy):
 
 @attrs
 class AutoGenIAMPolicy(IAMPolicy):
-    document = attrib()
+    pass
 
 
 @attrs

--- a/chalice/deploy/models.pyi
+++ b/chalice/deploy/models.pyi
@@ -181,7 +181,13 @@ class DeploymentPackage(Model):
 
 
 class IAMPolicy(Model):
-    pass
+    document = ...  # type: DV[Dict[str, Any]]
+
+    def __init__(self,
+                 document,   # type: DV[Dict[str, Any]]
+                 ):
+        # type: (...) -> None
+        ...
 
 
 class FileBasedIAMPolicy(IAMPolicy):
@@ -189,6 +195,7 @@ class FileBasedIAMPolicy(IAMPolicy):
 
     def __init__(self,
                  filename,   # type: str
+                 document,   # type: DV[Dict[str, Any]]
                  ):
         # type: (...) -> None
         ...

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1,5 +1,3 @@
-import json
-
 from typing import List, Dict, Any, Optional, Union, Tuple, Set, cast  # noqa
 from typing import Sequence  # noqa
 
@@ -249,7 +247,7 @@ class PlanStage(object):
 
     def _plan_managediamrole(self, resource):
         # type: (models.ManagedIAMRole) -> Sequence[_INSTRUCTION_MSG]
-        document = self._get_policy_document(resource.policy)
+        document = resource.policy.document
         role_exists = self._remote_state.resource_exists(resource)
         varname = '%s_role_arn' % resource.role_name
         if not role_exists:
@@ -464,23 +462,6 @@ class PlanStage(object):
             return Variable('%s_role_arn' % resource.role_name)
         # Make mypy happy.
         raise RuntimeError("Unknown resource type: %s" % resource)
-
-    def _get_policy_document(self, resource):
-        # type: (models.IAMPolicy) -> Dict[str, Any]
-        if isinstance(resource, models.AutoGenIAMPolicy):
-            # mypy can't check this, but we assert that the
-            # placeholder values are filled in before we invoke
-            # any planners, so we can safely cast from
-            # Placholder[T] to T.
-            document = cast(Dict[str, Any], resource.document)
-        elif isinstance(resource, models.FileBasedIAMPolicy):
-            try:
-                document = json.loads(
-                    self._osutils.get_file_contents(resource.filename))
-            except IOError as e:
-                raise RuntimeError("Unable to load IAM policy file %s: %s"
-                                   % (resource.filename, e))
-        return document
 
 
 class NoopPlanner(PlanStage):

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -276,10 +276,13 @@ class TemplatePostProcessor(object):
         # outdir.  That would require plumbing through user
         # provided params such as "outdir" into the build stage
         # somehow, which isn't currently possible.
+        copied = False
         for resource in template['Resources'].values():
             if resource['Type'] != 'AWS::Serverless::Function':
                 continue
             original_location = resource['Properties']['CodeUri']
             new_location = os.path.join(outdir, 'deployment.zip')
-            self._osutils.copy(original_location, new_location)
+            if not copied:
+                self._osutils.copy(original_location, new_location)
+                copied = True
             resource['Properties']['CodeUri'] = './deployment.zip'

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -103,6 +103,10 @@ class SAMTemplateGenerator(object):
                 'MemorySize': resource.memory_size,
             },
         }
+        if resource.environment_variables:
+            resources[cfn_name]['Properties']['EnvironmentVariables'] = {
+                'Variables': resource.environment_variables
+            }
         self._inject_iam_permissions(resource, resources[cfn_name])
 
     def _inject_iam_permissions(self, resource, cfn_resource):

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1,39 +1,34 @@
 import os
 import copy
 
-from typing import Any, Dict  # noqa
+from typing import Any, Dict, List  # noqa
 
 from chalice.deploy.swagger import CFNSwaggerGenerator
-from chalice.deploy.swagger import SwaggerGenerator  # noqa
-from chalice.deploy.packager import LambdaDeploymentPackager
-from chalice.deploy.packager import DependencyBuilder
-from chalice.deploy.deployer import ApplicationPolicyHandler
-from chalice.constants import DEFAULT_LAMBDA_TIMEOUT
-from chalice.constants import DEFAULT_LAMBDA_MEMORY_SIZE
 from chalice.utils import OSUtils, UI, serialize_to_json, to_cfn_resource_name
 from chalice.config import Config  # noqa
-from chalice.app import Chalice  # noqa
-from chalice.policy import AppPolicyGenerator
+from chalice.deploy import models
+from chalice.deploy.deployer import ApplicationGraphBuilder
+from chalice.deploy.deployer import DependencyBuilder
+from chalice.deploy.deployer import BuildStage  # noqa
+from chalice.deploy.deployer import create_build_stage
 
 
 def create_app_packager(config):
     # type: (Config) -> AppPackager
     osutils = OSUtils()
     ui = UI()
-    # The config object does not handle a default value
-    # for autogen'ing a policy so we need to handle this here.
+    application_builder = ApplicationGraphBuilder()
+    deps_builder = DependencyBuilder()
+    build_stage = create_build_stage(
+        osutils, ui, CFNSwaggerGenerator()
+    )
+    resource_builder = ResourceBuilder(application_builder,
+                                       deps_builder, build_stage)
     return AppPackager(
-        # We're add place holder values that will be filled in once the
-        # lambda function is deployed.
-        SAMTemplateGenerator(
-            CFNSwaggerGenerator(),
-            ApplicationPolicyHandler(
-                osutils, AppPolicyGenerator(osutils))),
-        LambdaDeploymentPackager(
-            osutils=osutils,
-            dependency_builder=DependencyBuilder(osutils),
-            ui=ui,
-        )
+        SAMTemplateGenerator(),
+        resource_builder,
+        TemplatePostProcessor(osutils=osutils),
+        osutils,
     )
 
 
@@ -41,177 +36,250 @@ class UnsupportedFeatureError(Exception):
     pass
 
 
+class ResourceBuilder(object):
+    def __init__(self,
+                 application_builder,  # type: ApplicationGraphBuilder
+                 deps_builder,         # type: DependencyBuilder
+                 build_stage,          # type: BuildStage
+                 ):
+        # type: (...) -> None
+        self._application_builder = application_builder
+        self._deps_builder = deps_builder
+        self._build_stage = build_stage
+
+    def construct_resources(self, config, chalice_stage_name):
+        # type: (Config, str) -> List[models.Model]
+        application = self._application_builder.build(
+            config, chalice_stage_name)
+        resources = self._deps_builder.build_dependencies(application)
+        self._build_stage.execute(config, resources)
+        return resources
+
+
 class SAMTemplateGenerator(object):
     _BASE_TEMPLATE = {
         'AWSTemplateFormatVersion': '2010-09-09',
         'Transform': 'AWS::Serverless-2016-10-31',
-        'Outputs': {
-            'RestAPIId': {
-                'Value': {'Ref': 'RestAPI'},
-            },
-            'APIHandlerName': {
-                'Value': {'Ref': 'APIHandler'},
-            },
-            'APIHandlerArn': {
-                'Value': {'Fn::GetAtt': ['APIHandler', 'Arn']}
-            },
-            'EndpointURL': {
-                'Value': {
-                    'Fn::Sub': (
-                        'https://${RestAPI}.execute-api.${AWS::Region}'
-                        # The api_gateway_stage is filled in when
-                        # the template is built.
-                        '.amazonaws.com/%s/'
-                    )
-                }
-            }
-        }
-    }  # type: Dict[str, Any]
+        'Outputs': {},
+        'Resources': {},
+    }
 
-    def __init__(self, swagger_generator, policy_generator):
-        # type: (SwaggerGenerator, ApplicationPolicyHandler) -> None
-        self._swagger_generator = swagger_generator
-        self._policy_generator = policy_generator
-
-    def generate_sam_template(self, config, code_uri='<placeholder>'):
-        # type: (Config, str) -> Dict[str, Any]
+    def generate_sam_template(self, resources):
+        # type: (List[models.Model]) -> Dict[str, Any]
         template = copy.deepcopy(self._BASE_TEMPLATE)
-        resources = {
-            'APIHandler': self._generate_serverless_function(
-                config, code_uri, 'app.app', 'api'),
-            'RestAPI': self._generate_rest_api(
-                config.chalice_app, config.api_gateway_stage),
-        }
-        self._add_auth_handlers(resources, config, code_uri)
-        template['Resources'] = resources
-        self._update_endpoint_url_output(template, config)
+        for resource in resources:
+            name = '_generate_%s' % resource.__class__.__name__.lower()
+            handler = getattr(self, name, self._default)
+            handler(resource, template)
         return template
 
-    def _add_auth_handlers(self, resources, config, code_uri):
-        # type: (Dict[str, Any], Config, str) -> None
-        for auth_config in config.chalice_app.builtin_auth_handlers:
-            auth_resource_name = to_cfn_resource_name(auth_config.name)
-            new_config = config.scope(chalice_stage=config.chalice_stage,
-                                      function_name=auth_config.name)
-            resources[auth_resource_name] = self._generate_serverless_function(
-                new_config, code_uri, auth_config.handler_string, 'authorizer')
-            resources[auth_resource_name + 'InvokePermission'] = \
-                self._generate_lambda_permission(auth_resource_name)
+    def _generate_scheduledevent(self, resource, template):
+        # type: (models.ScheduledEvent, Dict[str, Any]) -> None
+        function_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        function_cfn = template['Resources'][function_cfn_name]
+        event_cfn_name = to_cfn_resource_name(resource.resource_name)
+        function_cfn['Properties']['Events'] = {
+            event_cfn_name: {
+                'Type': 'Schedule',
+                'Properties': {
+                    'Schedule': resource.schedule_expression,
+                }
+            }
+        }
 
-    def _generate_lambda_permission(self, lambda_ref):
-        # type: (str) -> Dict[str, Any]
-        return {
+    def _generate_lambdafunction(self, resource, template):
+        # type: (models.LambdaFunction, Dict[str, Any]) -> None
+        resources = template['Resources']
+        cfn_name = to_cfn_resource_name(resource.resource_name)
+        resources[cfn_name] = {
+            'Type': 'AWS::Serverless::Function',
+            'Properties': {
+                'Runtime': resource.runtime,
+                'Handler': resource.handler,
+                'CodeUri': resource.deployment_package.filename,
+                'Tags': resource.tags,
+                'Timeout': resource.timeout,
+                'MemorySize': resource.memory_size,
+            },
+        }
+        self._inject_iam_permissions(resource, resources[cfn_name])
+
+    def _inject_iam_permissions(self, resource, cfn_resource):
+        # type: (models.LambdaFunction, Dict[str, Any]) -> None
+        role = resource.role
+        if isinstance(role, models.ManagedIAMRole):
+            cfn_resource['Properties']['Policies'] = role.policy.document
+        else:
+            # resource is a PreCreatedIAMRole
+            cfn_resource['Properties']['Role'] = role.role_arn
+
+    def _generate_restapi(self, resource, template):
+        # type: (models.RestAPI, Dict[str, Any]) -> None
+        resources = template['Resources']
+        resources['RestAPI'] = {
+            'Type': 'AWS::Serverless::Api',
+            'Properties': {
+                'StageName': resource.api_gateway_stage,
+                'DefinitionBody': resource.swagger_doc,
+            }
+        }
+        handler_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        api_handler = template['Resources'].pop(handler_cfn_name)
+        template['Resources']['APIHandler'] = api_handler
+        resources['APIHandlerInvokePermission'] = {
             'Type': 'AWS::Lambda::Permission',
             'Properties': {
-                'FunctionName': {'Fn::GetAtt': [lambda_ref, 'Arn']},
+                'FunctionName': {'Ref': 'APIHandler'},
                 'Action': 'lambda:InvokeFunction',
-                'Principal': 'apigateway.amazonaws.com'
+                'Principal': 'apigateway.amazonaws.com',
+                'SourceArn': {
+                    'Fn::Sub': [
+                        ('arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}'
+                         ':${RestAPIId}/*'),
+                        {'RestAPIId': {'Ref': 'RestAPI'}},
+                    ]
+                },
             }
         }
-
-    def _update_endpoint_url_output(self, template, config):
-        # type: (Dict[str, Any], Config) -> None
-        url = template['Outputs']['EndpointURL']['Value']['Fn::Sub']
-        template['Outputs']['EndpointURL']['Value']['Fn::Sub'] = (
-            url % config.api_gateway_stage)
-
-    def _generate_serverless_function(self, config, code_uri, handler_string,
-                                      function_type):
-        # type: (Config, str, str, str) -> Dict[str, Any]
-        properties = {
-            'Runtime': config.lambda_python_version,
-            'Handler': handler_string,
-            'CodeUri': code_uri,
-            'Events': self._generate_function_events(
-                config.chalice_app, function_type),
-            'Tags': config.tags,
-            'Timeout': DEFAULT_LAMBDA_TIMEOUT,
-            'MemorySize': DEFAULT_LAMBDA_MEMORY_SIZE
-        }
-        if config.environment_variables:
-            properties['Environment'] = {
-                'Variables': config.environment_variables
-            }
-        if config.lambda_timeout is not None:
-            properties['Timeout'] = config.lambda_timeout
-        if config.lambda_memory_size is not None:
-            properties['MemorySize'] = config.lambda_memory_size
-        if not config.manage_iam_role:
-            properties['Role'] = config.iam_role_arn
-        else:
-            properties['Policies'] = [self._generate_iam_policy(config)]
-        return {
-            'Type': 'AWS::Serverless::Function',
-            'Properties': properties,
-        }
-
-    def _generate_function_events(self, app, function_type):
-        # type: (Chalice, str) -> Dict[str, Any]
-        return getattr(
-            self, '_generate_' + function_type + '_function_events')(app)
-
-    def _generate_api_function_events(self, app):
-        # type: (Chalice) -> Dict[str, Any]
-        events = {}
-        for methods in app.routes.values():
-            for http_method, view in methods.items():
-                key_name = to_cfn_resource_name(
-                    view.view_name + http_method.lower())
-                events[key_name] = {
-                    'Type': 'Api',
-                    'Properties': {
-                        'Path': view.uri_pattern,
-                        'RestApiId': {'Ref': 'RestAPI'},
-                        'Method': http_method.lower(),
-                    }
+        for auth in resource.authorizers:
+            auth_cfn_name = to_cfn_resource_name(auth.resource_name)
+            resources[auth_cfn_name + 'InvokePermission'] = {
+                'Type': 'AWS::Lambda::Permission',
+                'Properties': {
+                    'FunctionName': {'Fn::GetAtt': [auth_cfn_name, 'Arn']},
+                    'Action': 'lambda:InvokeFunction',
+                    'Principal': 'apigateway.amazonaws.com',
+                    'SourceArn': {
+                        'Fn::Sub': [
+                            ('arn:aws:execute-api:${AWS::Region}:'
+                             '${AWS::AccountId}:${RestAPIId}/*'),
+                            {'RestAPIId': {'Ref': 'RestAPI'}},
+                        ]
+                    },
                 }
-        return events
+            }
+        self._inject_restapi_outputs(template)
 
-    def _generate_authorizer_function_events(self, app):
-        # type: (Chalice) -> Dict[str, Any]
-        return {}
-
-    def _generate_rest_api(self, app, api_gateway_stage):
-        # type: (Chalice, str) -> Dict[str, Any]
-        swagger_definition = self._swagger_generator.generate_swagger(app)
-        properties = {
-            'StageName': api_gateway_stage,
-            'DefinitionBody': swagger_definition,
+    def _inject_restapi_outputs(self, template):
+        # type: (Dict[str, Any]) -> None
+        # The 'Outputs' of the SAM template are considered
+        # part of the public API of chalice and therefore
+        # need to maintain backwards compatibility.  This
+        # method uses the same output key names as the old
+        # deployer.
+        # For now, we aren't adding any of the new resources
+        # to the Outputs section until we can figure out
+        # a consist naming scheme.  Ideally we don't use
+        # the autogen'd names that contain the md5 suffixes.
+        stage_name = template['Resources']['RestAPI'][
+            'Properties']['StageName']
+        outputs = template['Outputs']
+        outputs['RestAPIId'] = {
+            'Value': {'Ref': 'RestAPI'}
         }
-        return {
-            'Type': 'AWS::Serverless::Api',
-            'Properties': properties,
+        outputs['APIHandlerName'] = {
+            'Value': {'Ref': 'APIHandler'}
+        }
+        outputs['APIHandlerArn'] = {
+            'Value': {'Fn::GetAtt': ['APIHandler', 'Arn']}
+        }
+        outputs['EndpointURL'] = {
+            'Value': {
+                'Fn::Sub': (
+                    'https://${RestAPI}.execute-api.${AWS::Region}'
+                    # The api_gateway_stage is filled in when
+                    # the template is built.
+                    '.amazonaws.com/%s/'
+                ) % stage_name
+            }
         }
 
-    def _generate_iam_policy(self, config):
-        # type: (Config) -> Dict[str, Any]
-        return self._policy_generator.generate_policy_from_app_source(config)
+    # The various IAM roles/policies are handled in the
+    # Lambda function generation.  We're creating these
+    # noop methods to indicate we've accounted for these
+    # resources.
+
+    def _generate_managediamrole(self, resource, template):
+        # type: (models.ManagedIAMRole, Dict[str, Any]) -> None
+        pass
+
+    def _generate_filebasediampolicy(self, resource, template):
+        # type: (models.FileBasedIAMPolicy, Dict[str, Any]) -> None
+        pass
+
+    def _generate_autogeniampolicy(self, resource, template):
+        # type: (models.AutoGenIAMPolicy, Dict[str, Any]) -> None
+        pass
+
+    def _generate_deploymentpackage(self, resource, template):
+        # type: (models.DeploymentPackage, Dict[str, Any]) -> None
+        pass
+
+    def _default(self, resource, template):
+        # type: (models.Model, Dict[str, Any]) -> None
+        raise NotImplementedError(resource)
 
 
 class AppPackager(object):
     def __init__(self,
-                 sam_templater,       # type: SAMTemplateGenerator
-                 lambda_packager,     # type: LambdaDeploymentPackager
+                 sam_templater,     # type: SAMTemplateGenerator
+                 resource_builder,  # type: ResourceBuilder
+                 post_processor,    # type: TemplatePostProcessor
+                 osutils,           # type: OSUtils
                  ):
         # type: (...) -> None
         self._sam_templater = sam_templater
-        self._lambda_packaager = lambda_packager
+        self._resource_builder = resource_builder
+        self._template_post_processor = post_processor
+        self._osutils = osutils
 
     def _to_json(self, doc):
         # type: (Any) -> str
         return serialize_to_json(doc)
 
-    def package_app(self, config, outdir):
-        # type: (Config, str) -> None
+    def package_app(self, config, outdir, chalice_stage_name):
+        # type: (Config, str, str) -> None
         # Deployment package
-        zip_file = os.path.join(outdir, 'deployment.zip')
-        self._lambda_packaager.create_deployment_package(
-            config.project_dir, config.lambda_python_version, zip_file)
+        resources = self._resource_builder.construct_resources(
+            config, chalice_stage_name)
 
         # SAM template
         sam_template = self._sam_templater.generate_sam_template(
-            config, './deployment.zip')
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
-        with open(os.path.join(outdir, 'sam.json'), 'w') as f:
-            f.write(self._to_json(sam_template))
+            resources)
+        if not self._osutils.directory_exists(outdir):
+            self._osutils.makedirs(outdir)
+        self._template_post_processor.process(
+            sam_template, config, outdir, chalice_stage_name)
+        self._osutils.set_file_contents(
+            filename=os.path.join(outdir, 'sam.json'),
+            contents=self._to_json(sam_template),
+            binary=False
+        )
+
+
+class TemplatePostProcessor(object):
+    def __init__(self, osutils):
+        # type: (OSUtils) -> None
+        self._osutils = osutils
+
+    def process(self, template, config, outdir, chalice_stage_name):
+        # type: (Dict[str, Any], Config, str, str) -> None
+        self._fixup_deployment_package(template, outdir)
+
+    def _fixup_deployment_package(self, template, outdir):
+        # type: (Dict[str, Any], str) -> None
+        # NOTE: This isn't my ideal way to do this.  I'd like
+        # to move this into the build step where something
+        # copies the DeploymentPackage.filename over to the
+        # outdir.  That would require plumbing through user
+        # provided params such as "outdir" into the build stage
+        # somehow, which isn't currently possible.
+        for resource in template['Resources'].values():
+            if resource['Type'] != 'AWS::Serverless::Function':
+                continue
+            original_location = resource['Properties']['CodeUri']
+            new_location = os.path.join(outdir, 'deployment.zip')
+            self._osutils.copy(original_location, new_location)
+            resource['Properties']['CodeUri'] = './deployment.zip'

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -211,6 +211,10 @@ class OSUtils(object):
         # type: (str) -> None
         shutil.rmtree(directory)
 
+    def copy(self, source, destination):
+        # type: (str, str) -> None
+        shutil.copy(source, destination)
+
     def move(self, source, destination):
         # type: (str, str) -> None
         shutil.move(source, destination)

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -737,7 +737,7 @@ def test_can_create_app_packager_with_no_autogen(tmpdir):
                            chalice_app=sample_app(),
                            **default_params)
     p = package.create_app_packager(config)
-    p.package_app(config, str(outdir))
+    p.package_app(config, str(outdir), 'dev')
     # We're not concerned with the contents of the files
     # (those are tested in the unit tests), we just want to make
     # sure they're written to disk and look (mostly) right.
@@ -754,7 +754,7 @@ def test_will_create_outdir_if_needed(tmpdir):
                            chalice_app=sample_app(),
                            **default_params)
     p = package.create_app_packager(config)
-    p.package_app(config, str(outdir))
+    p.package_app(config, str(outdir), 'dev')
     contents = os.listdir(str(outdir))
     assert 'deployment.zip' in contents
     assert 'sam.json' in contents

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,24 @@ def sample_app_with_auth():
 
 
 @fixture
+def sample_app_schedule_only():
+    app = Chalice('schedule_only')
+
+    @app.schedule('rate(5 minutes)')
+    def cron(event):
+        pass
+
+
+@fixture
+def sample_app_lambda_only():
+    app = Chalice('lambda_only')
+
+    @app.lambda_function()
+    def myfunction(event, context):
+        pass
+
+
+@fixture
 def create_event():
     def create_event_inner(uri, method, path, content_type='application/json'):
         return {

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -131,6 +131,17 @@ class TestSAMTemplate(object):
             },
         }
 
+    def test_adds_env_vars_when_provided(self, sample_app):
+        function = self.lambda_function()
+        function.environment_variables = {'foo': 'bar'}
+        template = self.template_gen.generate_sam_template([function])
+        cfn_resource = list(template['Resources'].values())[0]
+        assert cfn_resource['Properties']['EnvironmentVariables'] == {
+            'Variables': {
+                'foo': 'bar'
+            }
+        }
+
     def test_role_arn_inserted_when_necessary(self):
         function = models.LambdaFunction(
             resource_name='foo',

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -3,8 +3,10 @@ import mock
 import pytest
 from chalice.config import Config
 from chalice import package
-from chalice import __version__ as chalice_version
-from chalice.deploy.deployer import ApplicationPolicyHandler
+from chalice.deploy.deployer import ApplicationGraphBuilder
+from chalice.deploy.deployer import DependencyBuilder
+from chalice.deploy.deployer import BuildStage
+from chalice.deploy import models
 from chalice.deploy.swagger import SwaggerGenerator
 
 
@@ -13,362 +15,192 @@ def mock_swagger_generator():
     return mock.Mock(spec=SwaggerGenerator)
 
 
-@pytest.fixture
-def mock_policy_generator():
-    return mock.Mock(spec=ApplicationPolicyHandler)
-
-
 def test_can_create_app_packager():
     config = Config()
     packager = package.create_app_packager(config)
     assert isinstance(packager, package.AppPackager)
 
 
-def test_can_create_app_packager_with_no_autogen():
-    # We can't actually observe a change here, but we want
-    # to make sure the function can handle this param being
-    # False.
-    config = Config.create(autogen_policy=False)
-    packager = package.create_app_packager(config)
-    assert isinstance(packager, package.AppPackager)
+class TestSAMTemplate(object):
+    def setup_method(self):
+        self.resource_builder = package.ResourceBuilder(
+            application_builder=ApplicationGraphBuilder(),
+            deps_builder=DependencyBuilder(),
+            build_stage=mock.Mock(spec=BuildStage)
+        )
+        self.template_gen = package.SAMTemplateGenerator()
 
+    def generate_template(self, config, chalice_stage_name):
+        resources = self.resource_builder.construct_resources(
+            config, chalice_stage_name)
+        return self.template_gen.generate_sam_template(resources)
 
-def test_preconfigured_policy_proxies():
-    policy_gen = mock.Mock(spec=ApplicationPolicyHandler)
-    config = Config.create(project_dir='project_dir', autogen_policy=False)
-    policy_gen.generate_policy_from_app_source.return_value = {
-        'policy': True}
-    policy = policy_gen.generate_policy_from_app_source(config)
-    assert policy == {'policy': True}
+    def lambda_function(self):
+        return models.LambdaFunction(
+            resource_name='foo',
+            function_name='app-dev-foo',
+            environment_variables={},
+            runtime='python27',
+            handler='app.app',
+            tags={'foo': 'bar'},
+            timeout=120,
+            memory_size=128,
+            deployment_package=models.DeploymentPackage(filename='foo.zip'),
+            role=models.PreCreatedIAMRole(role_arn='role:arn'),
+        )
 
+    def test_sam_generates_sam_template_basic(self, sample_app):
+        config = Config.create(chalice_app=sample_app,
+                               project_dir='.',
+                               api_gateway_stage='api')
+        template = self.generate_template(config, 'dev')
+        # Verify the basic structure is in place.  The specific parts
+        # are validated in other tests.
+        assert template['AWSTemplateFormatVersion'] == '2010-09-09'
+        assert template['Transform'] == 'AWS::Serverless-2016-10-31'
+        assert 'Outputs' in template
+        assert 'Resources' in template
+        assert list(sorted(template['Resources'])) == [
+            'APIHandler', 'APIHandlerInvokePermission', 'RestAPI',
+        ]
 
-def test_sam_generates_sam_template_basic(sample_app,
-                                          mock_swagger_generator,
-                                          mock_policy_generator):
-    p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                     mock_policy_generator)
-    config = Config.create(chalice_app=sample_app,
-                           api_gateway_stage='dev')
-    template = p.generate_sam_template(config, 'code-uri')
-    # Verify the basic structure is in place.  The specific parts
-    # are validated in other tests.
-    assert template['AWSTemplateFormatVersion'] == '2010-09-09'
-    assert template['Transform'] == 'AWS::Serverless-2016-10-31'
-    assert 'Outputs' in template
-    assert 'Resources' in template
-
-
-def test_sam_injects_policy(sample_app,
-                            mock_swagger_generator,
-                            mock_policy_generator):
-    p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                     mock_policy_generator)
-
-    mock_policy_generator.generate_policy_from_app_source.return_value = {
-        'iam': 'policy',
-    }
-    config = Config.create(chalice_app=sample_app,
-                           api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
-    assert template['Resources']['APIHandler']['Properties']['Policies'] == [{
-        'iam': 'policy',
-    }]
-    assert 'Role' not in template['Resources']['APIHandler']['Properties']
-
-
-def test_sam_injects_swagger_doc(sample_app,
-                                 mock_swagger_generator,
-                                 mock_policy_generator):
-    p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                     mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app,
-                           api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['RestAPI']['Properties']
-    assert properties['DefinitionBody'] == {'swagger': 'document'}
-
-
-def test_can_inject_environment_vars(sample_app,
-                                     mock_swagger_generator,
-                                     mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app,
-        api_gateway_stage='dev',
-        environment_variables={
-            'FOO': 'BAR'
-        }
-    )
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert 'Environment' in properties
-    assert properties['Environment']['Variables'] == {'FOO': 'BAR'}
-
-
-def test_chalice_tag_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
-                           app_name='myapp')
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['Tags'] == {
-        'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version}
-
-
-def test_custom_tags_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
-                           app_name='myapp', tags={'mykey': 'myvalue'})
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['Tags'] == {
-        'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version,
-        'mykey': 'myvalue'
-    }
-
-
-def test_default_function_timeout(sample_app,
-                                  mock_swagger_generator,
-                                  mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['Timeout'] == 60
-
-
-def test_timeout_added_to_function(sample_app,
-                                   mock_swagger_generator,
-                                   mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
-                           app_name='myapp', lambda_timeout=240)
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['Timeout'] == 240
-
-
-def test_default_function_memory_size(sample_app,
-                                      mock_swagger_generator,
-                                      mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev')
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['MemorySize'] == 128
-
-
-def test_memory_size_added_to_function(sample_app,
-                                       mock_swagger_generator,
-                                       mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app, api_gateway_stage='dev',
-                           app_name='myapp', lambda_memory_size=256)
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['MemorySize'] == 256
-
-
-def test_endpoint_url_reflects_apig_stage(sample_app,
-                                          mock_swagger_generator,
-                                          mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app,
-        api_gateway_stage='prod',
-    )
-    template = p.generate_sam_template(config)
-    endpoint_url = template['Outputs']['EndpointURL']['Value']['Fn::Sub']
-    assert endpoint_url == (
-        'https://${RestAPI}.execute-api.${AWS::Region}.amazonaws.com/prod/')
-
-
-def test_maps_python_version(sample_app,
-                             mock_swagger_generator,
-                             mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app,
-        api_gateway_stage='dev',
-    )
-    template = p.generate_sam_template(config)
-    expected = config.lambda_python_version
-    actual = template['Resources']['APIHandler']['Properties']['Runtime']
-    assert actual == expected
-
-
-def test_role_arn_added_to_function(sample_app,
-                                    mock_swagger_generator,
-                                    mock_policy_generator):
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app, api_gateway_stage='dev', app_name='myapp',
-        manage_iam_role=False, iam_role_arn='role-arn')
-    template = p.generate_sam_template(config)
-    properties = template['Resources']['APIHandler']['Properties']
-    assert properties['Role'] == 'role-arn'
-    assert 'Policies' not in properties
-
-
-def test_app_incompatible_with_cf(sample_app,
-                                  mock_swagger_generator,
-                                  mock_policy_generator):
-
-    @sample_app.route('/foo')
-    def foo_invalid():
-        return {}
-
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(chalice_app=sample_app,
-                           api_gateway_stage='dev',
-                           app_name='sample_invalid_cf')
-    template = p.generate_sam_template(config)
-    events = template['Resources']['APIHandler']['Properties']['Events']
-    # The underscore should be removed from the event name.
-    assert 'fooinvalidget4cee' in events
-
-
-def test_app_with_auth(sample_app,
-                       mock_swagger_generator,
-                       mock_policy_generator):
-
-    @sample_app.authorizer('myauth')
-    def myauth(auth_request):
-        pass
-
-    @sample_app.route('/authorized', authorizer=myauth)
-    def foo():
-        return {}
-    # The last four digits come from the hash of the auth name
-    cfn_auth_name = 'myauthdb6d'
-
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app,
-        api_gateway_stage='dev',
-    )
-    template = p.generate_sam_template(config)
-    assert cfn_auth_name in template['Resources']
-    auth_function = template['Resources'][cfn_auth_name]
-    assert auth_function['Type'] == 'AWS::Serverless::Function'
-    assert auth_function['Properties']['Handler'] == 'app.myauth'
-
-    # Assert that the invoke permsissions were added as well.
-    assert cfn_auth_name + 'InvokePermission' in template['Resources']
-    assert template['Resources'][cfn_auth_name + 'InvokePermission'] == {
-        'Type': 'AWS::Lambda::Permission',
-        'Properties': {
-            'Action': 'lambda:InvokeFunction',
-            'FunctionName': {
-                'Fn::GetAtt': [
-                    cfn_auth_name,
-                    'Arn'
-                ]
+    def test_sam_injects_policy(self, sample_app):
+        function = models.LambdaFunction(
+            resource_name='foo',
+            function_name='app-dev-foo',
+            environment_variables={},
+            runtime='python27',
+            handler='app.app',
+            tags={'foo': 'bar'},
+            timeout=120,
+            memory_size=128,
+            deployment_package=models.DeploymentPackage(filename='foo.zip'),
+            role=models.ManagedIAMRole(
+                resource_name='role',
+                role_name='app-role',
+                trust_policy={},
+                policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+            )
+        )
+        template = self.template_gen.generate_sam_template([function])
+        cfn_resource = list(template['Resources'].values())[0]
+        assert cfn_resource == {
+            'Type': 'AWS::Serverless::Function',
+            'Properties': {
+                'CodeUri': 'foo.zip',
+                'Handler': 'app.app',
+                'MemorySize': 128,
+                'Policies': {'iam': 'policy'},
+                'Runtime': 'python27',
+                'Tags': {'foo': 'bar'},
+                'Timeout': 120
             },
-            'Principal': 'apigateway.amazonaws.com'
         }
-    }
 
-
-def test_app_with_auth_but_invalid_cfn_name(sample_app,
-                                            mock_swagger_generator,
-                                            mock_policy_generator):
-
-    # Underscores are not allowed for CFN resource names
-    # This instead should be referred to as customauth in CFN templates
-    # where the underscore is removed.
-    @sample_app.authorizer('custom_auth')
-    def custom_auth(auth_request):
-        pass
-
-    @sample_app.route('/authorized', authorizer=custom_auth)
-    def foo():
-        return {}
-
-    # The last four digits come from the hash of the auth name
-    cfn_auth_name = 'customauth8767'
-    p = package.SAMTemplateGenerator(
-        mock_swagger_generator, mock_policy_generator)
-    mock_swagger_generator.generate_swagger.return_value = {
-        'swagger': 'document'
-    }
-    config = Config.create(
-        chalice_app=sample_app,
-        api_gateway_stage='dev',
-    )
-    template = p.generate_sam_template(config)
-    assert cfn_auth_name in template['Resources']
-    auth_function = template['Resources'][cfn_auth_name]
-    assert auth_function['Type'] == 'AWS::Serverless::Function'
-    assert auth_function['Properties']['Handler'] == 'app.custom_auth'
-
-    # Assert that the invoke permsissions were added as well.
-    assert cfn_auth_name + 'InvokePermission' in template['Resources']
-    assert template['Resources'][cfn_auth_name + 'InvokePermission'] == {
-        'Type': 'AWS::Lambda::Permission',
-        'Properties': {
-            'Action': 'lambda:InvokeFunction',
-            'FunctionName': {
-                'Fn::GetAtt': [
-                    cfn_auth_name,
-                    'Arn'
-                ]
+    def test_role_arn_inserted_when_necessary(self):
+        function = models.LambdaFunction(
+            resource_name='foo',
+            function_name='app-dev-foo',
+            environment_variables={},
+            runtime='python27',
+            handler='app.app',
+            tags={'foo': 'bar'},
+            timeout=120,
+            memory_size=128,
+            deployment_package=models.DeploymentPackage(filename='foo.zip'),
+            role=models.PreCreatedIAMRole(role_arn='role:arn'),
+        )
+        template = self.template_gen.generate_sam_template([function])
+        cfn_resource = list(template['Resources'].values())[0]
+        assert cfn_resource == {
+            'Type': 'AWS::Serverless::Function',
+            'Properties': {
+                'CodeUri': 'foo.zip',
+                'Handler': 'app.app',
+                'MemorySize': 128,
+                'Role': 'role:arn',
+                'Runtime': 'python27',
+                'Tags': {'foo': 'bar'},
+                'Timeout': 120
             },
-            'Principal': 'apigateway.amazonaws.com'
         }
-    }
+
+    def test_can_generate_scheduled_event(self, sample_app_schedule_only):
+        function = self.lambda_function()
+        event = models.ScheduledEvent(
+            resource_name='foo',
+            rule_name='myrule',
+            schedule_expression='rate(5 minutes)',
+            lambda_function=function,
+        )
+        template = self.template_gen.generate_sam_template(
+            [function, event]
+        )
+        resources = template['Resources']
+        assert len(resources) == 1
+        cfn_resource = list(resources.values())[0]
+        assert cfn_resource['Properties']['Events'] == {
+            'fooacbd': {
+                'Type': 'Schedule',
+                'Properties': {
+                    'Schedule': 'rate(5 minutes)'
+                },
+            },
+        }
+
+    def test_can_generate_rest_api(self, sample_app_with_auth):
+        config = Config.create(chalice_app=sample_app_with_auth,
+                               project_dir='.',
+                               api_gateway_stage='api')
+        template = self.generate_template(config, 'dev')
+        resources = template['Resources']
+        # Lambda function should be created.
+        assert resources['APIHandler']['Type'] == 'AWS::Serverless::Function'
+        # Along with permission to invoke from API Gateway.
+        assert resources['APIHandlerInvokePermission'] == {
+            'Type': 'AWS::Lambda::Permission',
+            'Properties': {
+                'Action': 'lambda:InvokeFunction',
+                'FunctionName': {'Ref': 'APIHandler'},
+                'Principal': 'apigateway.amazonaws.com',
+                'SourceArn': {
+                    'Fn::Sub': [
+                        ('arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}'
+                         ':${RestAPIId}/*'),
+                        {'RestAPIId': {'Ref': 'RestAPI'}}]}},
+        }
+        assert resources['RestAPI']['Type'] == 'AWS::Serverless::Api'
+        # We should also create the auth lambda function.
+        assert resources['myauthdb6d']['Type'] == 'AWS::Serverless::Function'
+        # Along with permission to invoke from API Gateway.
+        assert resources['myauthdb6dInvokePermission'] == {
+            'Type': 'AWS::Lambda::Permission',
+            'Properties': {
+                'Action': 'lambda:InvokeFunction',
+                'FunctionName': {'Fn::GetAtt': ['myauthdb6d', 'Arn']},
+                'Principal': 'apigateway.amazonaws.com',
+                'SourceArn': {
+                    'Fn::Sub': [
+                        ('arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}'
+                         ':${RestAPIId}/*'),
+                        {'RestAPIId': {'Ref': 'RestAPI'}}]}},
+        }
+        # Also verify we add the expected outputs when using
+        # a Rest API.
+        assert template['Outputs'] == {
+            'APIHandlerArn': {
+                'Value': {
+                    'Fn::GetAtt': ['APIHandler', 'Arn']
+                }
+            },
+            'APIHandlerName': {'Value': {'Ref': 'APIHandler'}},
+            'EndpointURL': {
+                'Value': {
+                    'Fn::Sub': (
+                        'https://${RestAPI}.execute-api.'
+                        '${AWS::Region}.amazonaws.com/api/'
+                    )
+                }
+            },
+            'RestAPIId': {'Value': {'Ref': 'RestAPI'}}
+        }


### PR DESCRIPTION
This brings numerous benefits:

1. Full parity with `chalice deploy`.  This means you can use the
package command for pure lambda functions, built in authorizers,
and scheduled events.
2. We'll now get exceptions raised when a new resource isn't supported
in the `package` command instead of silently ignoring the resource
like we do now.

The generated template is slightly different from the old deployer,
notably:

1. The `Events` key is no longer used for `Api` types.  Instead we just
manually create a lambda permission resource that allows api gateway to
invoke the API handler.  This also more closely matches what
`chalice deploy` does.
2. The `Policies` is just the generated policy (when it applies).
Previously the value was a list of policies, but chalice only generates
a single policy.

Here's an worked example with diffs of the old vs. new packager: https://gist.github.com/jamesls/c80880fb7df39bc33ef4d30aca7d6995