### PR TITLE
Update SAM template to have parity with chalice deploy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ for more detailed information about upgrading to this release.
   (`#685 <https://github.com/aws/chalice/issues/685>`__)
 * Rewrite Chalice deployer to more easily support additional AWS resources
   (`#604 <https://github.com/aws/chalice/issues/604>`__)
+* Update the ``chalice package`` command to support
+  pure lambda functions and scheduled events.
+  (`#772 <https://github.com/aws/chalice/issues/772>`__)
 
 
 1.1.1

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -520,7 +520,7 @@ class ApplicationGraphBuilder(object):
             )
         policy = models.IAMPolicy(document=models.Placeholder.BUILD_STAGE)
         if not config.autogen_policy:
-            resource_name = 'role-%s' % function_name
+            resource_name = '%s_role' % function_name
             role_name = '%s-%s-%s' % (config.app_name, stage_name,
                                       function_name)
             if config.iam_policy_file is not None:

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -220,7 +220,6 @@ class SAMTemplateGenerator(object):
                     {'PolicyDocument': resource.policy.document,
                      'PolicyName': role_cfn_name + 'Policy'},
                 ],
-                'RoleName': resource.role_name,
             }
         }
 

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -449,7 +449,7 @@ class CodePipeline(BaseResource):
                         "RoleArn": {
                             "Fn::GetAtt": "CFNDeployRole.Arn"
                         },
-                        "Capabilities": "CAPABILITY_IAM",
+                        "Capabilities": "CAPABILITY_NAMED_IAM",
                         "StackName": {
                             "Fn::Sub": "${ApplicationName}BetaStack"
                         },

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -465,7 +465,7 @@ class CodePipeline(BaseResource):
                         "RoleArn": {
                             "Fn::GetAtt": "CFNDeployRole.Arn"
                         },
-                        "Capabilities": "CAPABILITY_NAMED_IAM",
+                        "Capabilities": "CAPABILITY_IAM",
                         "StackName": {
                             "Fn::Sub": "${ApplicationName}BetaStack"
                         },

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Any, Optional  # noqa
 
 from chalice.config import Config  # noqa
 from chalice import constants
+from chalice import __version__ as chalice_version
 
 
 class InvalidCodeBuildPythonVersion(Exception):
@@ -16,12 +17,23 @@ class InvalidCodeBuildPythonVersion(Exception):
 
 class PipelineParameters(object):
     def __init__(self, app_name, lambda_python_version,
-                 codebuild_image=None, code_source='codecommit'):
-        # type: (str, str, Optional[str], str) -> None
+                 codebuild_image=None, code_source='codecommit',
+                 chalice_version_range=None):
+        # type: (str, str, Optional[str], str, Optional[str]) -> None
         self.app_name = app_name
         self.lambda_python_version = lambda_python_version
         self.codebuild_image = codebuild_image
         self.code_source = code_source
+        if chalice_version_range is None:
+            chalice_version_range = self._lock_to_minor_version()
+        self.chalice_version_range = chalice_version_range
+
+    def _lock_to_minor_version(self):
+        # type: () -> str
+        parts = [int(p) for p in chalice_version.split('.')]
+        min_version = '%s.%s.%s' % (parts[0], parts[1], 0)
+        max_version = '%s.%s.%s' % (parts[0], parts[1] + 1, 0)
+        return '>=%s,<%s' % (min_version, max_version)
 
 
 class CreatePipelineTemplate(object):
@@ -138,10 +150,10 @@ class CodeBuild(BaseResource):
         self._add_s3_bucket(resources, outputs)
         self._add_codebuild_role(resources, outputs)
         self._add_codebuild_policy(resources)
-        self._add_package_build(resources)
+        self._add_package_build(resources, pipeline_params)
 
-    def _add_package_build(self, resources):
-        # type: (Dict[str, Any]) -> None
+    def _add_package_build(self, resources, pipeline_params):
+        # type: (Dict[str, Any], PipelineParameters) -> None
         resources['AppPackageBuild'] = {
             "Type": "AWS::CodeBuild::Project",
             "Properties": {
@@ -171,28 +183,32 @@ class CodeBuild(BaseResource):
                 },
                 "Source": {
                     "Type": "CODEPIPELINE",
-                    "BuildSpec": (
-                        "version: 0.1\n"
-                        "phases:\n"
-                        "  install:\n"
-                        "    commands:\n"
-                        "      - sudo pip install --upgrade awscli\n"
-                        "      - aws --version\n"
-                        "      - sudo pip install chalice\n"
-                        "      - sudo pip install -r requirements.txt\n"
-                        "      - chalice package /tmp/packaged\n"
-                        "      - aws cloudformation package"
-                        " --template-file /tmp/packaged/sam.json"
-                        " --s3-bucket ${APP_S3_BUCKET}"
-                        " --output-template-file transformed.yaml\n"
-                        "artifacts:\n"
-                        "  type: zip\n"
-                        "  files:\n"
-                        "    - transformed.yaml\n"
-                    )
+                    "BuildSpec": self._get_default_buildspec(pipeline_params),
                 }
             }
         }
+
+    def _get_default_buildspec(self, pipeline_params):
+        # type: (PipelineParameters) -> str
+        return (
+            "version: 0.1\n"
+            "phases:\n"
+            "  install:\n"
+            "    commands:\n"
+            "      - sudo pip install --upgrade awscli\n"
+            "      - aws --version\n"
+            "      - sudo pip install 'chalice%s'\n"
+            "      - sudo pip install -r requirements.txt\n"
+            "      - chalice package /tmp/packaged\n"
+            "      - aws cloudformation package"
+            " --template-file /tmp/packaged/sam.json"
+            " --s3-bucket ${APP_S3_BUCKET}"
+            " --output-template-file transformed.yaml\n"
+            "artifacts:\n"
+            "  type: zip\n"
+            "  files:\n"
+            "    - transformed.yaml\n"
+        ) % pipeline_params.chalice_version_range
 
     def _add_s3_bucket(self, resources, outputs):
         # type: (Dict[str, Any], Dict[str, Any]) -> None

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -3,7 +3,6 @@ import os
 import zipfile
 import json
 import contextlib
-import hashlib
 import tempfile
 import re
 import shutil

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -29,10 +29,10 @@ def to_cfn_resource_name(name):
     This transform ensures that only alphanumeric characters are used
     and prevent collisions by appending the hash of the original name.
     """
-    alphanumeric_only_name = re.sub(r'[^A-Za-z0-9]+', '', name)
-    return ''.join([
-        alphanumeric_only_name, hashlib.md5(
-            name.encode('utf-8')).hexdigest()[:4]])
+    for word_separator in ['-', '_']:
+        word_parts = name.split(word_separator)
+        name = ''.join([w[0].upper() + w[1:] for w in word_parts])
+    return re.sub(r'[^A-Za-z0-9]+', '', name)
 
 
 def remove_stage_from_deployed_values(key, filename):

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -25,11 +25,17 @@ def to_cfn_resource_name(name):
     # type: (str) -> str
     """Transform a name to a valid cfn name.
 
-    This transform ensures that only alphanumeric characters are used
-    and prevent collisions by appending the hash of the original name.
+    This will convert the provided name to a CamelCase name.
+    It's possible that the conversion to a CFN resource name
+    can result in name collisions.  It's up to the caller
+    to handle name collisions appropriately.
+
     """
-    for word_separator in ['-', '_']:
-        word_parts = name.split(word_separator)
+    if not name:
+        raise ValueError("Invalid name: %r" % name)
+    word_separators = ['-', '_']
+    for word_separator in word_separators:
+        word_parts = [p for p in name.split(word_separator) if p]
         name = ''.join([w[0].upper() + w[1:] for w in word_parts])
     return re.sub(r'[^A-Za-z0-9]+', '', name)
 

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -17,12 +17,13 @@ This release features a rewrite of the Chalice deployer
 This is a backwards compatible change, and should not have any
 noticeable changes with deployments with the exception of
 fixing deployer bugs (e.g. https://github.com/aws/chalice/issues/604).
-This code path affects the ``chalice deploy`` and ``chalice delete`` commands.
+This code path affects the ``chalice deploy``, ``chalice delete``, and
+``chalice package`` commands.
 
 While this release is backwards compatible, you will notice several
 changes when you upgrade to version 1.2.0.
 
-First, the output of ``chalice deploy`` has changed in order to give
+The output of ``chalice deploy`` has changed in order to give
 more details about the resources it creates along with a more detailed
 summary at the end::
 
@@ -37,7 +38,7 @@ summary at the end::
       - Lambda ARN: arn:aws:lambda:us-west-2:12345:function:myapp-dev
       - Rest API URL: https://abcd.execute-api.us-west-2.amazonaws.com/api/
 
-Second, the files used to store deployed values has changed.  These files are
+Also, the files used to store deployed values has changed.  These files are
 used internally by the ``chalice deploy/delete`` commands and you typically
 do not interact with these files directly.  It's mentioned here in case
 you notice new files in your ``.chalice`` directory.  Note that these files
@@ -115,6 +116,31 @@ the format as you deploy a given stage.
   ``.chalice/deployed/<stage>.json``.  This means you cannot downgrade
   to earlier versions of chalice unless you manually update
   ``.chalice/deployed.json`` as well.
+
+
+The ``chalice package`` command has also been updated to use the
+deployer.  This results in several changes compared to the previous
+version:
+
+* Pure lambdas are supported
+* Scheduled events are supported
+* Parity between the behavior of ``chalice deploy`` and ``chalice package``
+
+As part of this change, the CFN resource names have been updated
+to use ``CamelCase`` names.  Previously, chalice converted your
+python function names to CFN resource names by removing all
+non alphanumeric characters and appending an md5 checksum,
+e.g ``my_function -> myfunction3bfc``.  With this new packager
+update, the resource name would be converted as
+``my_function -> MyFunction``.  Note, the ``Outputs`` section
+renames unchanged in order to preserve backwards compatibility.
+In order to fix parity issues with ``chalice deploy`` and
+``chalice package``, we now explicitly create an IAM role
+resource as part of the default configuration.  This means
+the default SAM template requires capability ``CAPABILITY_NAMED_IAM``
+instead of ``CAPABILITY_IAM``.  As always, you still have the
+ability to control exactly how IAM roles map to your AWS Lambda
+functions.  This only affects the default configuration.
 
 
 .. _v1-0-0b2:

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -136,11 +136,7 @@ update, the resource name would be converted as
 renames unchanged in order to preserve backwards compatibility.
 In order to fix parity issues with ``chalice deploy`` and
 ``chalice package``, we now explicitly create an IAM role
-resource as part of the default configuration.  This means
-the default SAM template requires capability ``CAPABILITY_NAMED_IAM``
-instead of ``CAPABILITY_IAM``.  As always, you still have the
-ability to control exactly how IAM roles map to your AWS Lambda
-functions.  This only affects the default configuration.
+resource as part of the default configuration.
 
 
 .. _v1-0-0b2:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,6 +56,8 @@ def sample_app_schedule_only():
     def cron(event):
         pass
 
+    return app
+
 
 @fixture
 def sample_app_lambda_only():
@@ -64,6 +66,8 @@ def sample_app_lambda_only():
     @app.lambda_function()
     def myfunction(event, context):
         pass
+
+    return app
 
 
 @fixture

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -502,7 +502,7 @@ def test_will_custom_auth_with_cfn(sample_app):
             'authorizerUri': {
                 'Fn::Sub': (
                     'arn:aws:apigateway:${AWS::Region}:lambda:path'
-                    '/2015-03-31/functions/${authfa53.Arn}/invocations'
+                    '/2015-03-31/functions/${Auth.Arn}/invocations'
                 )
             }
         }

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -147,6 +147,14 @@ class TestSAMTemplate(object):
             }
         }
 
+    def test_duplicate_resource_name_raises_error(self):
+        one = self.lambda_function()
+        two = self.lambda_function()
+        one.resource_name = 'foo_bar'
+        two.resource_name = 'foo__bar'
+        with pytest.raises(package.DuplicateResourceNameError):
+            self.template_gen.generate_sam_template([one, two])
+
     def test_role_arn_inserted_when_necessary(self):
         function = models.LambdaFunction(
             resource_name='foo',
@@ -178,7 +186,7 @@ class TestSAMTemplate(object):
     def test_can_generate_scheduled_event(self):
         function = self.lambda_function()
         event = models.ScheduledEvent(
-            resource_name='foo',
+            resource_name='foo-event',
             rule_name='myrule',
             schedule_expression='rate(5 minutes)',
             lambda_function=function,
@@ -190,7 +198,7 @@ class TestSAMTemplate(object):
         assert len(resources) == 1
         cfn_resource = list(resources.values())[0]
         assert cfn_resource['Properties']['Events'] == {
-            'Foo': {
+            'FooEvent': {
                 'Type': 'Schedule',
                 'Properties': {
                     'Schedule': 'rate(5 minutes)'

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -267,11 +267,13 @@ class TestSAMTemplate(object):
         assert len(resources) == 1
         cfn_role = resources['DefaultRole']
         assert cfn_role['Type'] == 'AWS::IAM::Role'
-        assert cfn_role['Properties']['RoleName'] == 'app-dev'
         assert cfn_role['Properties']['Policies'] == [
             {'PolicyName': 'DefaultRolePolicy',
              'PolicyDocument': {'iam': 'policy'}}
         ]
+        # Ensure the RoleName is not in the resource properties
+        # so we don't require CAPABILITY_NAMED_IAM.
+        assert 'RoleName' not in cfn_role['Properties']
 
     def test_single_role_generated_for_default_config(self,
                                                       sample_app_lambda_only):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -9,6 +9,7 @@ from chalice.deploy.deployer import DependencyBuilder
 from chalice.deploy.deployer import BuildStage
 from chalice.deploy import models
 from chalice.deploy.swagger import SwaggerGenerator
+from chalice.constants import LAMBDA_TRUST_POLICY
 from chalice.utils import OSUtils
 
 
@@ -95,7 +96,11 @@ class TestSAMTemplate(object):
         assert 'Outputs' in template
         assert 'Resources' in template
         assert list(sorted(template['Resources'])) == [
-            'APIHandler', 'APIHandlerInvokePermission', 'RestAPI',
+            'APIHandler', 'APIHandlerInvokePermission',
+            # This casing on the ApiHandlerRole name is unfortunate, but the 3
+            # other resources in this list are hardcoded from the old deployer.
+            'ApiHandlerRole',
+            'RestAPI',
         ]
 
     def test_sam_injects_policy(self, sample_app):
@@ -124,7 +129,7 @@ class TestSAMTemplate(object):
                 'CodeUri': 'foo.zip',
                 'Handler': 'app.app',
                 'MemorySize': 128,
-                'Policies': {'iam': 'policy'},
+                'Role': {'Fn::GetAtt': ['Role', 'Arn']},
                 'Runtime': 'python27',
                 'Tags': {'foo': 'bar'},
                 'Timeout': 120
@@ -170,7 +175,7 @@ class TestSAMTemplate(object):
             },
         }
 
-    def test_can_generate_scheduled_event(self, sample_app_schedule_only):
+    def test_can_generate_scheduled_event(self):
         function = self.lambda_function()
         event = models.ScheduledEvent(
             resource_name='foo',
@@ -185,7 +190,7 @@ class TestSAMTemplate(object):
         assert len(resources) == 1
         cfn_resource = list(resources.values())[0]
         assert cfn_resource['Properties']['Events'] == {
-            'fooacbd': {
+            'Foo': {
                 'Type': 'Schedule',
                 'Properties': {
                     'Schedule': 'rate(5 minutes)'
@@ -216,13 +221,13 @@ class TestSAMTemplate(object):
         }
         assert resources['RestAPI']['Type'] == 'AWS::Serverless::Api'
         # We should also create the auth lambda function.
-        assert resources['myauthdb6d']['Type'] == 'AWS::Serverless::Function'
+        assert resources['Myauth']['Type'] == 'AWS::Serverless::Function'
         # Along with permission to invoke from API Gateway.
-        assert resources['myauthdb6dInvokePermission'] == {
+        assert resources['MyauthInvokePermission'] == {
             'Type': 'AWS::Lambda::Permission',
             'Properties': {
                 'Action': 'lambda:InvokeFunction',
-                'FunctionName': {'Fn::GetAtt': ['myauthdb6d', 'Arn']},
+                'FunctionName': {'Fn::GetAtt': ['Myauth', 'Arn']},
                 'Principal': 'apigateway.amazonaws.com',
                 'SourceArn': {
                     'Fn::Sub': [
@@ -249,3 +254,55 @@ class TestSAMTemplate(object):
             },
             'RestAPIId': {'Value': {'Ref': 'RestAPI'}}
         }
+
+    def test_managed_iam_role(self):
+        role = models.ManagedIAMRole(
+            resource_name='default_role',
+            role_name='app-dev',
+            trust_policy=LAMBDA_TRUST_POLICY,
+            policy=models.AutoGenIAMPolicy(document={'iam': 'policy'}),
+        )
+        template = self.template_gen.generate_sam_template([role])
+        resources = template['Resources']
+        assert len(resources) == 1
+        cfn_role = resources['DefaultRole']
+        assert cfn_role['Type'] == 'AWS::IAM::Role'
+        assert cfn_role['Properties']['RoleName'] == 'app-dev'
+        assert cfn_role['Properties']['Policies'] == [
+            {'PolicyName': 'DefaultRolePolicy',
+             'PolicyDocument': {'iam': 'policy'}}
+        ]
+
+    def test_single_role_generated_for_default_config(self,
+                                                      sample_app_lambda_only):
+        # The sample_app has one lambda function.
+        # We'll add a few more and verify they all share the same role.
+        @sample_app_lambda_only.lambda_function()
+        def second(event, context):
+            pass
+
+        @sample_app_lambda_only.lambda_function()
+        def third(event, context):
+            pass
+
+        config = Config.create(chalice_app=sample_app_lambda_only,
+                               project_dir='.',
+                               autogen_policy=True,
+                               api_gateway_stage='api')
+        template = self.generate_template(config, 'dev')
+        roles = [resource for resource in template['Resources'].values()
+                 if resource['Type'] == 'AWS::IAM::Role']
+        assert len(roles) == 1
+        # The lambda functions should all reference this role.
+        functions = [
+            resource for resource in template['Resources'].values()
+            if resource['Type'] == 'AWS::Serverless::Function'
+        ]
+        role_names = [
+            function['Properties']['Role'] for function in functions
+        ]
+        assert role_names == [
+            {'Fn::GetAtt': ['DefaultRole', 'Arn']},
+            {'Fn::GetAtt': ['DefaultRole', 'Arn']},
+            {'Fn::GetAtt': ['DefaultRole', 'Arn']},
+        ]

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -158,10 +158,22 @@ def test_codepipeline_resource(pipeline_params):
 
 def test_install_requirements_in_buildspec(pipeline_params):
     template = {}
+    pipeline_params.chalice_version_range = '>=1.0.0,<2.0.0'
     pipeline.CodeBuild().add_to_template(template, pipeline_params)
     build = template['Resources']['AppPackageBuild']
     build_spec = build['Properties']['Source']['BuildSpec']
     assert 'pip install -r requirements.txt' in build_spec
+    assert "pip install 'chalice>=1.0.0,<2.0.0'" in build_spec
+
+
+def test_default_version_range_locks_minor_version():
+    parts = [int(p) for p in chalice_version.split('.')]
+    min_version = '%s.%s.%s' % (parts[0], parts[1], 0)
+    max_version = '%s.%s.%s' % (parts[0], parts[1] + 1, 0)
+    params = pipeline.PipelineParameters('appname', 'python2.7')
+    assert params.chalice_version_range == '>=%s,<%s' % (
+        min_version, max_version
+    )
 
 
 def test_can_generate_github_source(pipeline_params):

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -148,7 +148,7 @@ def test_codepipeline_resource(pipeline_params):
     beta_config = beta_stage['Actions'][0]['Configuration']
     assert beta_config == {
         'ActionMode': 'CHANGE_SET_REPLACE',
-        'Capabilities': 'CAPABILITY_NAMED_IAM',
+        'Capabilities': 'CAPABILITY_IAM',
         'ChangeSetName': {'Fn::Sub': '${ApplicationName}ChangeSet'},
         'RoleArn': {'Fn::GetAtt': 'CFNDeployRole.Arn'},
         'StackName': {'Fn::Sub': '${ApplicationName}BetaStack'},

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -43,3 +43,24 @@ def test_serialize_json():
         '  "foo": "bar"\n'
         '}\n'
     )
+
+
+@pytest.mark.parametrize('name,cfn_name', [
+    ('f', 'F'),
+    ('foo', 'Foo'),
+    ('foo_bar', 'FooBar'),
+    ('foo_bar_baz', 'FooBarBaz'),
+    ('F', 'F'),
+    ('FooBar', 'FooBar'),
+    ('S3Bucket', 'S3Bucket'),
+    ('s3Bucket', 'S3Bucket'),
+    ('123', '123'),
+    ('foo-bar-baz', 'FooBarBaz'),
+    ('foo_bar-baz', 'FooBarBaz'),
+    ('foo-bar_baz', 'FooBarBaz'),
+    # Not actually possible, but we should
+    # ensure we only have alphanumeric chars.
+    ('foo_bar!?', 'FooBar'),
+])
+def test_to_cfn_resource_name(name, cfn_name):
+    assert utils.to_cfn_resource_name(name) == cfn_name


### PR DESCRIPTION
This fixes issues with the IAM role generation logic used when
creating Lambda function.  Previously, we'd just attach the policy
directly to the serverless function resource.  This resulted in
generating a role per lambda function.  However, this didn't
match the behavior of `chalice deploy`.  The default behavior is
that all the Lambda functions share the same role unless you
explicitly configure things.

In order to achieve this parity, a separate IAM role resource is
now created, and the serverless function resource is updated
to point to this resource.  This allows us to match exactly
what `chalice deploy` does.

There are two user visible changes/consequences from this:

1. I udpated the resource names to be `CamelCased`.  This fixes
a consistency issue where the hard coded names were camel cased
(e.g `APIHandler`) whereas the autogenerated names removed
non-alphanumeric character and added an md5 hash on the end.

2. Because we are explicitly created a named IAM resource, you
need to use the `CAPABILITY_NAMED_IAM` instead of `CAPABILITY_IAM`
when deploying your SAM template.


(2) is a bit iffy, but this is fixing a bug, so we need to decide
if fixing the bugs with the inconsistency between package/deploy
is more important than preserving `CAPABILITY_IAM` in the default
configuration case.
