### PR TITLE
Fix doc links used in make doccheck

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -26,7 +26,7 @@ Chalice
 
       A Lambda context object that is passed to the invoked view by AWS
       Lambda. You can find out more about this object by reading the
-      `lambda context object documentation <http://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_.
+      `lambda context object documentation <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_.
 
    .. attribute:: debug
 
@@ -157,7 +157,7 @@ Chalice
         instance of type ``ScheduleExpression``, which is either a
         :class:`Cron` or :class:`Rate` object.  If a string value is
         provided, it will be provided directly as the ``ScheduleExpression``
-        value in the `PutRule <http://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax>`__ API
+        value in the `PutRule <https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax>`__ API
         call.
 
       :param name: The name of the function to use.  This name is combined
@@ -594,7 +594,7 @@ Scheduled Events
     supported.
 
   For more information, see the API
-  `docs page <http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`__.
+  `docs page <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions>`__.
 
   Examples:
 

--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -40,7 +40,7 @@ To associate an IAM authorizer with a route in chalice, you use the
 
 
 See the `API Gateway documentation
-<http://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html>`__
+<https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html>`__
 for more information on controlling access to API Gateway with IAM permissions.
 
 Amazon Cognito User Pools
@@ -69,7 +69,7 @@ cognito user pool configured.
 
 For more information about using Cognito user pools with API Gateway,
 see the `Use Amazon Cognito User Pools documentation
-<http://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html>`__.
+<https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html>`__.
 
 
 Custom Authorizers
@@ -217,10 +217,10 @@ without modification back to API Gateway.
 
 For more information on custom authorizers, see the
 `Use API Gateway Custom Authorizers
-<http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html>`__
+<https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html>`__
 page in the API Gateway user guide.
 
 
-.. _IAM permissions: http://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html
-.. _Cognito User Pools: http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html
-.. _API Gateway documentation: http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-lambda-function-create
+.. _IAM permissions: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html
+.. _Cognito User Pools: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html
+.. _API Gateway documentation: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html

--- a/docs/source/topics/cd.rst
+++ b/docs/source/topics/cd.rst
@@ -74,7 +74,7 @@ a change needs to be deployed.
 The default CodeCommit repository that is created is empty, you will have to
 populate it with the Chalice application code. Permissions will also need to be
 set up, you can find the documentation on how to do that
-`here <http://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html>`_
+`here <https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html>`_
 .
 
 

--- a/docs/source/topics/logging.rst
+++ b/docs/source/topics/logging.rst
@@ -5,7 +5,7 @@ You have several options for logging in your
 application.  You can use any of the options
 available to lambda functions as outlined
 in the
-`AWS Lambda Docs <http://docs.aws.amazon.com/lambda/latest/dg/python-logging.html>`_.
+`AWS Lambda Docs <https://docs.aws.amazon.com/lambda/latest/dg/python-logging.html>`_.
 The simplest option is to just use print statements.
 Anything you print will be accessible in cloudwatch logs
 as well as in the output of the ``chalice logs`` command.

--- a/docs/source/topics/purelambda.rst
+++ b/docs/source/topics/purelambda.rst
@@ -58,4 +58,4 @@ Limitations:
   possible to deploy only lambda functions without an API Gateway API.
 
 
-.. _defined here: http://docs.aws.amazon.com/lambda/latest/dg/python-programming-model-handler-types.html
+.. _defined here: https://docs.aws.amazon.com/lambda/latest/dg/python-programming-model-handler-types.html

--- a/docs/source/topics/sdks.rst
+++ b/docs/source/topics/sdks.rst
@@ -161,4 +161,4 @@ page to test:
     </html>
 
 
-.. _API Gateway: http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-generate-sdk.html
+.. _API Gateway: https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-generate-sdk.html


### PR DESCRIPTION
1. Fix http to https.  You get redirects now.
2. Fix a broken link (looks like the doc page has been removed)