### PR TITLE
Generate codecov reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
   - make $TEST_TYPE
 after_success:
-  - if [[ $TEST_TYPE == 'coverage' ]]; then pip install codecov==2.0.5 && codecov; fi
+  - if [[ $TEST_TYPE == 'prcheck-py2' ]]; then pip install codecov==2.0.5 && codecov; fi


### PR DESCRIPTION
This broke when the travis yml file was updated
to use prcheck/prcheck2 as TEST_TYPEs.

Working now: https://travis-ci.org/jamesls/chalice/jobs/361826416#L806