### PR TITLE
Fix packager edge case normalizing sdist names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ for more detailed information about upgrading to this release.
 * Update the ``chalice package`` command to support
   pure lambda functions and scheduled events.
   (`#772 <https://github.com/aws/chalice/issues/772>`__)
+* Fix packager edge case normalizing sdist names
+  (`#778 <https://github.com/aws/chalice/issues/778>`__)
 
 
 1.1.1

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -504,13 +504,13 @@ class Package(object):
             # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-
             # {platform tag}.whl
             name, version = self.filename.split('-')[:2]
-            name = self._normalize_name(name)
         else:
             info_fetcher = SDistMetadataFetcher(osutils=self._osutils)
             sdist_path = self._osutils.joinpath(self._directory, self.filename)
             name, version = info_fetcher.get_package_name_and_version(
                 sdist_path)
-        return name, version
+        normalized_name = self._normalize_name(name)
+        return normalized_name, version
 
 
 class SDistMetadataFetcher(object):

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -951,3 +951,21 @@ class TestPackage(object):
             pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
             pkgs.add(Package(tempdir, 'foobar-1.0.zip'))
             assert len(pkgs) == 1
+
+    def test_ensure_sdist_name_normalized_for_comparison(self, osutils,
+                                                         sdist_builder):
+        with osutils.tempdir() as tempdir:
+            sdist_builder.write_fake_sdist(tempdir, 'Foobar', '1.0')
+            pkgs = set()
+            pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
+            pkgs.add(Package(tempdir, 'Foobar-1.0.zip'))
+            assert len(pkgs) == 1
+
+    def test_ensure_wheel_name_normalized_for_comparison(self, osutils,
+                                                         sdist_builder):
+        with osutils.tempdir() as tempdir:
+            sdist_builder.write_fake_sdist(tempdir, 'foobar', '1.0')
+            pkgs = set()
+            pkgs.add(Package('', 'Foobar-1.0-py3-none-any.whl'))
+            pkgs.add(Package(tempdir, 'foobar-1.0.zip'))
+            assert len(pkgs) == 1


### PR DESCRIPTION
If a package name is different from its normalized name then there would
be a packaging issue where it would fail to recognize a valid whl file
it had generated from an sdist. The whl file would be normalized
according to PEP 550 and the sdist one would not causing it not to be
added to the list of valid whl files for deployment.

fixes #778 