### PR TITLE
Rename UnreferencedResourcePlanner to ResourceSweeper

### DIFF
--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -106,7 +106,7 @@ from chalice.deploy import models
 from chalice.deploy.packager import PipRunner, SubprocessPip, \
     DependencyBuilder as PipDependencyBuilder, LambdaDeploymentPackager
 from chalice.deploy.planner import PlanStage, RemoteState, \
-    UnreferencedResourcePlanner, NoopPlanner, Variable, StringFormat
+    ResourceSweeper, NoopPlanner, Variable, StringFormat
 from chalice.deploy.swagger import TemplatedSwaggerGenerator
 from chalice.deploy.swagger import SwaggerGenerator  # noqa
 from chalice.policy import AppPolicyGenerator
@@ -245,7 +245,7 @@ def create_default_deployer(session, config, ui):
             osutils=osutils, remote_state=RemoteState(
                 client, config.deployed_resources(config.chalice_stage)),
         ),
-        sweeper=UnreferencedResourcePlanner(),
+        sweeper=ResourceSweeper(),
         executor=Executor(client, ui),
         recorder=ResultsRecorder(osutils=osutils),
     )
@@ -290,7 +290,7 @@ def create_deletion_deployer(client, ui):
         deps_builder=DependencyBuilder(),
         build_stage=BuildStage(steps=[]),
         plan_stage=NoopPlanner(),
-        sweeper=UnreferencedResourcePlanner(),
+        sweeper=ResourceSweeper(),
         executor=Executor(client, ui),
         recorder=ResultsRecorder(osutils=OSUtils()),
     )
@@ -323,7 +323,7 @@ class Deployer(object):
                  deps_builder,         # type: DependencyBuilder
                  build_stage,          # type: BuildStage
                  plan_stage,           # type: PlanStage
-                 sweeper,              # type: UnreferencedResourcePlanner
+                 sweeper,              # type: ResourceSweeper
                  executor,             # type: Executor
                  recorder,             # type: ResultsRecorder
                  ):

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -80,7 +80,7 @@ class RemoteState(object):
         return self._client.rest_api_exists(rest_api_id)
 
 
-class UnreferencedResourcePlanner(object):
+class ResourceSweeper(object):
 
     def execute(self, plan, config):
         # type: (models.Plan, Config) -> None

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -39,7 +39,7 @@ from chalice.deploy.deployer import create_default_deployer, \
     ResultsRecorder, DeploymentReporter
 from chalice.deploy.swagger import SwaggerGenerator, TemplatedSwaggerGenerator
 from chalice.deploy.planner import PlanStage, Variable
-from chalice.deploy.planner import UnreferencedResourcePlanner, StringFormat
+from chalice.deploy.planner import ResourceSweeper, StringFormat
 from chalice.deploy.models import APICall, StoreValue, RecordResourceValue
 from chalice.deploy.models import RecordResourceVariable
 from chalice.deploy.models import JPSearch, BuiltinFunction, Instruction
@@ -1433,7 +1433,7 @@ class TestDeployer(unittest.TestCase):
         self.deps_builder = mock.Mock(spec=DependencyBuilder)
         self.build_stage = mock.Mock(spec=BuildStage)
         self.plan_stage = mock.Mock(spec=PlanStage)
-        self.sweeper = mock.Mock(spec=UnreferencedResourcePlanner)
+        self.sweeper = mock.Mock(spec=ResourceSweeper)
         self.executor = mock.Mock(spec=Executor)
         self.recorder = mock.Mock(spec=ResultsRecorder)
         self.chalice_app = Chalice(app_name='foo')

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -9,7 +9,7 @@ from chalice.config import DeployedResources
 from chalice.utils import OSUtils
 from chalice.deploy.planner import PlanStage, Variable, RemoteState
 from chalice.deploy.planner import StringFormat
-from chalice.deploy.planner import UnreferencedResourcePlanner
+from chalice.deploy.planner import ResourceSweeper
 
 
 def create_function_resource(name, function_name=None,
@@ -620,7 +620,7 @@ class TestRemoteState(object):
 
 class TestUnreferencedResourcePlanner(object):
     def setup_method(self):
-        self.sweeper = UnreferencedResourcePlanner()
+        self.sweeper = ResourceSweeper()
 
     def execute(self, plan, config):
         self.sweeper.execute(models.Plan(plan, messages={}), config)


### PR DESCRIPTION
The name was always confusing to me, and I think
sweeper makes a lot of sense.