### PR TITLE
Fix abi3 packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ for more detailed information about upgrading to this release.
   (`#778 <https://github.com/aws/chalice/issues/778>`__)
 * Fix SQLAlchemy packaging
   (`#778 <https://github.com/aws/chalice/issues/778>`__)
+* Fix packaging abi3, wheels this fixes cryptography 2.2.x packaging
+  (`#764 <https://github.com/aws/chalice/issues/764>`__)
 
 
 1.1.1

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -284,7 +284,9 @@ class DependencyBuilder(object):
         prefix_version = implementation[:3]
         if prefix_version == 'cp3':
             # Deploying python 3 function which means we need cp36m abi
-            return abi == 'cp36m'
+            # We can also accept abi3 which is the CPython 3 Stable ABI and
+            # will work on any version of python 3.
+            return abi == 'cp36m' or abi == 'abi3'
         elif prefix_version == 'cp2':
             # Deploying to python 2 function which means we need cp27mu abi
             return abi == 'cp27mu'

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -248,6 +248,30 @@ class TestDependencyBuilder(object):
         for req in reqs:
             assert req in installed_packages
 
+    def test_can_use_abi3_whl_for_any_python3(self, tmpdir, pip_runner):
+        reqs = ['foo', 'bar', 'baz', 'qux']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp33-abi3-manylinux1_x86_64.whl',
+                'bar-1.2-cp34-abi3-manylinux1_x86_64.whl',
+                'baz-1.2-cp35-abi3-manylinux1_x86_64.whl',
+                'qux-1.2-cp36-abi3-manylinux1_x86_64.whl',
+            ]
+        )
+
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
     def test_can_expand_purelib_whl(self, tmpdir, pip_runner):
         reqs = ['foo']
         pip, runner = pip_runner


### PR DESCRIPTION
Python 3 has an ABI called abi3 which is the CPython 3 Stable ABI which
is compatible with any version of Python 3 after 3.2. The packager
previously did not recognize these as being compatible with the Lambda
abi of cp36m and would not use them. This fix adds abi3 as a valid abi
for python 3.

This fixes automatic packaging of cryptography 2.2.x since it removed
its specific python 3 wheel files in favor of a single cp34 abi3 wheel.

fixes #764 