### PR TITLE
Fix regression when using role arn in package command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Next Release (TBD)
   (`#715 <https://github.com/aws/chalice/pull/715>`__)
 * Fix parsing empty query strings in local mode
   (`#767 <https://github.com/aws/chalice/pull/767>`__)
+* Fix regression in ``chalice package`` when using role arns
+  (`#793 <https://github.com/aws/chalice/issues/793>`__)
 
 
 1.2.0

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -246,6 +246,10 @@ class SAMTemplateGenerator(object):
         # type: (models.DeploymentPackage, Dict[str, Any]) -> None
         pass
 
+    def _generate_precreatediamrole(self, resource, template):
+        # type: (models.DeploymentPackage, Dict[str, Any]) -> None
+        pass
+
     def _default(self, resource, template):
         # type: (models.Model, Dict[str, Any]) -> None
         raise NotImplementedError(resource)

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -103,6 +103,17 @@ class TestSAMTemplate(object):
             'RestAPI',
         ]
 
+    def test_supports_precreated_role(self):
+        builder = DependencyBuilder()
+        resources = builder.build_dependencies(
+            models.Application(
+                stage='dev',
+                resources=[self.lambda_function()],
+            )
+        )
+        template = self.template_gen.generate_sam_template(resources)
+        assert template['Resources']['Foo']['Properties']['Role'] == 'role:arn'
+
     def test_sam_injects_policy(self, sample_app):
         function = models.LambdaFunction(
             resource_name='foo',


### PR DESCRIPTION
We need a noop method for precreated roles in the template generator.
This was missed in testing because the models were directly
passed to the template generator instead of using the
dependency builder.  In this case we were only passing the
LambdaFunction resource to the template generator, but
in reality we'd also pass the `models.IAMRole` resource
as well because it's a dependency of the lambda function.

Fixes #793.