### PR TITLE
Change EnvironmentVariables to Environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Fix package command not correctly setting environment variables
+  (`#795 <https://github.com/aws/chalice/issues/795>`__)
+
+
 1.2.1
 =====
 

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -114,7 +114,7 @@ class SAMTemplateGenerator(object):
             },
         }
         if resource.environment_variables:
-            resources[cfn_name]['Properties']['EnvironmentVariables'] = {
+            resources[cfn_name]['Properties']['Environment'] = {
                 'Variables': resource.environment_variables
             }
         self._add_iam_role(resource, resources[cfn_name])

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -152,7 +152,7 @@ class TestSAMTemplate(object):
         function.environment_variables = {'foo': 'bar'}
         template = self.template_gen.generate_sam_template([function])
         cfn_resource = list(template['Resources'].values())[0]
-        assert cfn_resource['Properties']['EnvironmentVariables'] == {
+        assert cfn_resource['Properties']['Environment'] == {
             'Variables': {
                 'foo': 'bar'
             }


### PR DESCRIPTION
To set an environment variable for a Lambda funciton through
CloudFormation the Environment key is needed rather than
EnvironmentVariables.

fixes #795  