### PR TITLE
Actually load environment variables before the first loading of the app

### DIFF
--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -119,8 +119,6 @@ class CLIFactory(object):
                                % err)
 
         self._validate_config_from_disk(config_from_disk)
-        app_obj = self.load_chalice_app()
-        user_provided_params['chalice_app'] = app_obj
         if autogen_policy is not None:
             user_provided_params['autogen_policy'] = autogen_policy
         if self.profile is not None:
@@ -131,6 +129,9 @@ class CLIFactory(object):
                         user_provided_params=user_provided_params,
                         config_from_disk=config_from_disk,
                         default_params=default_params)
+        os.environ.update(config.environment_variables)
+        app_obj = self.load_chalice_app()
+        user_provided_params['chalice_app'] = app_obj
         return config
 
     def _validate_config_from_disk(self, config):


### PR DESCRIPTION
This may address #748 where environment variables are not available outside of route handler functions. The app actually gets loaded on both the config object and as a stand alone object within `run_local_server` when using `chalice local`. It's fairly confusing why this happens, but this change actually sets the OS environment variables to what you have in `config.json` before the _first_ time the app gets loaded (in `create_config_obj`)