### PR TITLE
Add --name option to 'chalice logs' command

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -26,6 +26,7 @@ from chalice.utils import getting_started_prompt, UI, serialize_to_json
 from chalice.constants import CONFIG_VERSION, TEMPLATE_APP, GITIGNORE
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
+from chalice.constants import DEFAULT_HANDLER_NAME
 
 
 def create_new_project_skeleton(project_name, profile=None):
@@ -164,7 +165,7 @@ def delete(ctx, profile, stage):
 @click.option('--stage', default=DEFAULT_STAGE_NAME)
 @click.option('-n', '--name',
               help='The name of the lambda function to retrieve logs from.',
-              default='api_handler')
+              default=DEFAULT_HANDLER_NAME)
 @click.option('--profile', help='The profile to use for fetching logs.')
 @click.pass_context
 def logs(ctx, num_entries, include_lambda_messages, stage, name, profile):

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -162,16 +162,19 @@ def delete(ctx, profile, stage):
               default=False,
               help='Controls whether or not lambda log messages are included.')
 @click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('-n', '--name',
+              help='The name of the lambda function to retrieve logs from.',
+              default='api_handler')
 @click.option('--profile', help='The profile to use for fetching logs.')
 @click.pass_context
-def logs(ctx, num_entries, include_lambda_messages, stage, profile):
-    # type: (click.Context, int, bool, str, str) -> None
+def logs(ctx, num_entries, include_lambda_messages, stage, name, profile):
+    # type: (click.Context, int, bool, str, str, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
     factory.profile = profile
     config = factory.create_config_obj(stage, False)
     deployed = config.deployed_resources(stage)
-    if deployed is not None and 'api_handler' in deployed.resource_names():
-        lambda_arn = deployed.resource_values('api_handler')['lambda_arn']
+    if name in deployed.resource_names():
+        lambda_arn = deployed.resource_values(name)['lambda_arn']
         session = factory.create_botocore_session()
         retriever = factory.create_log_retriever(
             session, lambda_arn)

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -154,7 +154,7 @@ class CLIFactory(object):
     def create_log_retriever(self, session, lambda_arn):
         # type: (Session, str) -> LogRetriever
         client = TypedAWSClient(session)
-        retriever = LogRetriever.create_from_arn(client, lambda_arn)
+        retriever = LogRetriever.create_from_lambda_arn(client, lambda_arn)
         return retriever
 
     def load_chalice_app(self, environment_variables=None):

--- a/chalice/logs.py
+++ b/chalice/logs.py
@@ -30,7 +30,7 @@ class LogRetriever(object):
         self._log_group_name = log_group_name
 
     @classmethod
-    def create_from_arn(cls, client, lambda_arn):
+    def create_from_lambda_arn(cls, client, lambda_arn):
         # type: (TypedAWSClient, str) -> LogRetriever
         """Create a LogRetriever from a client and lambda arn.
 

--- a/docs/source/topics/logging.rst
+++ b/docs/source/topics/logging.rst
@@ -83,3 +83,36 @@ output of ``chalice logs``, we'll see the following log message::
 
 
 As you can see here, both the debug and error log message are shown.
+
+You can use the ``-n/--name`` option to view the logs for a specific lambda
+function.  By default, the logs for the API handler lambda function are shown.
+This corresponds to any log statements made within an ``@app.route()`` call.
+The name option is the logical name of the lambda function.  This is the
+name of the python function by default, or whatever name you provided
+as the ``name`` kwarg to the ``@app.lambda_function()`` call.  For example,
+given this app:
+
+.. code-block:: python
+
+    from chalice import Chalice
+
+    app = Chalice(app_name='multilog')
+
+
+    @app.lambda_function()
+    def foo(event, context):
+        app.log.debug("Invoking from function foo")
+        return {'hello': 'world'}
+
+
+    @app.lambda_function(name='MyFunction)
+    def bar(event, context):
+        incr_counter()
+        app.log.debug("Invoking from function bar")
+        return {'hello': 'world'}
+
+
+You can retrieve logs for the above function by running::
+
+    $ chalice logs --name foo
+    $ chalice logs --name MyFunction

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -9,9 +9,18 @@ import mock
 
 from chalice import cli
 from chalice.cli import factory
-from chalice.config import Config
+from chalice.config import Config, DeployedResources
 from chalice.utils import record_deployed_values
 from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
+from chalice.logs import LogRetriever
+
+
+class FakeConfig(object):
+    def __init__(self, deployed_resources):
+        self._deployed_resources = deployed_resources
+
+    def deployed_resources(self, chalice_stage_name):
+        return self._deployed_resources
 
 
 @pytest.fixture
@@ -318,3 +327,30 @@ def test_can_specify_profile_for_logs(runner, mock_cli_factory):
         )
         assert result.exit_code == 0
         assert mock_cli_factory.profile == 'my-profile'
+
+
+def test_can_provide_lambda_name_for_logs(runner, mock_cli_factory):
+    deployed_resources = DeployedResources({
+        "resources": [
+            {"name": "foo",
+             "lambda_arn": "arn:aws:lambda::app-dev-foo",
+             "resource_type": "lambda_function"}]
+    })
+    mock_cli_factory.create_config_obj.return_value = FakeConfig(
+        deployed_resources)
+    log_retriever = mock.Mock(spec=LogRetriever)
+    log_retriever.retrieve_logs.return_value = []
+    mock_cli_factory.create_log_retriever.return_value = log_retriever
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        result = _run_cli_command(
+            runner, cli.logs, ['--name', 'foo'],
+            cli_factory=mock_cli_factory
+        )
+        assert result.exit_code == 0
+    log_retriever.retrieve_logs.assert_called_with(
+        include_lambda_messages=False, max_entries=None)
+    mock_cli_factory.create_log_retriever.assert_called_with(
+        mock.sentinel.Session, 'arn:aws:lambda::app-dev-foo'
+    )

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -12,6 +12,7 @@ from chalice.config import Config
 from chalice import local
 from chalice.utils import UI
 from chalice import Chalice
+from chalice.logs import LogRetriever
 
 
 @fixture
@@ -191,3 +192,12 @@ def test_can_create_deployment_reporter(clifactory):
 def test_can_access_lazy_loaded_app(clifactory):
     config = clifactory.create_config_obj()
     assert isinstance(config.chalice_app, Chalice)
+
+
+def test_can_create_log_retriever(clifactory):
+    session = clifactory.create_botocore_session()
+    lambda_arn = (
+        'arn:aws:lambda:us-west-2:1:function:app-dev-foo'
+    )
+    logs = clifactory.create_log_retriever(session, lambda_arn)
+    assert isinstance(logs, LogRetriever)

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -63,7 +63,7 @@ def test_can_parse_short_id():
 
 
 def test_can_create_from_arn():
-    retriever = logs.LogRetriever.create_from_arn(
+    retriever = logs.LogRetriever.create_from_lambda_arn(
         mock.sentinel.client,
         'arn:aws:lambda:us-east-1:123:function:my-function'
     )


### PR DESCRIPTION
*Issue #, if available:*

#841.

*Description of changes:*

Adds a `--name` option to chalice logs command.  The original `logs` command was written in when there was only a single lambda function.  This now adds support for all lambda functions.

### Example

Given this app:

```python
from chalice import Chalice

app = Chalice(app_name='multilog')
app.debug = True

i = 0

def incr_counter():
    global i
    i += 1


@app.lambda_function()
def foo(event, context):
    incr_counter()
    app.log.debug("Invoking from function foo: %s", i)
    return {'hello': 'world'}


@app.lambda_function()
def bar(event, context):
    incr_counter()
    app.log.debug("Invoking from function bar: %s", i)
    return {'hello': 'world'}


@app.route('/')
def index():
    incr_counter()
    app.log.info("Invoking from '/' route: %s", i)
    return {'hello': 'world'}
```


After invoking the functions a few times:

```
$ http https://abcd.execute-api.us-west-2.amazonaws.com/api/
$ aws lambda invoke --function-name multilog-dev-foo /dev/stdout
$ aws lambda invoke --function-name multilog-dev-bar /dev/stdout
```

The default is still for the API handler lambda so there's no change in behavior:

```
2018-05-19 09:59:44.454000 59fc08 multilog - INFO - Invoking from '/' route: 1
2018-05-19 09:59:44.977000 59fc08 multilog - INFO - Invoking from '/' route: 2
2018-05-19 09:59:45.496000 59fc08 multilog - INFO - Invoking from '/' route: 3
2018-05-19 09:59:46.076000 59fc08 multilog - INFO - Invoking from '/' route: 4
2018-05-19 09:59:46.637000 59fc08 multilog - INFO - Invoking from '/' route: 5
2018-05-19 09:59:47.192000 59fc08 multilog - INFO - Invoking from '/' route: 6
2018-05-19 09:59:47.775000 59fc08 multilog - INFO - Invoking from '/' route: 7
```

But you can now retrieve logs for your other lambda functions as well:

```
$ chalice logs -n foo
2018-05-19 10:01:16.966000 d47fc8 multilog - DEBUG - Invoking from function foo: 1
2018-05-19 10:01:21.994000 d47fc8 multilog - DEBUG - Invoking from function foo: 2
2018-05-19 10:01:22.615000 d47fc8 multilog - DEBUG - Invoking from function foo: 3
2018-05-19 10:01:23.204000 d47fc8 multilog - DEBUG - Invoking from function foo: 4
...

$ chalice logs -n bar
2018-05-19 10:01:39.631000 577e3a multilog - DEBUG - Invoking from function bar: 1
2018-05-19 10:01:40.340000 577e3a multilog - DEBUG - Invoking from function bar: 2
2018-05-19 10:01:41.008000 577e3a multilog - DEBUG - Invoking from function bar: 3
2018-05-19 10:01:41.644000 577e3a multilog - DEBUG - Invoking from function bar: 4
2018-05-19 10:01:42.245000 577e3a multilog - DEBUG - Invoking from function bar: 5
```

Note that the argument of `-n/--name` is the logical resource name, that is `foo` and `bar`, which match the `def foo(): ...`, `def bar(): ...` in the `app.py` file.