### PR TITLE
Fix up cloudwatch event docs

### DIFF
--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -23,12 +23,10 @@ decorator.  Let's look at an example.
         print(event.to_dict())
 
 
-In this example, we've updated the starter hello world app with
-a scheduled event.  When you run ``chalice deploy`` Chalice will create
-two Lambda functions.  The first lambda function is for the API handler
-used by API gateway.  The second lambda function will be for the scheduled
-CloudWatch event (the ``every_hour`` function).   The ``every_hour`` function
-will be automatically invoked every hour by Lambda.
+In this example, we have a single lambda function that we want automatically
+invoked every hour.  When you run ``chalice deploy`` Chalice will create a
+lambda function as well as the necessary CloudWatch events/rules such that the
+``every_hour`` function is invoked every hour.
 
 The :meth:`Chalice.schedule` method accepts either a string or an
 instance of :class:`Rate` or :class:`Cron`.  For example:
@@ -44,3 +42,27 @@ instance of :class:`Rate` or :class:`Cron`.  For example:
 
 The function you decorate must accept a single argument,
 which will be of type :class:`CloudWatchEvent`.
+
+You can use the ``schedule()`` decorator multiple times
+in your chalice app.  Each ``schedule()`` decorator will
+result in a new lambda function and associated CloudWatch
+event rule.  For example:
+
+
+.. code-block:: python
+
+    app = chalice.Chalice(app_name='foo')
+
+    @app.schedule(Rate(1, unit=Rate.HOURS))
+    def every_hour(event):
+        print(event.to_dict())
+
+
+    @app.schedule(Rate(2, unit=Rate.HOURS))
+    def every_two_hours(event):
+        print(event.to_dict())
+
+
+In the app above, chalice will create two lambda functions,
+and configure ``every_hour`` to be invoked once an hour,
+and ``every_two_hours`` to be invoked once every two hours.


### PR DESCRIPTION
When I removed the note about the limitation of app.route(),
I didn't update the text about how many lambda functions are
being created.

I also added a paragraph about using the schedule decorator
multiple times, to make it clear that it's going to create
two separate lambda functions for you.