### PR TITLE
Disable autoreload in integration tests

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -28,7 +28,7 @@ def test_stack_trace_printed_on_error(local_app):
             'app = Chalice(app_name="test")\n'
             'foobarbaz\n'
         )
-    p = subprocess.Popen(['chalice', 'local'],
+    p = subprocess.Popen(['chalice', 'local', '--no-autoreload'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stderr = p.communicate()[1].decode('ascii')
     rc = p.returncode


### PR DESCRIPTION
With the autoreloader in place, an uncaught exception doesn't stop `chalice local`.  It will just wait until there's a file change and then restart the server.  This results in the integration test hanging.  To fix this, I've just disabled autoreload for this test, which was checking that exceptions are printed to stderr.
