### PR TITLE
Initial commit of S3 events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 
 * Add support for generating python 3.6 pipelines
   (`#858 <https://github.com/aws/chalice/pull/858>`)
+* Add support for connecting lambda functions to S3 events
+  (`#855 <https://github.com/aws/chalice/issues/855>`)
 
 
 1.3.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -41,7 +41,7 @@ else:
         return unquote_plus(byte_string).decode(encoding)
     # In python 2 there is a base class for the string types that we can check
     # for. It was removed in python 3 so it will cause a name error.
-    _ANY_STRING = (basestring, bytes)
+    _ANY_STRING = (basestring, bytes)  # noqa
 
 
 def handle_decimals(obj):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -18,15 +18,15 @@ _PARAMS = re.compile(r'{\w+}')
 # on other parts of chalice so it can stay small and lightweight, with minimal
 # startup overhead.  This also means we need to handle py2/py3 compat issues
 # directly in this file instead of copying over compat.py
-if sys.version_info.major == 3:
-    from urllib.parse import unquote_plus  # pylint: disable=E0611,E0401
+try:
+    from urllib.parse import unquote_plus
 
     unquote_str = unquote_plus
 
     # In python 3 string and bytes are different so we explicitly check
     # for both.
     _ANY_STRING = (str, bytes)
-else:
+except ImportError:
     from urllib import unquote_plus
 
     # This is borrowed from botocore/compat.py
@@ -41,7 +41,7 @@ else:
         return unquote_plus(byte_string).decode(encoding)
     # In python 2 there is a base class for the string types that we can check
     # for. It was removed in python 3 so it will cause a name error.
-    _ANY_STRING = (basestring, bytes)  # noqa
+    _ANY_STRING = (basestring, bytes)  # noqa pylint: disable=E0602
 
 
 def handle_decimals(obj):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -129,6 +129,7 @@ class Chalice(object):
     builtin_auth_handlers = ... # type: List[BuiltinAuthConfig]
     event_sources = ... # type: List[CloudWatchEventSource]
     pure_lambda_functions = ... # type: List[LambdaFunction]
+    s3_events = ... # type: List[S3EventConfig]
 
     def __init__(self, app_name: str, debug: bool=False,
                  configure_logs: bool=True,
@@ -206,3 +207,12 @@ class LambdaFunction(object):
     name = ... # type: str
     handler_string = ... # type: str
     func = ... # type: Callable[..., Any]
+
+
+class S3EventConfig(object):
+    name = ... # type: str
+    bucket = ... # type: str
+    events = ... # type: List[str]
+    prefix = ... # type: str
+    suffix = ... # type: str
+    handler_string = ... # type: str

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -185,3 +185,17 @@ class RestAPI(ManagedModel):
     def dependencies(self):
         # type: () -> List[Model]
         return cast(List[Model], [self.lambda_function] + self.authorizers)
+
+
+@attrs
+class S3BucketNotification(ManagedModel):
+    resource_type = 's3_event'
+    bucket = attrib()           # type: str
+    events = attrib()           # type: List[str]
+    prefix = attrib()           # type: Optional[str]
+    suffix = attrib()           # type: Optional[str]
+    lambda_function = attrib()  # type: LambdaFunction
+
+    def dependencies(self):
+        # type: () -> List[Model]
+        return [self.lambda_function]

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -263,8 +263,18 @@ class SAMTemplateGenerator(object):
         pass
 
     def _generate_precreatediamrole(self, resource, template):
-        # type: (models.DeploymentPackage, Dict[str, Any]) -> None
+        # type: (models.PreCreatedIAMRole, Dict[str, Any]) -> None
         pass
+
+    def _generate_s3bucketnotification(self, resource, template):
+        # type: (models.S3BucketNotification, Dict[str, Any]) -> None
+        message = (
+            "Unable to package chalice apps that @app.on_s3_event decorator. "
+            "CloudFormation does not support modifying the event "
+            "notifications of existing buckets. "
+            "You can deploy this app using `chalice deploy`."
+        )
+        raise NotImplementedError(message)
 
     def _default(self, resource, template):
         # type: (models.Model, Dict[str, Any]) -> None

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -779,6 +779,11 @@ Scheduled Events
    .. attribute:: key
 
       The S3 key name associated with the event.
+      The original key name in the S3 event payload
+      is URL encoded.  However, this ``key`` attribute automatically
+      URL decodes the key name for you.  If you need
+      access to the original URL encoded key name, you can
+      access it through the ``to_dict()`` method.
 
    .. method:: to_dict()
 
@@ -787,4 +792,7 @@ Scheduled Events
       access to the lambda event, for example if a
       new key is added to the lambda event that has not
       been mapped as an attribute to the ``S3Event``
-      object.
+      object.  Note that this event is not modified in any way.
+      This means that the key name of the S3 object is URL
+      encoded, which is the way that S3 sends this value
+      to Lambda.

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -87,18 +87,16 @@ Here's an example:
 
 .. code-block:: python
 
-    import boto3
     from chalice import Chalice
 
     app = chalice.Chalice(app_name='s3eventdemo')
-    s3 = boto3.client('s3')
+    app.debug = True
 
     @app.on_s3_event(bucket='mybucket-name',
                      events=['s3:ObjectCreated:*'])
     def handle_s3_event(event):
-        # Download the newly created file locally.
-        s3.downlad_file(event.bucket, event.key, '/tmp/tempfile')
-        # Now we can process '/tmp/tempfile' however we want.
+        app.log.debug("Received event for bucket: %s, key: %s",
+                      event.bucket, event.key)
 
 In this example above, Chalice connects the S3 bucket to the
 ``handle_s3_event`` Lambda function such that whenver an object is uploaded

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -673,8 +673,9 @@ class TestRemoteState(object):
             self.remote_state.resource_exists(foo)
 
 
-class TestUnreferencedResourcePlanner(object):
+class TestUnreferencedResourcePlanner(BasePlannerTests):
     def setup_method(self):
+        super(TestUnreferencedResourcePlanner, self).setup_method()
         self.sweeper = ResourceSweeper()
 
     def execute(self, plan, config):
@@ -862,3 +863,53 @@ class TestUnreferencedResourcePlanner(object):
                 params={'rest_api_id': 'my_rest_api_id'},
             )
         ]
+
+    def test_can_handle_when_resource_changes_values(self):
+        plan = self.determine_plan(
+            models.S3BucketNotification(
+                resource_name='test-s3-event',
+                bucket='NEWBUCKET',
+                events=['s3:ObjectCreated:*'],
+                prefix=None,
+                suffix=None,
+                lambda_function=create_function_resource('function_name'),
+            )
+        )
+        deployed = {
+            'resources': [{
+                'name': 'test-s3-event',
+                'resource_type': 's3_event',
+                'bucket': 'OLDBUCKET',
+                'lambda_arn': 'lambda_arn',
+            }]
+        }
+        config = FakeConfig(deployed)
+        self.execute(plan, config)
+        assert plan[-1] == models.APICall(
+            method_name='disconnect_s3_bucket_from_lambda',
+            params={'bucket': 'OLDBUCKET', 'function_arn': 'lambda_arn'},
+        )
+
+    def test_no_sweeping_when_resource_value_unchanged(self):
+        plan = self.determine_plan(
+            models.S3BucketNotification(
+                resource_name='test-s3-event',
+                bucket='EXISTING-BUCKET',
+                events=['s3:ObjectCreated:*'],
+                prefix=None,
+                suffix=None,
+                lambda_function=create_function_resource('function_name'),
+            )
+        )
+        deployed = {
+            'resources': [{
+                'name': 'test-s3-event',
+                'resource_type': 's3_event',
+                'bucket': 'EXISTING-BUCKET',
+                'lambda_arn': 'lambda_arn',
+            }]
+        }
+        config = FakeConfig(deployed)
+        original_plan = plan[:]
+        self.execute(plan, config)
+        assert plan == original_plan

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1373,3 +1373,59 @@ def test_handles_binary_responses(body, content_type):
     assert serialized['isBase64Encoded']
     assert isinstance(serialized['body'], six.string_types)
     assert isinstance(base64.b64decode(serialized['body']), bytes)
+
+
+def test_can_create_s3_event_handler(sample_app):
+    @sample_app.on_s3_event(bucket='mybucket')
+    def handler(event):
+        pass
+
+    assert len(sample_app.s3_events) == 1
+    event = sample_app.s3_events[0]
+    assert event.name == 'handler'
+    assert event.bucket == 'mybucket'
+    assert event.events == ['s3:ObjectCreated:*']
+    assert event.handler_string == 'app.handler'
+
+
+def test_can_map_to_s3_event_object(sample_app):
+    @sample_app.on_s3_event(bucket='mybucket')
+    def handler(event):
+        return event
+
+    s3_event = {
+        'Records': [
+            {'awsRegion': 'us-west-2',
+             'eventName': 'ObjectCreated:Put',
+             'eventSource': 'aws:s3',
+             'eventTime': '2018-05-22T04:41:23.823Z',
+             'eventVersion': '2.0',
+             'requestParameters': {'sourceIPAddress': '174.127.235.55'},
+             'responseElements': {
+                'x-amz-id-2': 'request-id-2',
+                'x-amz-request-id': 'request-id-1'},
+             's3': {
+                 'bucket': {
+                     'arn': 'arn:aws:s3:::mybucket',
+                     'name': 'mybucket',
+                     'ownerIdentity': {
+                         'principalId': 'ABCD'
+                     }
+                 },
+                 'configurationId': 'config-id',
+                 'object': {
+                     'eTag': 'd41d8cd98f00b204e9800998ecf8427e',
+                     'key': 'hello-world.txt',
+                     'sequencer': '005B039F73C627CE8B',
+                     'size': 0
+                 },
+                 's3SchemaVersion': '1.0'
+             },
+             'userIdentity': {'principalId': 'AWS:XYZ'}
+             }
+        ]
+    }
+    actual_event = handler(s3_event, context=None)
+    assert actual_event.bucket == 'mybucket'
+    assert actual_event.key == 'hello-world.txt'
+    assert actual_event.to_dict() == s3_event

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -361,3 +361,18 @@ class TestSAMTemplate(object):
         vpc_config = lambda_fns[0]['Properties']['VpcConfig']
         assert vpc_config['SubnetIds'] == ['sn1', 'sn2']
         assert vpc_config['SecurityGroupIds'] == ['sg1', 'sg2']
+
+    def test_helpful_error_message_on_s3_event(self, sample_app):
+        @sample_app.on_s3_event(bucket='foo')
+        def handler(event):
+            pass
+
+        config = Config.create(chalice_app=sample_app,
+                               project_dir='.',
+                               api_gateway_stage='api')
+        with pytest.raises(NotImplementedError) as excinfo:
+            self.generate_template(config, 'dev')
+        # Should mention the decorator name.
+        assert '@app.on_s3_event' in str(excinfo.value)
+        # Should mention you can use `chalice deploy`.
+        assert 'chalice deploy' in str(excinfo.value)


### PR DESCRIPTION
This commit adds support for triggering a lambda function based
on an S3 event happening such as an object being created or deleted.
This is configured in chalice through a new `on_s3_event` decorator.
Chalice assumes your s3 bucket already exists.  However, it will
configure bucket configuration and function policies for you.
Given this is an existing bucket, we account for existing
notification configurations already in place, and intelligently
merge in the chalice specific lambda configuration as needed.
Same goes for `chalice delete`, it will only remove the lambda
configuration snippet it added to the S3 bucket notification config.

Before this can be merged, we need a plan for this feature
and `chalice package`.

Because you provide chalice with an existing bucket, we aren't
able to describe this in a CFN template (that is, CFN can't
adopt existing resources into a stack).  As a result, the
`chalice package` command fails.  There's a few options here.
We can implement initial support for managed resources so we
can create the bucket for you, or we can create a custom
cfn resource that can apply this config to an existing bucket.
Implementing managed resources doesn't solve the problem though
of what to do with existing buckets.  I think this is an important
enough use case that I don't want to remove support for it just
because CFN can't support this, so for me it boils down to
trying to make this work with custom resources or just not
support S3 events in `chalice package` until we add support for
managed resources.  Then at least customers would have a path
forward if they wanted to use CFN to deploy their app.  They'd
just have to accept the tradeoff that a new bucket would be
created for them.

*Issue #, if available:*

#855
