### PR TITLE
Compile .pyc bytecode cache files when installing wheels

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -3,6 +3,7 @@ import hashlib
 import inspect
 import re
 import subprocess
+import compileall
 from email.parser import FeedParser
 from email.message import Message  # noqa
 from zipfile import ZipFile  # noqa
@@ -469,6 +470,7 @@ class DependencyBuilder(object):
             zipfile_path = self._osutils.joinpath(src_dir, wheel.filename)
             self._osutils.extract_zipfile(zipfile_path, dst_dir)
             self._install_purelib_and_platlib(wheel, dst_dir)
+        compileall.compile_dir(dst_dir)
 
     def build_site_packages(self, requirements_filepath, target_directory):
         # type: (str, str) -> None


### PR DESCRIPTION
Fixes #868  https://github.com/HumanCellAtlas/data-store/pull/1314

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
