### PR TITLE
Added Python information to chalice --version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ chalice.egg-info/
 .hypothesis/
 .pytest_cache/
 .mypy_cache/
+*.pyc

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -58,16 +58,29 @@ def create_new_project_skeleton(project_name, profile=None):
         f.write(GITIGNORE)
 
 
-def getSystemInfo():
-    pythonVersion = '{}.{}.{}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2])
-    platformInfo = '{}/{}'.format(platform.system(), platform.release())
-    systemInfo =  "python {}, {}".format(pythonVersion, platformInfo)
-    if not(pythonVersion.startswith('2.7') or pythonVersion.startswith('3.6')):
-        systemInfo += '\nWarning: Not using the recommended python version. Recommended versions are 2.7 and 3.6'
-    return systemInfo
+def get_system_info(python_version_arg=None):
+    # type: (Optional[str]) -> str
+    if python_version_arg:
+        python_version = python_version_arg
+    else:
+        python_version = "{}.{}.{}".format(sys.version_info[0],
+                                           sys.version_info[1],
+                                           sys.version_info[2])
+    platform_system = platform.system()
+    platform_release = platform.release()
+    platform_info = "{}/{}".format(platform_system, platform_release)
+    system_info = "python {}, {}".format(python_version, platform_info)
+    if not(python_version.startswith("2.7.") or
+            python_version.startswith("3.6.")):
+        system_info += "\nWarning: Not using the recommended python version. "
+        system_info += "Recommended versions are 2.7 and 3.6"
+    return system_info
+
 
 @click.group()
-@click.version_option(version=chalice_version, message='%(prog)s %(version)s, {}'.format(getSystemInfo()))
+@click.version_option(version=chalice_version,
+                      message='%(prog)s %(version)s, {}'
+                      .format(get_system_info()))
 @click.option('--project-dir',
               help='The project directory.  Defaults to CWD')
 @click.option('--debug/--no-debug',

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -5,6 +5,7 @@ Contains commands for deploying chalice.
 """
 import logging
 import os
+import platform
 import sys
 import tempfile
 import shutil
@@ -57,8 +58,16 @@ def create_new_project_skeleton(project_name, profile=None):
         f.write(GITIGNORE)
 
 
+def getSystemInfo():
+    pythonVersion = '{}.{}.{}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2])
+    platformInfo = '{}/{}'.format(platform.system(), platform.release())
+    systemInfo =  "python {}, {}".format(pythonVersion, platformInfo)
+    if not(pythonVersion.startswith('2.7') or pythonVersion.startswith('3.6')):
+        systemInfo += '\nWarning: Not using the recommended python version. Recommended versions are 2.7 and 3.6'
+    return systemInfo
+
 @click.group()
-@click.version_option(version=chalice_version, message='%(prog)s %(version)s')
+@click.version_option(version=chalice_version, message='%(prog)s %(version)s, {}'.format(getSystemInfo()))
 @click.option('--project-dir',
               help='The project directory.  Defaults to CWD')
 @click.option('--debug/--no-debug',

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+import re
 
 from chalice import cli
 from chalice.cli.factory import CLIFactory
@@ -18,3 +19,19 @@ def test_cannot_run_local_mode_with_trailing_slash_route():
     with pytest.raises(ValueError) as e:
         cli.run_local_server(factory, 'localhost', 8000, local_stage_test)
     assert str(e.value) == 'Route cannot end with a trailing slash: foobar/'
+
+
+def test_get_system_info():
+    system_info = cli.get_system_info()
+    assert re.match(r'python\s*([\d.]+),?\s*(.*)/(.*)', system_info)
+
+
+def test_get_system_info_with_explicit_argument():
+    system_info = cli.get_system_info('2.7.12')
+    assert re.match(r'python\s*([\d.]+),?\s*(.*)/(.*)$', system_info)
+
+
+def test_get_system_info_with_warning_with_explicit_argument():
+    system_info = cli.get_system_info('3.5.2')
+    assert re.match(r'python\s*([\d.]+),?\s*(.*)/(.*)(\r\n|\r|\n)Warning:(.*)',
+                    system_info)


### PR DESCRIPTION
*Issue:* #865 

*Description of changes:* Added python information and OS information to `chalice --version`. A warning is also shown if python version is not the recommended one (`2.7` or `3.6`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
