### PR TITLE
Add HeadObject policy

### DIFF
--- a/chalice/policies.json
+++ b/chalice/policies.json
@@ -2810,6 +2810,7 @@
     "GetObjectTagging": "s3:GetObjectTagging",
     "GetObjectTorrent": "s3:GetObjectTorrent",
     "HeadBucket": "s3:HeadBucket",
+    "HeadObject": "s3:GetObject",
     "ListBuckets": "s3:ListAllMyBuckets",
     "ListObjects": "s3:ListBucket",
     "ListObjectsV2": "s3:ListBucket",

--- a/chalice/policy.py
+++ b/chalice/policy.py
@@ -121,8 +121,8 @@ class PolicyBuilder(object):
             client = self._session.create_client(service,
                                                  region_name='us-east-1')
             mapping = client.meta.method_to_api_mapping
-            actions = [service_actions[mapping[method_name]] for
-                       method_name in method_calls
+            actions = [service_actions[mapping[method_name]]
+                       for method_name in method_calls
                        if mapping.get(method_name) in service_actions]
             actions.sort()
             if actions:


### PR DESCRIPTION
*Issue #, if available:* 404 Not Found

*Description of changes:* Add HeadObject policy to policies.json and fix code style in policy.py

List of policies not implemented for `s3`. Generated with `[m for m in mapping.values() if m not in service_actions]` (variables from policy.py):
```
CopyObject
DeleteBucketAnalyticsConfiguration
DeleteBucketCors
DeleteBucketEncryption
DeleteBucketInventoryConfiguration
DeleteBucketLifecycle
DeleteBucketMetricsConfiguration
DeleteBucketReplication
DeleteBucketTagging
DeleteObjects
GetBucketAccelerateConfiguration
GetBucketAnalyticsConfiguration
GetBucketCors
GetBucketEncryption
GetBucketInventoryConfiguration
GetBucketLifecycle
GetBucketLifecycleConfiguration
GetBucketMetricsConfiguration
GetBucketNotificationConfiguration
GetBucketReplication
HeadObject
ListBucketAnalyticsConfigurations
ListBucketInventoryConfigurations
ListBucketMetricsConfigurations
ListMultipartUploads
ListObjectVersions
ListParts
PutBucketAccelerateConfiguration
PutBucketAnalyticsConfiguration
PutBucketCors
PutBucketEncryption
PutBucketInventoryConfiguration
PutBucketLifecycle
PutBucketLifecycleConfiguration
PutBucketMetricsConfiguration
PutBucketNotificationConfiguration
PutBucketReplication
SelectObjectContent
UploadPartCopy
```

I see that there may be flaws if using *string* for mapping with current policies.json format since there is no support for a method_call with multiple policies needed. Example, `HeadObject` requires two policy as seen in https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html