### PR TITLE
Fix watchdog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 install:
   - pip install -r requirements-dev.txt -r requirements-docs.txt
   - pip install -e .
-  - pip install -e ".[file-watcher]"
+  - pip install -e ".[event-file-poller]"
 script:
   - env
   - make $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
 install:
   - pip install -r requirements-dev.txt -r requirements-docs.txt
   - pip install -e .
+  - pip install -e ".[file-watcher]"
 script:
   - env
   - make $TEST_TYPE

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,14 @@ Next Release (TBD)
 ==================
 
 * Add support for generating python 3.6 pipelines
-  (`#858 <https://github.com/aws/chalice/pull/858>`)
+  (`#858 <https://github.com/aws/chalice/pull/858>`__)
 * Add support for connecting lambda functions to S3 events
-  (`#855 <https://github.com/aws/chalice/issues/855>`)
+  (`#855 <https://github.com/aws/chalice/issues/855>`__)
 * Add support for connecting lambda functions to SNS message
-  (`#488 <https://github.com/aws/chalice/issues/488>`)
+  (`#488 <https://github.com/aws/chalice/issues/488>`__)
+* Make ``watchdog`` an optional dependency and add a built in
+  ``stat()`` based file poller
+  (`#867 <https://github.com/aws/chalice/issues/867>`__)
 
 
 1.3.0

--- a/chalice/cli/filewatch/__init__.py
+++ b/chalice/cli/filewatch/__init__.py
@@ -1,0 +1,42 @@
+import threading
+
+from typing import Callable, Optional  # noqa
+from chalice.local import HTTPServerThread  # noqa
+
+
+RESTART_REQUEST_RC = 3
+
+
+class FileWatcher(object):
+    """Base class for watching files for changes."""
+
+    def watch_for_file_changes(self, root_dir, callback):
+        # type: (str, Callable[[], None]) -> None
+        """Recursively watch directory for changes.
+
+        When a changed file is detected, the provided callback
+        is immediately invoked and the current scan stops.
+
+        """
+        raise NotImplementedError("watch_for_file_changes")
+
+
+class WorkerProcess(object):
+    """Worker that runs the chalice dev server."""
+    def __init__(self, http_thread):
+        # type: (HTTPServerThread) -> None
+        self._http_thread = http_thread
+        self._restart_event = threading.Event()
+
+    def main(self, project_dir, timeout=None):
+        # type: (str, Optional[int]) -> int
+        self._http_thread.start()
+        self._start_file_watcher(project_dir)
+        if self._restart_event.wait(timeout):
+            self._http_thread.shutdown()
+            return RESTART_REQUEST_RC
+        return 0
+
+    def _start_file_watcher(self, project_dir):
+        # type: (str) -> None
+        raise NotImplementedError("_start_file_watcher")

--- a/chalice/cli/filewatch/__init__.py
+++ b/chalice/cli/filewatch/__init__.py
@@ -1,6 +1,6 @@
 import threading
 
-from typing import Callable, Optional  # noqa
+from typing import Callable, Optional, Type  # noqa
 from chalice.local import HTTPServerThread  # noqa
 
 

--- a/chalice/cli/filewatch/eventbased.py
+++ b/chalice/cli/filewatch/eventbased.py
@@ -1,0 +1,48 @@
+import threading  # noqa
+
+from typing import Callable, Optional  # noqa
+import watchdog.observers
+from watchdog.events import FileSystemEventHandler
+from watchdog.events import FileSystemEvent  # noqa
+
+from chalice.cli.filewatch import FileWatcher, WorkerProcess
+
+
+class WatchdogWorkerProcess(WorkerProcess):
+    """Worker that runs the chalice dev server."""
+
+    def _start_file_watcher(self, project_dir):
+        # type: (str) -> None
+        restart_callback = WatchdogRestarter(self._restart_event)
+        watcher = WatchdogFileWatcher()
+        watcher.watch_for_file_changes(
+            project_dir, restart_callback)
+
+
+class WatchdogFileWatcher(FileWatcher):
+    def watch_for_file_changes(self, root_dir, callback):
+        # type: (str, Callable[[], None]) -> None
+        observer = watchdog.observers.Observer()
+        observer.schedule(callback, root_dir, recursive=True)
+        observer.start()
+
+
+class WatchdogRestarter(FileSystemEventHandler):
+
+    def __init__(self, restart_event):
+        # type: (threading.Event) -> None
+        # The reason we're using threading
+        self.restart_event = restart_event
+
+    def on_any_event(self, event):
+        # type: (FileSystemEvent) -> None
+        # If we modify a file we'll get a FileModifiedEvent
+        # as well as a DirectoryModifiedEvent.
+        # We only care about reloading is a file is modified.
+        if event.is_directory:
+            return
+        self()
+
+    def __call__(self):
+        # type: () -> None
+        self.restart_event.set()

--- a/chalice/cli/filewatch/stat.py
+++ b/chalice/cli/filewatch/stat.py
@@ -1,7 +1,11 @@
 import logging
-from typing import Callable  # noqa
+import threading
+import time
+
+from typing import Callable, Dict, Optional  # noqa
 
 from chalice.cli.filewatch import FileWatcher, WorkerProcess
+from chalice.utils import OSUtils
 
 
 LOGGER = logging.getLogger(__name__)
@@ -10,11 +14,84 @@ LOGGER = logging.getLogger(__name__)
 class StatWorkerProcess(WorkerProcess):
     def _start_file_watcher(self, project_dir):
         # type: (str) -> None
-        LOGGER.debug("Fake watching: %s", project_dir)
+        watcher = StatFileWatcher()
+        watcher.watch_for_file_changes(project_dir, self._on_file_change)
+
+    def _on_file_change(self):
+        # type: () -> None
+        self._restart_event.set()
 
 
 class StatFileWatcher(FileWatcher):
+    POLL_INTERVAL = 1
+
+    def __init__(self):
+        # type: () -> None
+        self._mtime_cache = {}  # type: Dict[str, int]
+        self._shutdown_event = threading.Event()
+        self._thread = None  # type: Optional[threading.Thread]
+        self._osutils = OSUtils()
+
     def watch_for_file_changes(self, root_dir, callback):
         # type: (str, Callable[[], None]) -> None
+        t = threading.Thread(target=self.poll_for_changes_until_shutdown,
+                             args=(root_dir, callback))
+        t.daemon = True
+        t.start()
+        self._thread = t
         LOGGER.debug("Stat file watching: %s, with callback: %s",
                      root_dir, callback)
+
+    def shutdown(self):
+        # type: () -> None
+        self._shutdown_event.set()
+        if self._thread is not None:
+            self._thread.join()
+
+    def poll_for_changes_until_shutdown(self, root_dir, callback):
+        # type: (str, Callable[[], None]) -> None
+        self._seed_mtime_cache(root_dir)
+        while not self._shutdown_event.isSet():
+            self._single_pass_poll(root_dir, callback)
+            time.sleep(self.POLL_INTERVAL)
+
+    def _seed_mtime_cache(self, root_dir):
+        # type: (str) -> None
+        for rootdir, _, filenames in self._osutils.walk(root_dir):
+            for filename in filenames:
+                path = self._osutils.joinpath(rootdir, filename)
+                self._mtime_cache[path] = self._osutils.mtime(path)
+
+    def _single_pass_poll(self, root_dir, callback):
+        # type: (str, Callable[[], None]) -> None
+        mtime_cache = self._mtime_cache
+        new_mtimes = {}
+        for rootdir, _, filenames in self._osutils.walk(root_dir):
+            for filename in filenames:
+                path = self._osutils.joinpath(rootdir, filename)
+                last_mtime = mtime_cache.get(path)
+                if last_mtime is None:
+                    # New file added, we don't need to look any further.
+                    mtime_cache[path] = self._osutils.mtime(path)
+                    LOGGER.debug("File added: %s, triggering restart.",
+                                 path)
+                    callback()
+                    return
+                try:
+                    new_mtime = self._osutils.mtime(path)
+                    if new_mtime > last_mtime:
+                        # File has been updated.
+                        mtime_cache[path] = new_mtime
+                        LOGGER.debug("File updated: %s, triggering restart.",
+                                     path)
+                        callback()
+                        return
+                    new_mtimes[path] = new_mtime
+                except OSError:
+                    pass
+        if new_mtimes != mtime_cache:
+            # Files were removed.
+            LOGGER.debug("Files removed, triggering restart.")
+            self._mtime_cache = new_mtimes
+            callback()
+            return

--- a/chalice/cli/filewatch/stat.py
+++ b/chalice/cli/filewatch/stat.py
@@ -1,0 +1,20 @@
+import logging
+from typing import Callable  # noqa
+
+from chalice.cli.filewatch import FileWatcher, WorkerProcess
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StatWorkerProcess(WorkerProcess):
+    def _start_file_watcher(self, project_dir):
+        # type: (str) -> None
+        LOGGER.debug("Fake watching: %s", project_dir)
+
+
+class StatFileWatcher(FileWatcher):
+    def watch_for_file_changes(self, root_dir, callback):
+        # type: (str, Callable[[], None]) -> None
+        LOGGER.debug("Stat file watching: %s, with callback: %s",
+                     root_dir, callback)

--- a/chalice/cli/reloader.py
+++ b/chalice/cli/reloader.py
@@ -42,9 +42,11 @@ def get_best_worker_process():
     # type: () -> Type[WorkerProcess]
     try:
         from chalice.cli.filewatch.eventbased import WatchdogWorkerProcess
+        LOGGER.debug("Using watchdog worker process.")
         return WatchdogWorkerProcess
     except ImportError:
         from chalice.cli.filewatch.stat import StatWorkerProcess
+        LOGGER.debug("Using stat() based worker process.")
         return StatWorkerProcess
 
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -243,6 +243,10 @@ class OSUtils(object):
         p = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=env)
         return p
 
+    def mtime(self, path):
+        # type: (str) -> int
+        return os.stat(path).st_mtime
+
     @property
     def pipe(self):
         # type: () -> int

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     'attrs==17.4.0',
     'enum34==1.1.6',
     'jmespath>=0.9.3,<1.0.0',
-    'watchdog==0.8.3',
 ]
 
 setup(
@@ -28,6 +27,9 @@ setup(
     url='https://github.com/aws/chalice',
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
+    extras_require={
+        'file-watcher': ['watchdog==0.8.3'],
+    },
     license="Apache License 2.0",
     package_data={'chalice': ['*.json']},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     extras_require={
-        'file-watcher': ['watchdog==0.8.3'],
+        'event-file-poller': ['watchdog==0.8.3'],
     },
     license="Apache License 2.0",
     package_data={'chalice': ['*.json']},

--- a/tests/functional/cli/test_reloader.py
+++ b/tests/functional/cli/test_reloader.py
@@ -1,7 +1,9 @@
 import mock
 import threading
 
-from chalice.cli import reloader
+from chalice.cli.filewatch.eventbased import WatchdogWorkerProcess
+
+import chalice.local
 
 
 DEFAULT_DELAY = 0.1
@@ -22,11 +24,11 @@ def modify_file(filename, contents):
 
 
 def assert_reload_happens(root_dir, when_modified_file):
-    http_thread = mock.Mock(spec=reloader.HTTPServerThread)
-    p = reloader.WorkerProcess(http_thread)
+    http_thread = mock.Mock(spec=chalice.local.HTTPServerThread)
+    p = WatchdogWorkerProcess(http_thread)
     modify_file_after_n_seconds(when_modified_file, 'contents')
     rc = p.main(root_dir, MAX_TIMEOUT)
-    assert rc == reloader.RESTART_REQUEST_RC
+    assert rc == chalice.cli.filewatch.RESTART_REQUEST_RC
 
 
 def test_can_reload_when_file_created(tmpdir):
@@ -40,7 +42,7 @@ def test_can_reload_when_subdir_file_created(tmpdir):
 
 
 def test_rc_0_when_no_file_modified(tmpdir):
-    http_thread = mock.Mock(spec=reloader.HTTPServerThread)
-    p = reloader.WorkerProcess(http_thread)
+    http_thread = mock.Mock(spec=chalice.local.HTTPServerThread)
+    p = WatchdogWorkerProcess(http_thread)
     rc = p.main(str(tmpdir), timeout=0.2)
     assert rc == 0

--- a/tests/functional/cli/test_reloader.py
+++ b/tests/functional/cli/test_reloader.py
@@ -1,13 +1,22 @@
+import pytest
 import mock
 import threading
+import unittest
 
-from chalice.cli.filewatch.eventbased import WatchdogWorkerProcess
+from chalice.cli.filewatch.stat import StatWorkerProcess
+try:
+    from chalice.cli.filewatch.eventbased import WatchdogWorkerProcess
+    WATCHDOG_AVAILABLE = True
+except ImportError:
+    WATCHDOG_AVAILABLE = False
 
 import chalice.local
 
 
 DEFAULT_DELAY = 0.1
 MAX_TIMEOUT = 5.0
+use_all_watcher_types = pytest.mark.parametrize(
+    ['worker_class_type'], [('watchdog',), ('stat',)])
 
 
 def modify_file_after_n_seconds(filename, contents, delay=DEFAULT_DELAY):
@@ -23,26 +32,46 @@ def modify_file(filename, contents):
         f.write(contents)
 
 
-def assert_reload_happens(root_dir, when_modified_file):
+def assert_reload_happens(root_dir, when_modified_file, using_worker_class):
     http_thread = mock.Mock(spec=chalice.local.HTTPServerThread)
-    p = WatchdogWorkerProcess(http_thread)
+    worker_cls = get_worker_cls(using_worker_class)
+    p = worker_cls(http_thread)
     modify_file_after_n_seconds(when_modified_file, 'contents')
     rc = p.main(root_dir, MAX_TIMEOUT)
     assert rc == chalice.cli.filewatch.RESTART_REQUEST_RC
 
 
-def test_can_reload_when_file_created(tmpdir):
+def get_worker_cls(worker_class_name):
+    if worker_class_name == 'watchdog':
+        if not WATCHDOG_AVAILABLE:
+            raise unittest.SkipTest("Test requires watchdog package.")
+        else:
+            return WatchdogWorkerProcess
+    elif worker_class_name == 'stat':
+        return StatWorkerProcess
+    else:
+        raise RuntimeError("Unknown worker class type name: %s"
+                           % worker_class_name)
+
+
+@use_all_watcher_types
+def test_can_reload_when_file_created(tmpdir, worker_class_type):
     top_level_file = str(tmpdir.join('foo'))
-    assert_reload_happens(str(tmpdir), when_modified_file=top_level_file)
+    assert_reload_happens(str(tmpdir), when_modified_file=top_level_file,
+                          using_worker_class=worker_class_type)
 
 
-def test_can_reload_when_subdir_file_created(tmpdir):
+@use_all_watcher_types
+def test_can_reload_when_subdir_file_created(tmpdir, worker_class_type):
     subdir_file = str(tmpdir.join('subdir').mkdir().join('foo.txt'))
-    assert_reload_happens(str(tmpdir), when_modified_file=subdir_file)
+    assert_reload_happens(str(tmpdir), when_modified_file=subdir_file,
+                          using_worker_class=worker_class_type)
 
 
-def test_rc_0_when_no_file_modified(tmpdir):
+@use_all_watcher_types
+def test_rc_0_when_no_file_modified(tmpdir, worker_class_type):
     http_thread = mock.Mock(spec=chalice.local.HTTPServerThread)
-    p = WatchdogWorkerProcess(http_thread)
+    worker_cls = get_worker_cls(worker_class_type)
+    p = worker_cls(http_thread)
     rc = p.main(str(tmpdir), timeout=0.2)
     assert rc == 0

--- a/tests/unit/cli/filewatch/test_eventbased.py
+++ b/tests/unit/cli/filewatch/test_eventbased.py
@@ -3,13 +3,22 @@ from subprocess import Popen
 
 import mock
 import pytest
-from watchdog.events import FileSystemEvent, DirModifiedEvent
 
-from chalice.cli.filewatch.eventbased import WatchdogRestarter
+try:
+    from watchdog.events import FileSystemEvent, DirModifiedEvent
+    from chalice.cli.filewatch.eventbased import WatchdogRestarter
+    HAS_WATCHDOG = True
+except ImportError:
+    HAS_WATCHDOG = False
 
 import chalice.local
 from chalice.cli import reloader
 from chalice.local import LocalDevServer
+
+
+# This will skip all the tests in this module if watchdog is not installed.
+pytestmark = pytest.mark.skipif(not HAS_WATCHDOG,
+                                reason='Tests require watchdog package.')
 
 
 # NOTE: Most of the reloader module relies on threads, subprocesses,

--- a/tests/unit/cli/filewatch/test_stat.py
+++ b/tests/unit/cli/filewatch/test_stat.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from chalice.cli.filewatch import stat
 
@@ -31,4 +32,9 @@ def test_can_ignore_stat_errors():
 
     watcher = stat.StatFileWatcher(FakeOSUtils())
     watcher.watch_for_file_changes('rootdir', callback)
-    assert len(calls) == 1
+    for _ in range(10):
+        if len(calls) == 1:
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("Expected callback to be invoked but was not.")

--- a/tests/unit/cli/filewatch/test_stat.py
+++ b/tests/unit/cli/filewatch/test_stat.py
@@ -1,0 +1,34 @@
+import os
+
+from chalice.cli.filewatch import stat
+
+
+class FakeOSUtils(object):
+    def __init__(self):
+        self.initial_scan = True
+
+    def walk(self, rootdir):
+        yield 'rootdir', [], ['bad-file', 'baz']
+        if self.initial_scan:
+            self.initial_scan = False
+
+    def joinpath(self, *parts):
+        return os.path.join(*parts)
+
+    def mtime(self, path):
+        if self.initial_scan:
+            return 1
+        if path.endswith('bad-file'):
+            raise OSError("Bad file")
+        return 2
+
+
+def test_can_ignore_stat_errors():
+    calls = []
+
+    def callback(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    watcher = stat.StatFileWatcher(FakeOSUtils())
+    watcher.watch_for_file_changes('rootdir', callback)
+    assert len(calls) == 1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,12 +11,14 @@ from chalice.app import Chalice
 # On travis we'll have it run through more iterations.
 settings.register_profile(
     'ci', settings(max_examples=2000,
+                   use_coverage=False,
                    suppress_health_check=[HealthCheck.too_slow]),
 )
 # When you're developing locally, we'll only run a few examples
 # to keep unit tests fast.  If you want to run more iterations
 # locally just set HYPOTHESIS_PROFILE=ci.
-settings.register_profile('dev', settings(max_examples=10))
+settings.register_profile('dev', settings(use_coverage=False,
+                                          max_examples=10))
 settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'dev'))
 
 print("HYPOTHESIS PROFILE: %s" % os.environ.get("HYPOTHESIS_PROFILE"))


### PR DESCRIPTION
Remove hard dependency on watchdog

This is necessary because watchdog does not appear to be maintained
anymore, requires a compiler, and has issues installing on the MacOS
High Sierra.

Watchdog has been moved to an optional dependency and is only used if
Chalice is installed with the watchdog dependency extras modifier like
so: `chalice[watchdog]`.

A layer of abstraction was introduced between the watchdog observer
class and the reloader which hides the implementation of the file
observer. One implementation uses the watchdog observer class, which is
used if `import watchdog` succeeds. The fallback implementation uses the
stat system call to check the mtime of each file in the project
directory every second. If the mtime changes then the server is
refreshed.
