### PR TITLE
Add support for SQS events

### DIFF
--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -215,5 +215,10 @@ class SNSEventConfig(BaseEventSourceConfig):
     topic = ... # type: str
 
 
+class SQSEventConfig(BaseEventSourceConfig):
+    queue = ... # type: str
+    batch_size = ... # type: int
+
+
 class CloudWatchEventConfig(BaseEventSourceConfig):
     schedule_expression = ...  # type: Union[str, ScheduleExpression]

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -894,10 +894,13 @@ class TypedAWSClient(object):
     def create_sqs_event_source(self, queue_arn, function_name, batch_size):
         # type: (str, str, int) -> None
         lambda_client = self._client('lambda')
-        return lambda_client.create_event_source_mapping(
-            EventSourceArn=queue_arn,
-            FunctionName=function_name,
-            BatchSize=batch_size,
+        kwargs = {
+            'EventSourceArn': queue_arn,
+            'FunctionName': function_name,
+            'BatchSize': batch_size,
+        }
+        return self._call_client_method_with_retries(
+            lambda_client.create_event_source_mapping, kwargs
         )['UUID']
 
     def update_sqs_event_source(self, event_uuid, batch_size):

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -215,3 +215,14 @@ if missing dependencies are not present. For more information:
 http://chalice.readthedocs.io/en/latest/topics/packaging.html
 
 """
+
+
+SQS_EVENT_SOURCE_POLICY = {
+    "Effect": "Allow",
+    "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+    ],
+    "Resource": "*",
+}

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -405,6 +405,12 @@ class ApplicationGraphBuilder(object):
                         config, deployment, event_source, stage_name
                     )
                 )
+            elif isinstance(event_source, app.SQSEventConfig):
+                resources.append(
+                    self._create_sqs_subscription(
+                        config, deployment, event_source, stage_name,
+                    )
+                )
         return resources
 
     def _create_rest_api_model(self,
@@ -654,6 +660,27 @@ class ApplicationGraphBuilder(object):
             lambda_function=lambda_function,
         )
         return sns_subscription
+
+    def _create_sqs_subscription(
+        self,
+        config,      # type: Config
+        deployment,  # type: models.DeploymentPackage
+        sqs_config,  # type: app.SQSEventConfig
+        stage_name,  # type: str
+    ):
+        # type: (...) -> models.SQSEventSource
+        lambda_function = self._create_lambda_model(
+            config=config, deployment=deployment, name=sqs_config.name,
+            handler_name=sqs_config.handler_string, stage_name=stage_name
+        )
+        resource_name = sqs_config.name + '-sqs-event-source'
+        sqs_event_source = models.SQSEventSource(
+            resource_name=resource_name,
+            queue=sqs_config.queue,
+            batch_size=sqs_config.batch_size,
+            lambda_function=lambda_function,
+        )
+        return sqs_event_source
 
 
 class DependencyBuilder(object):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -211,3 +211,15 @@ class SNSLambdaSubscription(ManagedModel):
     def dependencies(self):
         # type: () -> List[Model]
         return [self.lambda_function]
+
+
+@attrs
+class SQSEventSource(ManagedModel):
+    resource_type = 'sqs_event'
+    queue = attrib()            # type: str
+    batch_size = attrib()       # type: int
+    lambda_function = attrib()  # type: LambdaFunction
+
+    def dependencies(self):
+        # type: () -> List[Model]
+        return [self.lambda_function]

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -606,7 +606,7 @@ class PlanStage(object):
                 method_name='create_sqs_event_source',
                 params={'queue_arn': Variable(queue_arn_varname),
                         'batch_size': resource.batch_size,
-                        'function_arn': function_arn},
+                        'function_name': function_arn},
                 output_var=uuid_varname,
             ), 'Subscribing %s to SQS queue %s\n'
                 % (resource.lambda_function.function_name, resource.queue)

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -303,6 +303,28 @@ class SAMTemplateGenerator(object):
             }
         }
 
+    def _generate_sqseventsource(self, resource, template):
+        # type: (models.SQSEventSource, Dict[str, Any]) -> None
+        function_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        function_cfn = template['Resources'][function_cfn_name]
+        sns_cfn_name = self._register_cfn_resource_name(
+            resource.resource_name)
+        function_cfn['Properties']['Events'] = {
+            sns_cfn_name: {
+                'Type': 'SQS',
+                'Properties': {
+                    'Queue': {
+                        'Fn::Sub': (
+                            'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:%s' %
+                            resource.queue
+                        )
+                    },
+                    'BatchSize': 5,
+                }
+            }
+        }
+
     def _default(self, resource, template):
         # type: (models.Model, Dict[str, Any]) -> None
         raise NotImplementedError(resource)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1521,3 +1521,45 @@ def test_can_map_sns_event(sample_app):
     assert actual_event.message == 'This is a raw message'
     assert actual_event.subject == 'ThisIsTheSubject'
     assert actual_event.to_dict() == sns_event
+
+
+def test_can_create_sqs_handler(sample_app):
+    @sample_app.on_sqs_message(queue='MyQueue', batch_size=200)
+    def handler(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    event = sample_app.event_sources[0]
+    assert event.queue == 'MyQueue'
+    assert event.batch_size == 200
+    assert event.handler_string == 'app.handler'
+
+
+def test_can_map_sqs_event(sample_app):
+    @sample_app.on_sqs_message(queue='queue-name')
+    def handler(event):
+        return event
+
+    sqs_event = {'Records': [{
+        'attributes': {
+            'ApproximateFirstReceiveTimestamp': '1530576251596',
+            'ApproximateReceiveCount': '1',
+            'SenderId': 'sender-id',
+            'SentTimestamp': '1530576251595'
+        },
+        'awsRegion': 'us-west-2',
+        'body': 'queue message body',
+        'eventSource': 'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:us-west-2:12345:queue-name',
+        'md5OfBody': '754ac2f7a12df38320e0c5eafd060145',
+        'messageAttributes': {},
+        'messageId': 'message-id',
+        'receiptHandle': 'handle'
+    }]}
+    actual_event = handler(sqs_event, context=None)
+    records = list(actual_event)
+    assert len(records) == 1
+    first_record = records[0]
+    assert first_record.body == 'queue message body'
+    assert first_record.to_dict() == sqs_event['Records'][0]
+    assert actual_event.to_dict() == sqs_event


### PR DESCRIPTION
This implements #884.  It's similar to s3 and sns events in terms of the interface.  The implementation is slightly different because unlike s3 and sns where you set up the configuration in the service emitting the events, you configure sqs integration through the lambda API and its event source mapping.

In addition, because the configuration happens through  lambda, the permissions need to be hooked up through the IAM role we create for you.  Therefore if you use autogen IAM policy, we'll insert a snippet that gives the role access to sqs (this is the `LambdaEventSourcePolicyInjector` class I've added to the build steps).  This is similar to what we do for permissions to cloudwatch logs https://github.com/aws/chalice/blob/master/chalice/constants.py#L72-L80.


Closes https://github.com/aws/chalice/issues/884