### PR TITLE
Chalice invoke command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Add ``chalice invoke`` command
+  (`#900 <https://github.com/aws/chalice/issues/900>`__)
+
+
 1.5.0
 =====
 

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -195,9 +195,10 @@ class TypedAWSClient(object):
         if payload is not None:
             kwargs['Payload'] = payload
 
-        return self._call_client_method_with_retries(
-            self._client('lambda').invoke, kwargs, max_attempts=1
-        )
+        try:
+            return self._client('lambda').invoke(**kwargs)
+        except RequestsReadTimeout as e:
+            raise ReadTimeout(str(e))
 
     def _is_iam_role_related_error(self, error):
         # type: (botocore.exceptions.ClientError) -> bool
@@ -991,8 +992,6 @@ class TypedAWSClient(object):
                         not should_retry(e):
                     raise
                 continue
-            except RequestsReadTimeout as e:
-                raise ReadTimeout(str(e))
             return response
 
     def _random_id(self):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -186,8 +186,8 @@ class TypedAWSClient(object):
             return True
         return False
 
-    def invoke_function(self, name, context=None, payload=None):
-        # type: (str, _OPT_STR, bytes) -> Dict[str, Any]
+    def invoke_function(self, name, payload=None):
+        # type: (str, bytes) -> Dict[str, Any]
         kwargs = {
             'FunctionName': name,
             'InvocationType': 'RequestResponse',

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -204,6 +204,9 @@ class CLIFactory(object):
             raise NoSuchFunctionError(name)
 
         function_scoped_config = config.scope(stage, name)
+        # The session for max retries needs to be set to 0 for invoking a
+        # lambda function because in the case of a timeout or other retriable
+        # error the underlying client will call the function again.
         session = self.create_botocore_session(
             read_timeout=function_scoped_config.lambda_timeout,
             max_retries=0,

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import functools
 
+import click
 from botocore.config import Config as BotocoreConfig
 from botocore.session import Session
 from typing import Any, Optional, Dict, MutableMapping  # noqa
@@ -13,6 +14,7 @@ from chalice import __version__ as chalice_version
 from chalice.awsclient import TypedAWSClient
 from chalice.app import Chalice  # noqa
 from chalice.config import Config
+from chalice.config import DeployedResources  # noqa
 from chalice.package import create_app_packager
 from chalice.package import AppPackager  # noqa
 from chalice.constants import DEFAULT_STAGE_NAME
@@ -20,19 +22,36 @@ from chalice.constants import DEFAULT_APIGATEWAY_STAGE_NAME
 from chalice.logs import LogRetriever
 from chalice import local
 from chalice.utils import UI  # noqa
+from chalice.utils import PipeReader  # noqa
 from chalice.deploy import deployer  # noqa
+from chalice.invoke import LambdaInvokeHandler
+from chalice.invoke import LambdaInvoker
+from chalice.invoke import LambdaResponseFormatter
+
+
+_OPT_STR = Optional[str]
+_OPT_INT = Optional[int]
 
 
 def create_botocore_session(profile=None, debug=False,
-                            connection_timeout=None):
-    # type: (str, bool, int) -> Session
+                            connection_timeout=None,
+                            read_timeout=None,
+                            max_retries=None):
+    # type: (_OPT_STR, bool, _OPT_INT, _OPT_INT, _OPT_INT) -> Session
     s = Session(profile=profile)
     _add_chalice_user_agent(s)
     if debug:
         s.set_debug_logger('')
         _inject_large_request_body_filter()
+    config_args = {}  # type: Dict[str, Any]
     if connection_timeout is not None:
-        config = BotocoreConfig(connect_timeout=connection_timeout)
+        config_args['connect_timeout'] = connection_timeout
+    if read_timeout is not None:
+        config_args['read_timeout'] = read_timeout
+    if max_retries is not None:
+        config_args['retries'] = {'max_attempts': max_retries}
+    if config_args:
+        config = BotocoreConfig(**config_args)
         s.set_default_client_config(config)
     return s
 
@@ -49,6 +68,14 @@ def _inject_large_request_body_filter():
     # type: () -> None
     log = logging.getLogger('botocore.endpoint')
     log.addFilter(LargeRequestBodyFilter())
+
+
+class NoSuchFunctionError(Exception):
+    """The specified function could not be found."""
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name
+        super(NoSuchFunctionError, self).__init__()
 
 
 class UnknownConfigFileVersion(Exception):
@@ -86,11 +113,14 @@ class CLIFactory(object):
             environ = dict(os.environ)
         self._environ = environ
 
-    def create_botocore_session(self, connection_timeout=None):
-        # type: (int) -> Session
+    def create_botocore_session(self, connection_timeout=None,
+                                read_timeout=None, max_retries=None):
+        # type: (_OPT_INT, _OPT_INT, _OPT_INT) -> Session
         return create_botocore_session(profile=self.profile,
                                        debug=self.debug,
-                                       connection_timeout=connection_timeout)
+                                       connection_timeout=connection_timeout,
+                                       read_timeout=read_timeout,
+                                       max_retries=max_retries)
 
     def create_default_deployer(self, session, config, ui):
         # type: (Session, Config, UI) -> deployer.Deployer
@@ -156,6 +186,39 @@ class CLIFactory(object):
         client = TypedAWSClient(session)
         retriever = LogRetriever.create_from_lambda_arn(client, lambda_arn)
         return retriever
+
+    def create_stdin_reader(self):
+        # type: () -> PipeReader
+        stream = click.get_binary_stream('stdin')
+        reader = PipeReader(stream)
+        return reader
+
+    def create_lambda_invoke_handler(self, name, stage):
+        # type: (str, str) -> LambdaInvokeHandler
+        config = self.create_config_obj(stage)
+        deployed = config.deployed_resources(stage)
+        try:
+            resource = deployed.resource_values(name)
+            arn = resource['lambda_arn']
+        except (KeyError, ValueError):
+            raise NoSuchFunctionError(name)
+
+        function_scoped_config = config.scope(stage, name)
+        session = self.create_botocore_session(
+            read_timeout=function_scoped_config.lambda_timeout,
+            max_retries=0,
+        )
+
+        client = TypedAWSClient(session)
+        invoker = LambdaInvoker(arn, client)
+
+        handler = LambdaInvokeHandler(
+            invoker,
+            LambdaResponseFormatter(),
+            UI(),
+        )
+
+        return handler
 
     def load_chalice_app(self, environment_variables=None):
         # type: (Optional[MutableMapping]) -> Chalice

--- a/chalice/invoke.py
+++ b/chalice/invoke.py
@@ -1,0 +1,110 @@
+"""Abstraction for invoking a lambda function."""
+import json
+
+from typing import Any, Optional, Dict, List, Union, Tuple  # noqa
+
+from chalice.config import DeployedResources  # noqa
+from chalice.awsclient import TypedAWSClient  # noqa
+from chalice.utils import UI  # noqa
+from chalice.compat import StringIO
+
+
+_OPT_STR = Optional[str]
+_ERROR_KEY = 'FunctionError'
+_ERROR_VALUE = 'Unhandled'
+
+
+def _response_is_error(response):
+    # type: (Dict[str, Any]) -> bool
+    return response.get(_ERROR_KEY) == _ERROR_VALUE
+
+
+class UnhandledLambdaError(Exception):
+    pass
+
+
+class LambdaInvokeHandler(object):
+    """Handler class to coordinate making an invoke call to lambda.
+
+    This class takes a LambdaInvoker, a LambdaResponseFormatter, and a UI
+    object in order to make an invoke call against lambda, format the response
+    and render it to the UI.
+    """
+    def __init__(self, invoker, formatter, ui):
+        # type: (LambdaInvoker, LambdaResponseFormatter, UI) -> None
+        self._invoker = invoker
+        self._formatter = formatter
+        self._ui = ui
+
+    def invoke(self, payload=None):
+        # type: (_OPT_STR) -> None
+        response = self._invoker.invoke(payload)
+        formatted_response = self._formatter.format_response(response)
+        if _response_is_error(response):
+            self._ui.error(formatted_response)
+            raise UnhandledLambdaError()
+        else:
+            self._ui.write(formatted_response)
+
+
+class LambdaInvoker(object):
+    def __init__(self, lambda_arn, client):
+        # type: (str, TypedAWSClient) -> None
+        self._lambda_arn = lambda_arn
+        self._client = client
+
+    def invoke(self, payload=None):
+        # type: (_OPT_STR) -> Dict[str, Any]
+        return self._client.invoke_function(
+            self._lambda_arn,
+            payload=payload
+        )
+
+
+class LambdaResponseFormatter(object):
+    _PAYLOAD_KEY = 'Payload'
+
+    _TRACEBACK_HEADING = 'Traceback (most recent call last):\n'
+
+    def format_response(self, response):
+        # type: (Dict[str, Any]) -> str
+        formatted = StringIO()
+        payload = response[self._PAYLOAD_KEY].read()
+        if _response_is_error(response):
+            self._format_error(formatted, payload)
+        else:
+            self._format_success(formatted, payload)
+        return str(formatted.getvalue())
+
+    def _format_error(self, formatted, payload):
+        # type: (StringIO, bytes) -> None
+        loaded_error = json.loads(payload)
+        error_message = loaded_error['errorMessage']
+        error_type = loaded_error.get('errorType')
+        stack_trace = loaded_error.get('stackTrace')
+
+        if stack_trace is not None:
+            self._format_stacktrace(formatted, stack_trace)
+
+        if error_type is not None:
+            formatted.write('{}: {}\n'.format(error_type, error_message))
+        else:
+            formatted.write('{}\n'.format(error_message))
+
+    def _format_stacktrace(self, formatted, stack_trace):
+        # type: (StringIO, List[List[Union[str, int]]]) -> None
+        formatted.write(self._TRACEBACK_HEADING)
+        for frame in stack_trace:
+            self._format_frame(formatted, frame)
+
+    def _format_frame(self, formatted, frame):
+        # type: (StringIO, List[Union[str, int]]) -> None
+        path, lineno, function, code = frame
+        formatted.write(
+            '  File "{}", line {}, in {}\n'.format(path, lineno, function))
+        formatted.write(
+            '    {}\n'.format(code))
+
+    def _format_success(self, formatted, payload):
+        # type: (StringIO, bytes) -> None
+        formatted.write('{}\n'.format(str(payload.decode('utf-8'))))

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -19,6 +19,7 @@ from chalice.constants import WELCOME_PROMPT
 
 
 OptInt = Optional[int]
+OptStr = Optional[str]
 EnvVars = MutableMapping
 
 
@@ -289,3 +290,15 @@ class UI(object):
             return self._confirm(msg, default, abort)
         except click.Abort:
             raise AbortedError()
+
+
+class PipeReader(object):
+    def __init__(self, stream):
+        # type: (IO[str]) -> None
+        self._stream = stream
+
+    def read(self):
+        # type: () -> OptStr
+        if not self._stream.isatty():
+            return self._stream.read()
+        return None

--- a/tests/unit/test_invoke.py
+++ b/tests/unit/test_invoke.py
@@ -1,0 +1,203 @@
+import json
+
+import pytest
+
+from chalice.awsclient import TypedAWSClient
+from chalice.invoke import LambdaInvoker
+from chalice.invoke import LambdaInvokeHandler
+from chalice.invoke import LambdaResponseFormatter
+from chalice.invoke import UnhandledLambdaError
+
+
+class FakeUI(object):
+    def __init__(self):
+        self.writes = []
+        self.errors = []
+
+    def write(self, value):
+        self.writes.append(value)
+
+    def error(self, value):
+        self.errors.append(value)
+
+
+class FakeStreamingBody(object):
+    def __init__(self, value):
+        self._value = value
+
+    def read(self):
+        return self._value
+
+
+class TestLambdaInvokeHandler(object):
+    def test_invoke_can_format_and_write_success_case(self, stubbed_session):
+        arn = 'arn:aws:lambda:region:id:function:name-dev'
+        stubbed_session.stub('lambda').invoke(
+            FunctionName=arn,
+            InvocationType='RequestResponse'
+        ).returns({
+            'StatusCode': 200,
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(b'foobarbaz')
+        })
+        ui = FakeUI()
+        stubbed_session.activate_stubs()
+        client = TypedAWSClient(stubbed_session)
+        invoker = LambdaInvoker(arn, client)
+        formatter = LambdaResponseFormatter()
+        invoke_handler = LambdaInvokeHandler(invoker, formatter, ui)
+        invoke_handler.invoke()
+
+        stubbed_session.verify_stubs()
+        assert ['foobarbaz\n'] == ui.writes
+
+    def test_invoke_can_format_and_write_error_case(self, stubbed_session):
+        arn = 'arn:aws:lambda:region:id:function:name-dev'
+        error = {
+            "errorMessage": "Something bad happened",
+            "errorType": "Error",
+            "stackTrace": [
+                ["/path/file.py", 123, "main", "foo(bar)"],
+                ["/path/other_file.py", 456, "function", "bar = baz"]
+            ]
+        }
+        serialized_error = json.dumps(error).encode('utf-8')
+        stubbed_session.stub('lambda').invoke(
+            FunctionName=arn,
+            InvocationType='RequestResponse'
+        ).returns({
+            'StatusCode': 200,
+            'FunctionError': 'Unhandled',
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(serialized_error)
+        })
+        ui = FakeUI()
+        stubbed_session.activate_stubs()
+        client = TypedAWSClient(stubbed_session)
+        invoker = LambdaInvoker(arn, client)
+        formatter = LambdaResponseFormatter()
+        invoke_handler = LambdaInvokeHandler(invoker, formatter, ui)
+        with pytest.raises(UnhandledLambdaError):
+            invoke_handler.invoke()
+
+        stubbed_session.verify_stubs()
+        assert [(
+            'Traceback (most recent call last):\n'
+            '  File "/path/file.py", line 123, in main\n'
+            '    foo(bar)\n'
+            '  File "/path/other_file.py", line 456, in function\n'
+            '    bar = baz\n'
+            'Error: Something bad happened\n'
+        )] == ui.errors
+
+    def test_invoke_can_format_and_write_small_error_case(self,
+                                                          stubbed_session):
+        # Some error response payloads do not have the errorType or
+        # stackTrace key.
+        arn = 'arn:aws:lambda:region:id:function:name-dev'
+        error = {
+            "errorMessage": "Something bad happened",
+        }
+        serialized_error = json.dumps(error).encode('utf-8')
+        stubbed_session.stub('lambda').invoke(
+            FunctionName=arn,
+            InvocationType='RequestResponse'
+        ).returns({
+            'StatusCode': 200,
+            'FunctionError': 'Unhandled',
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(serialized_error)
+        })
+        ui = FakeUI()
+        stubbed_session.activate_stubs()
+        client = TypedAWSClient(stubbed_session)
+        invoker = LambdaInvoker(arn, client)
+        formatter = LambdaResponseFormatter()
+        invoke_handler = LambdaInvokeHandler(invoker, formatter, ui)
+        with pytest.raises(UnhandledLambdaError):
+            invoke_handler.invoke()
+
+        stubbed_session.verify_stubs()
+        assert [(
+            'Something bad happened\n'
+        )] == ui.errors
+
+
+class TestLambdaInvoker(object):
+    def test_invoke_can_call_api_handler(self, stubbed_session):
+        arn = 'arn:aws:lambda:region:id:function:name-dev'
+        stubbed_session.stub('lambda').invoke(
+            FunctionName=arn,
+            InvocationType='RequestResponse'
+        ).returns({})
+        stubbed_session.activate_stubs()
+        client = TypedAWSClient(stubbed_session)
+        invoker = LambdaInvoker(arn, client)
+        invoker.invoke()
+        stubbed_session.verify_stubs()
+
+    def test_invoke_does_forward_payload(self, stubbed_session):
+        arn = 'arn:aws:lambda:region:id:function:name-dev'
+        stubbed_session.stub('lambda').invoke(
+            FunctionName=arn,
+            InvocationType='RequestResponse',
+            Payload=b'foobar',
+        ).returns({})
+        stubbed_session.activate_stubs()
+        client = TypedAWSClient(stubbed_session)
+        invoker = LambdaInvoker(arn, client)
+        invoker.invoke(b'foobar')
+        stubbed_session.verify_stubs()
+
+
+class TestLambdaResponseFormatter(object):
+    def test_formatter_can_format_success(self):
+        formatter = LambdaResponseFormatter()
+        formatted = formatter.format_response({
+            'StatusCode': 200,
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(b'foobarbaz')
+        })
+        assert 'foobarbaz\n' == formatted
+
+    def test_formatter_can_format_stack_trace(self):
+        error = {
+            "errorMessage": "Something bad happened",
+            "errorType": "Error",
+            "stackTrace": [
+                ["/path/file.py", 123, "main", "foo(bar)"],
+                ["/path/other_file.py", 456, "function", "bar = baz"]
+            ]
+        }
+        serialized_error = json.dumps(error).encode('utf-8')
+        formatter = LambdaResponseFormatter()
+        formatted = formatter.format_response({
+            'StatusCode': 200,
+            'FunctionError': 'Unhandled',
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(serialized_error)
+        })
+
+        assert (
+            'Traceback (most recent call last):\n'
+            '  File "/path/file.py", line 123, in main\n'
+            '    foo(bar)\n'
+            '  File "/path/other_file.py", line 456, in function\n'
+            '    bar = baz\n'
+            'Error: Something bad happened\n'
+        ) == formatted
+
+    def test_formatter_can_format_simple_error(self):
+        error = {
+            "errorMessage": "Something bad happened",
+        }
+        serialized_error = json.dumps(error).encode('utf-8')
+        formatter = LambdaResponseFormatter()
+        formatted = formatter.format_response({
+            'StatusCode': 200,
+            'FunctionError': 'Unhandled',
+            'ExecutedVersion': '$LATEST',
+            'Payload': FakeStreamingBody(serialized_error)
+        })
+
+        assert 'Something bad happened\n' == formatted

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 import re
 import mock
+import sys
 import click
 import pytest
 from six import StringIO
@@ -39,6 +40,24 @@ class TestUI(object):
         ui = utils.UI(self.out, self.err, confirm)
         return_value = ui.confirm("Confirm?")
         assert return_value == 'foo'
+
+
+class TestPipeReader(object):
+    def test_pipe_reader_does_read_pipe(self):
+        mock_stream = mock.Mock(spec=sys.stdin)
+        mock_stream.isatty.return_value = False
+        mock_stream.read.return_value = 'foobar'
+        reader = utils.PipeReader(mock_stream)
+        value = reader.read()
+        assert value == 'foobar'
+
+    def test_pipe_reader_does_not_read_tty(self):
+        mock_stream = mock.Mock(spec=sys.stdin)
+        mock_stream.isatty.return_value = True
+        mock_stream.read.return_value = 'foobar'
+        reader = utils.PipeReader(mock_stream)
+        value = reader.read()
+        assert value is None
 
 
 def test_serialize_json():


### PR DESCRIPTION
Implements #900 

## POC of the invoke command.

### Sample app
```python
from chalice import Chalice

app = Chalice(app_name='whatever')


@app.route('/')
def index():
    return {'hello': 'world'}


@app.lambda_function()
def error(event, context):
    return context


@app.lambda_function()
def echo(event, context):
    return event
```

### Calling a lambda function
Providing a payload is done from stdin
```
$ echo '"hello world"' | chalice invoke -n echo
"hello world"
```

No payload
```
$ chalice invoke -n echo
{}
```

### Calling a route
You can call a route by using the `api_handler` function name and fake all the values that API Gateway would send. This is a little nosier:
```
$ cat apig.json
{
    "queryStringParameters": [],
    "headers": {},
    "pathParameters": {},
    "body": {},
    "stageVariables": {},
    "requestContext": {
        "resourcePath": "/",
        "httpMethod": "GET"
    }
}
$ cat apig.json | chalice invoke -n api_handler
{"headers": {}, "statusCode": 200, "body": "{\"hello\": \"world\"}"}
```

### Unhandled errors will show a stack trace
Errors will show a formatted stack trace to look like a local python function failed. This prevents the need to wait for cloudwatch logs to propagate.
```
$ chalice invoke -n error
Traceback (most recent call last):
  File "/var/runtime/awslambda/bootstrap.py", line 110, in decimal_serializer
    raise TypeError(repr(o) + " is not JSON serializable")
  File "/var/lang/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/var/lang/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/lang/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
TypeError: <__main__.LambdaContext object at 0x7f3fa4d23f28> is not JSON serializable
```

### Handled errors are printed out
Errors thrown by the invoke command itself will be printed out in a pretty format. For example providing a non-json payload causes the `InvalidRequestContentException` to be thrown by lambda.
```
$ echo "invalid json" | chalice invoke -n echo
Error occured when invoking lambda: InvalidRequestContentException
Could not parse request body into json: Unrecognized token 'invalid': was expecting ('true', 'false' or 'null')
 at [Source: [B@30c3127a; line: 1, column: 9]
Aborted!
```