### PR TITLE
Content-Length header should be determined after any bytes encoding in local mode

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -575,6 +575,8 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
 
     def _send_http_response_with_body(self, code, headers, body):
         # type: (int, HeaderType, Union[str,bytes]) -> None
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
         self.send_response(code)
         self.send_header('Content-Length', str(len(body)))
         content_type = headers.pop(
@@ -583,8 +585,6 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
         for header_name, header_value in headers.items():
             self.send_header(header_name, header_value)
         self.end_headers()
-        if not isinstance(body, bytes):
-            body = body.encode('utf-8')
         self.wfile.write(body)
 
     do_GET = do_PUT = do_POST = do_HEAD = do_DELETE = do_PATCH = do_OPTIONS = \

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -140,6 +140,12 @@ def sample_app():
                         status_code=200,
                         headers={'Content-Type': 'application/octet-stream'})
 
+    @demo.route('/unicode-response')
+    def unicode_response():
+        return Response(body="le calice en s\u00e9curit\u00e9",
+                        status_code=200,
+                        headers={'Content-Type': 'text/plain; charset=utf-8'})
+
     return demo
 
 
@@ -454,6 +460,17 @@ def test_can_round_trip_binary(handler):
     handler.do_POST()
     response = _get_raw_body_from_response_stream(handler)
     assert response == body
+
+
+def test_body_contains_unicode(handler):
+    set_current_request(handler, method='GET', path='/unicode-response')
+    handler.do_GET()
+    value = handler.wfile.getvalue()
+    response_lines = value.splitlines()
+    expected_bytes = "le calice en s\u00e9curit\u00e9".encode('utf-8')
+    expected_header = b'Content-Length: %d' % len(expected_bytes)
+    assert expected_header in response_lines
+    assert expected_bytes in response_lines
 
 
 def test_querystring_is_mapped(handler):


### PR DESCRIPTION
In local mode, if a handler returns a Python 3 string (unicode) object as the Response body, then the Content-Length will be incorrect if the string contains any code points > 256. The Content-Length was being determined before the unicode object was encoded into a bytes object, meaning it was counting glyphs and not bytes, which resulted in truncation in a client which was obeying Content-Length.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.