### PR TITLE
switching dependency from enum34 to enum-compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'six>=1.10.0,<2.0.0',
     'pip>=9,<11',
     'attrs==17.4.0',
-    'enum-compat',
+    'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'six>=1.10.0,<2.0.0',
     'pip>=9,<11',
     'attrs==17.4.0',
-    'enum34==1.1.6',
+    'enum-compat',
     'jmespath>=0.9.3,<1.0.0',
 ]
 


### PR DESCRIPTION
*Issue #, if available:* 

#806

*Description of changes:*

To prevent the enum34 library from breaking python installs 3.4+, I switched to enum-compat which has a very simple [setup.py](https://github.com/jstasiak/enum-compat/blob/master/setup.py):

```python
has_enum = sys.version_info >= (3, 4)
...
install_requires=[] if has_enum else ['enum34'],
```

I have tested this change on python3.6.5 and python 2.7.14 on Amazon Linux (Amazon Linux AMI release 2018.03)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
