### PR TITLE
Fixed message truncation bug

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -576,6 +576,8 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
     def _send_http_response_with_body(self, code, headers, body):
         # type: (int, HeaderType, Union[str,bytes]) -> None
         self.send_response(code)
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
         self.send_header('Content-Length', str(len(body)))
         content_type = headers.pop(
             'Content-Type', 'application/json')
@@ -583,8 +585,6 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
         for header_name, header_value in headers.items():
             self.send_header(header_name, header_value)
         self.end_headers()
-        if not isinstance(body, bytes):
-            body = body.encode('utf-8')
         self.wfile.write(body)
 
     do_GET = do_PUT = do_POST = do_HEAD = do_DELETE = do_PATCH = do_OPTIONS = \


### PR DESCRIPTION
The length of the utf-8 encoded body may be different than the unicode length of the string. This causes message truncation on the response. This patch fixes the issue.

*Description of changes:*
Moved the code that converts the body to bytes up a few lines to reside before the code that sends the `Content-Length` header

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
