### PR TITLE
Fix pluggy requirement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Next Release (TBD)
 
 * Fix local mode issue with unicode responses and Content-Length
   (`#910 <https://github.com/aws/chalice/pull/910>`__)
+* Fix issue with ``requirements-dev.txt`` not setting up a working
+  dev environment
+  (`#920 <https://github.com/aws/chalice/pull/920>`__)
+
 
 1.6.0
 =====

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,5 +18,8 @@ pygments==2.1.3
 mock==2.0.0
 requests==2.18.4
 hypothesis==3.56.3
+# pip does not catch the <0.7 requirement in pytest so we need to add it to
+# the top level requirements.
+pluggy<0.7
 
 mypy==0.590; python_version >= '3.6'


### PR DESCRIPTION
Pluggy released 0.7.0 and 0.7.1and the way pip does dependency
resolution it doesn't catch that pytest requires < 0.7. Hoisting the
requirement of <0.7 up to the top of requirements-dev.txt allows pip to
pull in the correct version of pluggy which is 0.6.0.