### PR TITLE
Add event argument to scheduled function in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Tasks that run on a periodic basis:
 
     # Automatically runs every 5 minutes
     @app.schedule(Rate(5, unit=Rate.MINUTES))
-    def periodic_task():
+    def periodic_task(event):
         return {"hello": "world"}
 
 


### PR DESCRIPTION
The README's scheduled function example is missing the CloudWatch event argument that it will be passed. Relevant docs are here: http://chalice.readthedocs.io/en/latest/topics/events.html#scheduled-events

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
