### PR TITLE
Make local mode querystring processing consistent with APIGateway

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -125,7 +125,7 @@ class RouteMatcher(object):
         # Otherwise we need to check for param substitution
         parsed_url = urlparse(url)
         parsed_qs = parse_qs(parsed_url.query, keep_blank_values=True)
-        query_params = {k: v[0] for k, v in parsed_qs.items()}
+        query_params = {k: v[-1] for k, v in parsed_qs.items()}
         path = parsed_url.path
         # API Gateway removes the trailing slash if the route is not the root
         # path. We do the same here so our route matching works the same way.

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -462,6 +462,14 @@ def test_querystring_is_mapped(handler):
     assert _get_body_from_response_stream(handler) == {'a': 'b', 'c': 'd'}
 
 
+def test_querystring_undefined_is_mapped_consistent_with_apigateway(handler):
+    # API Gateway picks up the last element of duplicate keys in a
+    # querystring
+    set_current_request(handler, method='GET', path='/query-string?a=b&a=c')
+    handler.do_GET()
+    assert _get_body_from_response_stream(handler) == {'a': 'c'}
+
+
 def test_content_type_included_once(handler):
     set_current_request(handler, method='GET', path='/custom-response')
     handler.do_GET()


### PR DESCRIPTION
closes: #964 