### PR TITLE
Remove upper bound on pip version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'botocore>=1.10.48,<2.0.0',
     'typing==3.6.4',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<19.0',
+    'pip>=9,<=18.1',
     'attrs==17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'botocore>=1.10.48,<2.0.0',
     'typing==3.6.4',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<=18',
+    'pip>=9',
     'attrs==17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'botocore>=1.10.48,<2.0.0',
     'typing==3.6.4',
     'six>=1.10.0,<2.0.0',
-    'pip>=9',
+    'pip>=9,<19.0',
     'attrs==17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',


### PR DESCRIPTION
Since pip no longer uses semver the upper bound isn't particularly
useful. It also prevents Chalice from using newer versions once pip is
upgraded. Chalice will also downgrade the environment's pip version when
installed which can be a source of annoyance.

fixes #981 
