### PR TITLE
Add support for python 3.7

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -59,7 +59,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904,R0205,R1705,R1710
+disable=R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904,R0205,R1705,R1710,W0403
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -59,7 +59,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904
+disable=R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904,R0205,R1705,R1710
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 sudo: false
 matrix:
   include:
+  - python: "3.7"
+    dist: xenial
+    sudo: true
+    env: TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
   - python: "3.6"
     env: TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
   - python: "2.7"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TESTS=tests/unit tests/functional
 check:
 	###### FLAKE8 #####
 	# No unused imports, no undefined vars,
-	flake8 --ignore=E731,W503 --exclude chalice/__init__.py,chalice/compat.py --max-complexity 10 chalice/
-	flake8 --ignore=E731,W503,F401 --max-complexity 10 chalice/compat.py
+	flake8 --ignore=E731,W503,W504 --exclude chalice/__init__.py,chalice/compat.py --max-complexity 10 chalice/
+	flake8 --ignore=E731,W503,W504,F401 --max-complexity 10 chalice/compat.py
 	flake8 tests/unit/ tests/functional/ tests/integration
 	#
 	# Proper docstring conventions according to pep257

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -733,7 +733,7 @@ class Chalice(object):
             response = Response(body={'Code': e.__class__.__name__,
                                       'Message': str(e)},
                                 status_code=e.STATUS_CODE)
-        except Exception as e:
+        except Exception:
             headers = {}
             if self.debug:
                 # If the user has turned on debug mode,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1,5 +1,5 @@
 """Chalice app and routing code."""
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,ungrouped-imports
 import re
 import sys
 import os
@@ -8,7 +8,7 @@ import json
 import traceback
 import decimal
 import base64
-from collections import defaultdict, Mapping
+from collections import defaultdict
 
 
 __version__ = '1.6.1'
@@ -21,6 +21,7 @@ _PARAMS = re.compile(r'{\w+}')
 # directly in this file instead of copying over compat.py
 try:
     from urllib.parse import unquote_plus
+    from collections.abc import Mapping
 
     unquote_str = unquote_plus
 
@@ -29,6 +30,7 @@ try:
     _ANY_STRING = (str, bytes)
 except ImportError:
     from urllib import unquote_plus
+    from collections import Mapping
 
     # This is borrowed from botocore/compat.py
     def unquote_str(value, encoding='utf-8'):
@@ -276,6 +278,7 @@ class CORSConfig(object):
         if isinstance(other, self.__class__):
             return self.get_access_control_headers() == \
                 other.get_access_control_headers()
+        return False
 
 
 class Request(object):
@@ -875,7 +878,7 @@ class AuthResponse(object):
         # '/'.join(...)'d properly.
         base.extend([method, route[1:]])
         last_arn_segment = '/'.join(base)
-        if route == '/' or route == '*':
+        if route in ['/', '*']:
             # We have to special case the '/' case.  For whatever
             # reason, API gateway adds an extra '/' to the method_arn
             # of the auth request, so we need to do the same thing.

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -35,11 +35,11 @@ from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.constants import MAX_LAMBDA_DEPLOYMENT_SIZE
 
 
-_STR_MAP = Optional[Dict[str, str]]
-_OPT_STR = Optional[str]
-_OPT_INT = Optional[int]
-_OPT_STR_LIST = Optional[List[str]]
-_CLIENT_METHOD = Callable[..., Dict[str, Any]]
+StrMap = Optional[Dict[str, str]]
+OptStr = Optional[str]
+OptInt = Optional[int]
+OptStrList = Optional[List[str]]
+ClientMethod = Callable[..., Dict[str, Any]]
 
 _REMOTE_CALL_ERRORS = (
     botocore.exceptions.ClientError, RequestsConnectionError
@@ -113,7 +113,7 @@ class TypedAWSClient(object):
         return response
 
     def _create_vpc_config(self, security_group_ids, subnet_ids):
-        # type: (_OPT_STR_LIST, _OPT_STR_LIST) -> Dict[str, List[str]]
+        # type: (OptStrList, OptStrList) -> Dict[str, List[str]]
         # We always set the SubnetIds and SecurityGroupIds to an empty
         # list to ensure that we properly remove Vpc configuration
         # if you remove these values from your config.json.  Omitting
@@ -134,12 +134,12 @@ class TypedAWSClient(object):
                         zip_contents,                # type: str
                         runtime,                     # type: str
                         handler,                     # type: str
-                        environment_variables=None,  # type: _STR_MAP
-                        tags=None,                   # type: _STR_MAP
-                        timeout=None,                # type: _OPT_INT
-                        memory_size=None,            # type: _OPT_INT
-                        security_group_ids=None,     # type: _OPT_STR_LIST
-                        subnet_ids=None,             # type: _OPT_STR_LIST
+                        environment_variables=None,  # type: StrMap
+                        tags=None,                   # type: StrMap
+                        timeout=None,                # type: OptInt
+                        memory_size=None,            # type: OptInt
+                        security_group_ids=None,     # type: OptStrList
+                        subnet_ids=None,             # type: OptStrList
                         ):
         # type: (...) -> str
         kwargs = {
@@ -243,14 +243,14 @@ class TypedAWSClient(object):
     def update_function(self,
                         function_name,               # type: str
                         zip_contents,                # type: str
-                        environment_variables=None,  # type: _STR_MAP
-                        runtime=None,                # type: _OPT_STR
-                        tags=None,                   # type: _STR_MAP
-                        timeout=None,                # type: _OPT_INT
-                        memory_size=None,            # type: _OPT_INT
-                        role_arn=None,               # type: _OPT_STR
-                        subnet_ids=None,             # type: _OPT_STR_LIST
-                        security_group_ids=None,     # type: _OPT_STR_LIST
+                        environment_variables=None,  # type: StrMap
+                        runtime=None,                # type: OptStr
+                        tags=None,                   # type: StrMap
+                        timeout=None,                # type: OptInt
+                        memory_size=None,            # type: OptInt
+                        role_arn=None,               # type: OptStr
+                        subnet_ids=None,             # type: OptStrList
+                        security_group_ids=None,     # type: OptStrList
                         ):
         # type: (...) -> Dict[str, Any]
         """Update a Lambda function's code and configuration.
@@ -304,13 +304,13 @@ class TypedAWSClient(object):
             FunctionName=function_name)
 
     def _update_function_config(self,
-                                environment_variables,  # type: _STR_MAP
-                                runtime,                # type: _OPT_STR
-                                timeout,                # type: _OPT_INT
-                                memory_size,            # type: _OPT_INT
-                                role_arn,               # type: _OPT_STR
-                                subnet_ids,             # type: _OPT_STR_LIST
-                                security_group_ids,     # type: _OPT_STR_LIST
+                                environment_variables,  # type: StrMap
+                                runtime,                # type: OptStr
+                                timeout,                # type: OptInt
+                                memory_size,            # type: OptInt
+                                role_arn,               # type: OptStr
+                                subnet_ids,             # type: OptStrList
+                                security_group_ids,     # type: OptStrList
                                 function_name,          # type: str
                                 ):
         # type: (...) -> None
@@ -726,7 +726,7 @@ class TypedAWSClient(object):
 
     def connect_s3_bucket_to_lambda(self, bucket, function_arn, events,
                                     prefix=None, suffix=None):
-        # type: (str, str, List[str], _OPT_STR, _OPT_STR) -> None
+        # type: (str, str, List[str], OptStr, OptStr) -> None
         """Configure S3 bucket to invoke a lambda function.
 
         The S3 bucket must already have permission to invoke the
@@ -964,7 +964,7 @@ class TypedAWSClient(object):
 
     def _call_client_method_with_retries(
         self,
-        method,                 # type: _CLIENT_METHOD
+        method,                 # type: ClientMethod
         kwargs,                 # type: Dict[str, Any]
         max_attempts,           # type: int
         should_retry=None,      # type: Callable[[Exception], bool]

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -29,15 +29,15 @@ from chalice.invoke import LambdaInvoker
 from chalice.invoke import LambdaResponseFormatter
 
 
-_OPT_STR = Optional[str]
-_OPT_INT = Optional[int]
+OptStr = Optional[str]
+OptInt = Optional[int]
 
 
 def create_botocore_session(profile=None, debug=False,
                             connection_timeout=None,
                             read_timeout=None,
                             max_retries=None):
-    # type: (_OPT_STR, bool, _OPT_INT, _OPT_INT, _OPT_INT) -> Session
+    # type: (OptStr, bool, OptInt, OptInt, OptInt) -> Session
     s = Session(profile=profile)
     _add_chalice_user_agent(s)
     if debug:
@@ -114,7 +114,7 @@ class CLIFactory(object):
 
     def create_botocore_session(self, connection_timeout=None,
                                 read_timeout=None, max_retries=None):
-        # type: (_OPT_INT, _OPT_INT, _OPT_INT) -> Session
+        # type: (OptInt, OptInt, OptInt) -> Session
         return create_botocore_session(profile=self.profile,
                                        debug=self.debug,
                                        connection_timeout=connection_timeout,

--- a/chalice/cli/reloader.py
+++ b/chalice/cli/reloader.py
@@ -35,7 +35,7 @@ from chalice.local import LocalDevServer, HTTPServerThread  # noqa
 
 
 LOGGER = logging.getLogger(__name__)
-_WORKER_PROC_TYPE = Optional[Type[WorkerProcess]]
+WorkerProcType = Optional[Type[WorkerProcess]]
 
 
 def get_best_worker_process():
@@ -57,7 +57,7 @@ def start_parent_process(env):
 
 
 def start_worker_process(server_factory, root_dir, worker_process_cls=None):
-    # type: (Callable[[], LocalDevServer], str, _WORKER_PROC_TYPE) -> int
+    # type: (Callable[[], LocalDevServer], str, WorkerProcType) -> int
     if worker_process_cls is None:
         worker_process_cls = get_best_worker_process()
     t = HTTPServerThread(server_factory)
@@ -94,7 +94,7 @@ class ParentProcess(object):
 
 
 def run_with_reloader(server_factory, env, root_dir, worker_process_cls=None):
-    # type: (Callable, MutableMapping, str, _WORKER_PROC_TYPE) -> int
+    # type: (Callable, MutableMapping, str, WorkerProcType) -> int
     # This function is invoked in two possible modes, as the parent process
     # or as a chalice worker.
     try:

--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -111,14 +111,12 @@ else:
 
 if six.PY3:
     from urllib.parse import urlparse, parse_qs
-    lambda_abi = 'cp36m'
 
     def is_broken_pipe_error(error):
         # type: (Exception) -> bool
         return isinstance(error, BrokenPipeError)  # noqa
 else:
     from urlparse import urlparse, parse_qs
-    lambda_abi = 'cp27mu'
 
     def is_broken_pipe_error(error):
         # type: (Exception) -> bool

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -158,8 +158,7 @@ class Config(object):
         # for python versions 3.0-3.6. 3.7 and higher will use python3.7.
         elif (major, minor) <= (3, 6):
             return 'python3.6'
-        elif major == 3:
-            return 'python3.7'
+        return 'python3.7'
 
     def _chain_lookup(self, name, varies_per_chalice_stage=False,
                       varies_per_function=False):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -73,11 +73,6 @@ class Config(object):
 
     """
 
-    _PYTHON_VERSIONS = {
-        2: 'python2.7',
-        3: 'python3.6',
-    }
-
     def __init__(self,
                  chalice_stage=DEFAULT_STAGE_NAME,
                  function_name=DEFAULT_HANDLER_NAME,
@@ -156,7 +151,15 @@ class Config(object):
         # We may open this up to configuration later, but for now,
         # we attempt to match your python version to the closest version
         # supported by lambda.
-        return self._PYTHON_VERSIONS[sys.version_info[0]]
+        major, minor = sys.version_info[0], sys.version_info[1]
+        if major == 2:
+            return 'python2.7'
+        # Python 3 for backwards compatibility needs to select python3.6
+        # for python versions 3.0-3.6. 3.7 will use pytohn3.7, and future
+        # versions of of python 3 will map to 3.7 as well.
+        if minor <= 6:
+            return 'python.3.6'
+        return 'python3.7'
 
     def _chain_lookup(self, name, varies_per_chalice_stage=False,
                       varies_per_function=False):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -155,11 +155,11 @@ class Config(object):
         if major == 2:
             return 'python2.7'
         # Python 3 for backwards compatibility needs to select python3.6
-        # for python versions 3.0-3.6. 3.7 will use pytohn3.7, and future
-        # versions of of python 3 will map to 3.7 as well.
-        if minor <= 6:
-            return 'python.3.6'
-        return 'python3.7'
+        # for python versions 3.0-3.6. 3.7 and higher will use python3.7.
+        elif (major, minor) <= (3, 6):
+            return 'python3.6'
+        elif major == 3:
+            return 'python3.7'
 
     def _chain_lookup(self, name, varies_per_chalice_stage=False,
                       varies_per_function=False):

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -115,7 +115,7 @@ from chalice.utils import OSUtils, UI, serialize_to_json
 from chalice.deploy.validate import validate_configuration
 
 
-OPT_STR = Optional[str]
+OptStr = Optional[str]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -188,7 +188,7 @@ class ChaliceDeploymentError(Exception):
         return message
 
     def _get_error_suggestion(self, error):
-        # type: (Exception) -> OPT_STR
+        # type: (Exception) -> OptStr
         suggestion = None
         if isinstance(error, DeploymentPackageTooLargeError):
             suggestion = (

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -16,9 +16,9 @@ class RoleTraits(enum.Enum):
     VPC_NEEDED = 'vpc_needed'
 
 
-T = TypeVar('T')
-DV = Union[Placeholder, T]
-STR_MAP = Dict[str, str]
+Type = TypeVar('Type')
+DV = Union[Placeholder, Type]
+StrMap = Dict[str, str]
 
 
 @attrs
@@ -147,10 +147,10 @@ class LambdaFunction(ManagedModel):
     resource_type = 'lambda_function'
     function_name = attrib()          # type: str
     deployment_package = attrib()     # type: DeploymentPackage
-    environment_variables = attrib()  # type: STR_MAP
+    environment_variables = attrib()  # type: StrMap
     runtime = attrib()                # type: str
     handler = attrib()                # type: str
-    tags = attrib()                   # type: STR_MAP
+    tags = attrib()                   # type: StrMap
     timeout = attrib()                # type: int
     memory_size = attrib()            # type: int
     role = attrib()                   # type: IAMRole

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -51,7 +51,6 @@ class NoSuchPackageError(Exception):
 
 class PackageDownloadError(Exception):
     """Generic networking error during a package download."""
-    pass
 
 
 class LambdaDeploymentPackager(object):
@@ -280,7 +279,7 @@ class DependencyBuilder(object):
         self._pip = pip_runner
 
     def _is_compatible_wheel_filename(self, expected_abi, filename):
-        # type: (str) -> bool
+        # type: (str, str) -> bool
         wheel = filename[:-4]
         implementation, abi, platform = wheel.split('-')[-3:]
         # Verify platform is compatible

--- a/chalice/invoke.py
+++ b/chalice/invoke.py
@@ -9,7 +9,7 @@ from chalice.utils import UI  # noqa
 from chalice.compat import StringIO
 
 
-_OPT_STR = Optional[str]
+OptStr = Optional[str]
 _ERROR_KEY = 'FunctionError'
 _ERROR_VALUE = 'Unhandled'
 
@@ -37,7 +37,7 @@ class LambdaInvokeHandler(object):
         self._ui = ui
 
     def invoke(self, payload=None):
-        # type: (_OPT_STR) -> None
+        # type: (OptStr) -> None
         response = self._invoker.invoke(payload)
         formatted_response = self._formatter.format_response(response)
         if _response_is_error(response):
@@ -54,7 +54,7 @@ class LambdaInvoker(object):
         self._client = client
 
     def invoke(self, payload=None):
-        # type: (_OPT_STR) -> Dict[str, Any]
+        # type: (OptStr) -> Dict[str, Any]
         return self._client.invoke_function(
             self._lambda_arn,
             payload=payload

--- a/chalice/policy.py
+++ b/chalice/policy.py
@@ -17,8 +17,8 @@ from chalice.constants import CLOUDWATCH_LOGS, VPC_ATTACH_POLICY
 from chalice.utils import OSUtils  # noqa
 from chalice.config import Config  # noqa
 
-API_POLICY_T = Dict[str, Dict[str, str]]
-CUSTOM_POLICY_T = Dict[str, Dict[str, List[str]]]
+APIPolicyT = Dict[str, Dict[str, str]]
+CustomPolicyT = Dict[str, Dict[str, List[str]]]
 
 
 def policy_from_source_code(source_code):
@@ -31,12 +31,12 @@ def policy_from_source_code(source_code):
 
 
 def load_api_policy_actions():
-    # type: () -> API_POLICY_T
+    # type: () -> APIPolicyT
     return _load_json_file('policies.json')
 
 
 def load_custom_policy_actions():
-    # type: () -> CUSTOM_POLICY_T
+    # type: () -> CustomPolicyT
     return _load_json_file('policies-extra.json')
 
 
@@ -101,7 +101,7 @@ class PolicyBuilder(object):
 
     def __init__(self, session=None, api_policy_actions=None,
                  custom_policy_actions=None):
-        # type: (Any, API_POLICY_T, CUSTOM_POLICY_T) -> None
+        # type: (Any, APIPolicyT, CustomPolicyT) -> None
         if session is None:
             session = botocore.session.get_session()
         # The difference between api_policy_actions and custom_policy_actions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,8 @@ wheel==0.26.0
 doc8==0.8.0
 # Pylint will fail on py3.  Locking to a commit on master
 # until pylint2 is released.
--e git://github.com/PyCQA/pylint.git@7cb3ffddfd96f5e099ca697f6b1e30e727544627#egg=pylint
-astroid==1.6.1
+pylint==2.0.0
+astroid==2.0.0
 pytest-cov==2.5.1
 pydocstyle==2.0.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ doc8==0.8.0
 pylint==2.2.2
 astroid==2.1.0
 pytest-cov==2.5.1
-pycodestyle==2.4.0
+pydocstyle==2.0.0
 
 # Test requirements
 pytest==3.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,13 @@ flake8==3.6.0
 tox==3.0.0
 wheel==0.26.0
 doc8==0.8.0
-# Pylint will fail on py3.  Locking to a commit on master
-# until pylint2 is released.
-pylint==2.2.2
-astroid==2.1.0
+# The latest version of pylint only works on python3.
+pylint==2.2.2 ; python_version >= '3.6'
+astroid==2.1.0 ; python_version >= '3.6'
+# For python2, there are a few bugs in the latest versions of 1.x,
+# so we're locking to a specific version that we know works.
+pylint==1.9.3 ; python_version >= '3.6'
+astroid==1.6.5 ; python_version <= '2.7'
 pytest-cov==2.5.1
 pydocstyle==2.0.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,8 @@ wheel==0.26.0
 doc8==0.8.0
 # Pylint will fail on py3.  Locking to a commit on master
 # until pylint2 is released.
-pylint==2.0.0
-astroid==2.0.0
+pylint==2.2.2
+astroid==2.1.0
 pytest-cov==2.5.1
 pycodestyle==2.4.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dev requirements, used for various linting tools
 coverage==4.5.1
-flake8==3.5.0
+flake8==3.6.0
 tox==3.0.0
 wheel==0.26.0
 doc8==0.8.0
@@ -9,7 +9,7 @@ doc8==0.8.0
 pylint==2.0.0
 astroid==2.0.0
 pytest-cov==2.5.1
-pydocstyle==2.0.0
+pycodestyle==2.4.0
 
 # Test requirements
 pytest==3.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pylint==2.2.2 ; python_version >= '3.6'
 astroid==2.1.0 ; python_version >= '3.6'
 # For python2, there are a few bugs in the latest versions of 1.x,
 # so we're locking to a specific version that we know works.
-pylint==1.9.3 ; python_version >= '3.6'
+pylint==1.9.3 ; python_version <= '2.7'
 astroid==1.6.5 ; python_version <= '2.7'
 pytest-cov==2.5.1
 pydocstyle==2.0.0

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import zipfile
 import os
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -255,6 +256,8 @@ def test_error_when_no_deployed_record(runner, mock_cli_factory):
         assert 'not find' in result.output
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 7),
+                    reason="Cannot generate pipeline for python3.7.")
 def test_can_generate_pipeline_for_all(runner):
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -81,7 +81,7 @@ def test_app_injection_still_compresses_file(tmpdir, chalice_deployer):
     appdir = _create_app_structure(tmpdir)
     appdir.join('app.py').write('# Test app v1')
     name = chalice_deployer.create_deployment_package(
-        str(appdir), 'python 2.7')
+        str(appdir), 'python2.7')
     original_size = os.path.getsize(name)
     appdir.join('app.py').write('# Test app v2')
     chalice_deployer.inject_latest_app(name, str(appdir))

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -17,7 +17,6 @@ from chalice.deploy.packager import MissingDependencyError
 from chalice.deploy.packager import SubprocessPip
 from chalice.deploy.packager import SDistMetadataFetcher
 from chalice.deploy.packager import InvalidSourceDistributionNameError
-from chalice.compat import lambda_abi
 from chalice.compat import pip_no_compile_c_env_vars
 from chalice.compat import pip_no_compile_c_shim
 from chalice.utils import OSUtils
@@ -246,7 +245,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -267,7 +266,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -291,7 +290,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -313,7 +312,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -335,7 +334,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -362,7 +361,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -389,7 +388,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -417,7 +416,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -445,7 +444,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -475,7 +474,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -498,7 +497,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -521,7 +520,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp27mu', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -547,7 +546,8 @@ class TestDependencyBuilder(object):
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(requirements_file, site_packages)
+            builder.build_site_packages(
+                'cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
         missing_packages = list(e.value.missing)
 
@@ -572,7 +572,8 @@ class TestDependencyBuilder(object):
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(requirements_file, site_packages)
+            builder.build_site_packages(
+                'cp27mu', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         missing_packages = list(e.value.missing)
@@ -596,7 +597,8 @@ class TestDependencyBuilder(object):
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(requirements_file, site_packages)
+            builder.build_site_packages(
+                'cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         missing_packages = list(e.value.missing)
@@ -624,7 +626,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', 'cp36m', '--dest', mock.ANY,
                 'bar==1.2'
             ],
             packages=[
@@ -632,7 +634,7 @@ class TestDependencyBuilder(object):
             ]
         )
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -641,6 +643,7 @@ class TestDependencyBuilder(object):
 
     def test_whitelist_sqlalchemy(self, tmpdir, osutils, pip_runner):
         reqs = ['sqlalchemy==1.1.18']
+        abi = 'cp36m'
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(
             reqs, tmpdir, runner)
@@ -655,7 +658,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', abi, '--dest', mock.ANY,
                 'sqlalchemy==1.1.18'
             ],
             packages=[
@@ -663,7 +666,7 @@ class TestDependencyBuilder(object):
             ]
         )
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages(abi, requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -692,7 +695,7 @@ class TestDependencyBuilder(object):
             ]
         )
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -727,7 +730,8 @@ class TestDependencyBuilder(object):
         )
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(requirements_file, site_packages)
+            builder.build_site_packages(
+                'cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         # bar should succeed and foo should failed.
@@ -779,7 +783,7 @@ class TestDependencyBuilder(object):
         )
 
         site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
-        builder.build_site_packages(requirements_file, site_packages)
+        builder.build_site_packages('cp36m', requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         # Now we should have successfully built the foo package.
@@ -794,6 +798,7 @@ class TestDependencyBuilder(object):
         # they may be there by happenstance, or from an incompatible version
         # of python.
         reqs = ['foo', 'bar']
+        abi = 'cp36m'
         pip, runner = pip_runner
         appdir, builder = self._make_appdir_and_dependency_builder(
             reqs, tmpdir, runner)
@@ -809,7 +814,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', abi, '--dest', mock.ANY,
                 'foo==1.2'
             ],
             packages=[
@@ -825,7 +830,8 @@ class TestDependencyBuilder(object):
         bar = os.path.join(site_packages, 'bar')
         os.makedirs(bar)
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(requirements_file, site_packages)
+            builder.build_site_packages(
+                abi, requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         # bar should succeed and foo should failed.

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 from collections import namedtuple
 
@@ -193,11 +192,8 @@ class TestPipRunner(object):
         # for getting lambda compatible wheels.
         pip, runner = pip_factory()
         packages = ['foo', 'bar', 'baz']
-        runner.download_manylinux_wheels(packages, 'directory')
-        if sys.version_info[0] == 2:
-            abi = 'cp27mu'
-        else:
-            abi = 'cp36m'
+        abi = 'cp37m'
+        runner.download_manylinux_wheels(abi, packages, 'directory')
         expected_prefix = ['download', '--only-binary=:all:', '--no-deps',
                            '--platform', 'manylinux1_x86_64',
                            '--implementation', 'cp', '--abi', abi,
@@ -209,7 +205,7 @@ class TestPipRunner(object):
 
     def test_download_wheels_no_wheels(self, pip_factory):
         pip, runner = pip_factory()
-        runner.download_manylinux_wheels([], 'directory')
+        runner.download_manylinux_wheels('cp36m', [], 'directory')
         assert len(pip.calls) == 0
 
     def test_raise_no_such_package_error(self, pip_factory):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -851,7 +851,7 @@ class TestCORSConfig(object):
     def test_not_eq_different_type(self):
         cors_config = app.CORSConfig()
         different_type_obj = object()
-        assert cors_config != different_type_obj
+        assert not cors_config == different_type_obj
 
     def test_not_eq_differing_configurations(self):
         cors_config = app.CORSConfig()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -328,10 +328,13 @@ def test_env_vars_chain_merge():
 
 def test_can_load_python_version():
     c = Config('dev')
-    expected_runtime = {
-        2: 'python2.7',
-        3: 'python3.6',
-    }[sys.version_info[0]]
+    major, minor = sys.version_info[0], sys.version_info[1]
+    if major == 2:
+        expected_runtime = 'python2.7'
+    elif minor <= 6:
+        expected_runtime = 'python3.6'
+    else:
+        expected_runtime = 'python3.7'
     assert c.lambda_python_version == expected_runtime
 
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -47,10 +47,14 @@ class TestPipelineGen(object):
             'aws/codebuild/python:3.6.5'
 
     def test_invalid_python_throws_error(self):
-        # This test can be removed when there is a 3.6 codebuild image
-        # available.
         with pytest.raises(InvalidCodeBuildPythonVersion):
             self.generate_template('app', 'python2.6')
+
+    def test_python_37_throws_error(self):
+        # This test can be removed when there is a 3.7 codebuild image
+        # available.
+        with pytest.raises(InvalidCodeBuildPythonVersion):
+            self.generate_template('app', 'python3.7')
 
     def test_nonsense_py_version_throws_error(self):
         with pytest.raises(InvalidCodeBuildPythonVersion):


### PR DESCRIPTION
Lambda now supports python3.7. This commit adds support for packaging
your Chalice app, and deploying it to python 3.7.

Note: To support python 3.7 pylint needed to be updated to 2.0.0. This adds a lot of new validations that we fail. So this PR needs another commit that goes through and disables them or fixes our code to pass them. I don't have the energy to play whack a mole with that right now so pushing this up to get thoughts on the relevant code changes.