### PR TITLE
Fix documentation typo to correct custom authorizer URI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1109,7 +1109,7 @@ to the URI of your lambda function.
 
     authorizer = CustomAuthorizer(
         'MyCustomAuth', header='Authorization',
-        authorizer_uri=('arn:aws:apigateway:region:lambda:path/2015-03-01'
+        authorizer_uri=('arn:aws:apigateway:region:lambda:path/2015-03-31'
                         '/functions/arn:aws:lambda:region:account-id:'
                         'function:FunctionName/invocations'))
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -454,7 +454,7 @@ for an ``@app.route(authorizer=...)`` call:
 
      The URI of the lambda function to use for the custom authorizer.  This
      usually has the form
-     ``arn:aws:apigateway:{region}:lambda:path/2015-03-01/functions/{lambda_arn}/invocations``.
+     ``arn:aws:apigateway:{region}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations``.
 
   .. attribute:: ttl_seconds
 

--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -89,7 +89,7 @@ you use the ``CustomAuthorizer`` class:
 
     authorizer = CustomAuthorizer(
         'MyCustomAuth', header='Authorization',
-        authorizer_uri=('arn:aws:apigateway:region:lambda:path/2015-03-01'
+        authorizer_uri=('arn:aws:apigateway:region:lambda:path/2015-03-31'
                         '/functions/arn:aws:lambda:region:account-id:'
                         'function:FunctionName/invocations'))
 


### PR DESCRIPTION
The example URI for a Lambda custom authorizer does not work as expected with API Gateway, and on invocation will fail with an `AuthorizerConfigurationException`.

Workarounds included editing and saving the API Gateway authorizer configuration without making any changes in the console. Inspecting CloudTrail logs generated from doing so shows that this is updating the URI with an Arn with date `2015-03-31` rather than `2015-03-01` as appears in the Chalice documentation.

See comments here for more detail: https://github.com/aws/chalice/issues/670#issuecomment-442292644

*Issue #, if available:* #670 

*Description of changes:*
Updated the documentation to use the URIs which match those generated by API Gateway which work as expected, by replacing appropriate instances of `2015-03-01` with `2015-03-31` to match similar URIs found throughout the AWS documentation. Closes #670 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
