### PR TITLE
Fix to prevent FileNotFoundErrors from stopping filewatcher  

### DIFF
--- a/chalice/cli/filewatch/stat.py
+++ b/chalice/cli/filewatch/stat.py
@@ -56,7 +56,10 @@ class StatFileWatcher(FileWatcher):
         for rootdir, _, filenames in self._osutils.walk(root_dir):
             for filename in filenames:
                 path = self._osutils.joinpath(rootdir, filename)
-                self._mtime_cache[path] = self._osutils.mtime(path)
+                try:
+                    self._mtime_cache[path] = self._osutils.mtime(path)
+                except OSError:
+                    pass
 
     def _single_pass_poll(self, root_dir, callback):
         # type: (str, Callable[[], None]) -> None

--- a/tests/unit/cli/filewatch/test_stat.py
+++ b/tests/unit/cli/filewatch/test_stat.py
@@ -9,7 +9,7 @@ class FakeOSUtils(object):
         self.initial_scan = True
 
     def walk(self, rootdir):
-        yield 'rootdir', [], ['bad-file', 'baz']
+        yield 'rootdir', [], ['bad-file', 'no-file', 'baz']
         if self.initial_scan:
             self.initial_scan = False
 
@@ -17,6 +17,8 @@ class FakeOSUtils(object):
         return os.path.join(*parts)
 
     def mtime(self, path):
+        if path.endswith('no-file'):
+            raise FileNotFoundError()
         if self.initial_scan:
             return 1
         if path.endswith('bad-file'):


### PR DESCRIPTION
See issue #997.

* Changed the test so it exposes a bug in `StatFileWatcher._seed_mtime_cache` wrt/ `FileNotFoundError`
* Added exception handler to `_seed_mtime_cache` to handle the case (ignore it)

Someone more familiar with these tests should take a look at `test_stat.py`, the use of `initial_scan` in the mock osutils class smells like it is making assumptions about the specific implementation of `StatFileWatcher`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.