### PR TITLE
Loading the environment variables before deploying

### DIFF
--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -162,6 +162,7 @@ class CLIFactory(object):
                         user_provided_params=user_provided_params,
                         config_from_disk=config_from_disk,
                         default_params=default_params)
+        os.environ.update(config.environment_variables)
         user_provided_params['chalice_app'] = functools.partial(
             self.load_chalice_app, config.environment_variables)
         return config


### PR DESCRIPTION
*Description of changes:*
I added this line to the `chalice/cli/factory.py` file in order to load the environment variables before deploying an chalice project :

```python
def create_config_obj(self, chalice_stage_name=DEFAULT_STAGE_NAME,
        ...
        os.environ.update(config.environment_variables)
```

By loading these variables, we can now use variables outside of a lambda scope. I needed this using domovoi, in order to use clean variables in cloudwatch event patterns.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.