### PR TITLE
Don’t multi-thread local dev server, but also force connection close to prevent hanging

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -554,6 +554,7 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
             )
             status_code = response['statusCode']
             headers = response['headers']
+            headers['Connection'] = 'Close'
             body = response['body']
             self._send_http_response(status_code, headers, body)
         except LocalGatewayException as e:
@@ -615,7 +616,7 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 class LocalDevServer(object):
     def __init__(self, app_object, config, host, port,
                  handler_cls=ChaliceRequestHandler,
-                 server_cls=ThreadedHTTPServer):
+                 server_cls=HTTPServer):
         # type: (Chalice, Config, str, int, HandlerCls, ServerCls) -> None
         self.app_object = app_object
         self.host = host


### PR DESCRIPTION
Prevents request handlers from running concurrently resulting in indeterminate app.current_request during a request.

*Issue #, if available:*
https://github.com/aws/chalice/issues/759

*Description of changes:*
Use HTTPServer instead of ThreadedHTTPServer, but also instruct HTTP client to close keep-alive connection by adding a "Connection: Close" header.

Tested with Chrome web browser and iOS client using actual apps hitting a production HTTP API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
