### PR TITLE
Verify we see a debug log from chalice code

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -77,7 +77,9 @@ class LambdaDeploymentPackager(object):
     def create_deployment_package(self, project_dir, python_version,
                                   package_filename=None):
         # type: (str, str, Optional[str]) -> str
-        self._ui.write("Creating deployment package.\n")
+        msg = "Creating deployment package."
+        self._ui.write("%s\n" % msg)
+        logger.debug(msg)
         # Now we need to create a zip file and add in the site-packages
         # dir first, followed by the app_dir contents next.
         deployment_package_filename = self.deployment_package_filename(

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -2,6 +2,7 @@ import json
 import zipfile
 import os
 import sys
+import re
 
 import pytest
 from click.testing import CliRunner
@@ -157,7 +158,8 @@ def test_debug_flag_enables_logging(runner):
         result = runner.invoke(
             cli.cli, ['--debug', 'package', 'outdir'], obj={})
         assert result.exit_code == 0
-        assert '[DEBUG]' in result.output
+        assert re.search('[DEBUG].*Creating deployment package',
+                         result.output) is not None
 
 
 def test_does_deploy_with_default_api_gateway_stage_name(runner,


### PR DESCRIPTION
The existing test_debug_flag_enables_logging test
was relying on a debug message being present from botocore.
If you package an empty project with nothing in requirements.txt
you'll get:

```
$ chalice --debug package out5
2018-12-05 15:27:26,586 botocore.hooks [DEBUG] Changing event name from creating-client-class.iot-data to creating-client-class.iot-data-plane
2018-12-05 15:27:26,590 botocore.hooks [DEBUG] Changing event name from before-call.apigateway to before-call.api-gateway
2018-12-05 15:27:26,591 botocore.hooks [DEBUG] Changing event name from request-created.machinelearning.Predict to request-created.machine-learning.Predict
...
```

which all come from botocore when you create a client.
The issue is that those messages in botocore are only present in
versions of botocore after the "service id" switchover.  Our
version range dependency of botocore includes versions of botocore
before we switched the internal to user service id.  As a result
this test can fail if you have old (but allowed) version of
botocore installed.

The fix is to explicitly verify a debug message from within
the chalice code base so it's something we can control.  I added
a debug message to the packager that's in every code path
to ensure we see debug logs.

cc @kyleknap @joguSD 