### PR TITLE
Make local server address+port a URL

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -630,7 +630,7 @@ class LocalDevServer(object):
 
     def serve_forever(self):
         # type: () -> None
-        print("Serving on %s:%s" % (self.host, self.port))
+        print("Serving on http://%s:%s" % (self.host, self.port))
         self.server.serve_forever()
 
     def shutdown(self):


### PR DESCRIPTION
Currently if you run `chalice local` it outputs:

    Serving on 127.0.0.1:8000

This PR adds "http://", i.e:

    Serving on http://127.0.0.1:8000

This allows the user to then just click on the hyperlink which most terminals automatically recognize.
