### PR TITLE
Add support for blueprints

### DIFF
--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -1,4 +1,4 @@
-from chalice.app import Chalice
+from chalice.app import Chalice, Blueprint
 from chalice.app import (
     ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
     NotFoundError, ConflictError, TooManyRequestsError, Response, CORSConfig,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -488,8 +488,8 @@ class DecoratorAPI(object):
             handler_type='route',
             name=kwargs.get('name'),
             # This looks a little weird taking kwargs as a key,
-            # but to preserve backwards compatibility we have to
-            # keep the **kwargs signature in the route decorator.
+            # but we want to preserve keep the **kwargs signature
+            # in the route decorator.
             registration_kwargs={'path': path, 'kwargs': kwargs},
         )
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1186,10 +1186,8 @@ class SQSRecord(BaseLambdaEvent):
 
 
 class Blueprint(DecoratorAPI):
-    def __init__(self, import_name, name_prefix=None, url_prefix=None):
+    def __init__(self, import_name):
         self._import_name = import_name
-        self._name_prefix = name_prefix
-        self._url_prefix = url_prefix
         self._deferred_registrations = []
         self._current_app = None
         self._lambda_context = None

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1192,6 +1192,7 @@ class Blueprint(DecoratorAPI):
         self._url_prefix = url_prefix
         self._deferred_registrations = []
         self._current_app = None
+        self._lambda_context = None
 
     @property
     def current_request(self):
@@ -1201,6 +1202,15 @@ class Blueprint(DecoratorAPI):
                 "to an app."
             )
         return self._current_app.current_request
+
+    @property
+    def lambda_context(self):
+        if self._current_app is None:
+            raise RuntimeError(
+                "Can only access Blueprint.lambda_context if it's registered "
+                "to an app."
+            )
+        return self._current_app.lambda_context
 
     def register(self, app, options):
         self._current_app = app

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -508,13 +508,13 @@ class DecoratorAPI(object):
             else:
                 kwargs = {}
             wrapped = self._wrap_handler(handler_type, handler_name,
-                                         user_handler, kwargs)
+                                         user_handler)
             self._register_handler(handler_type, handler_name,
                                    user_handler, wrapped, kwargs)
             return wrapped
         return _register_handler
 
-    def _wrap_handler(self, handler_type, handler_name, user_handler, kwargs):
+    def _wrap_handler(self, handler_type, handler_name, user_handler):
         event_classes = {
             'on_s3_event': S3Event,
             'on_sns_message': SNSEvent,

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -222,3 +222,7 @@ class SQSEventConfig(BaseEventSourceConfig):
 
 class CloudWatchEventConfig(BaseEventSourceConfig):
     schedule_expression = ...  # type: Union[str, ScheduleExpression]
+
+
+class Blueprint(Chalice):
+    pass

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -116,7 +116,38 @@ class APIGateway(object):
     binary_types = ... # type: List[str]
 
 
-class Chalice(object):
+class DecoratorAPI(object):
+    def authorizer(self,
+                   ttl_seconds: Optional[int]=None,
+                   execution_role: Optional[str]=None,
+                   name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def on_s3_event(self,
+                    bucket: str,
+                    events: Optional[List[str]]=None,
+                    prefix: Optional[str]=None,
+                    suffix: Optional[str]=None,
+                    name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def on_sns_message(self,
+                      topic: str,
+                      name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def on_sqs_message(self,
+                       queue: str,
+                       batch_size: int=1,
+                       name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def schedule(self,
+                 expression: str,
+                 name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def route(self, path: str, **kwargs: Any) -> Callable[..., Any]: ...
+
+    def lambda_function(self, name: Optional[str]=None) -> Callable[..., Any]: ...
+
+
+class Chalice(DecoratorAPI):
     app_name = ... # type: str
     api = ... # type: APIGateway
     routes = ... # type: Dict[str, Dict[str, RouteEntry]]
@@ -134,8 +165,6 @@ class Chalice(object):
                  configure_logs: bool=True,
                  env: Optional[Dict[str, str]]=None) -> None: ...
 
-    def route(self, path: str, **kwargs: Any) -> Callable[..., Any]: ...
-    def _add_route(self, path: str, view_func: Callable[..., Any], **kwargs: Any) -> None: ...
     def __call__(self, event: Any, context: Any) -> Any: ...
     def _get_view_function_response(self,
                                     view_function: Callable[..., Any],
@@ -224,5 +253,6 @@ class CloudWatchEventConfig(BaseEventSourceConfig):
     schedule_expression = ...  # type: Union[str, ScheduleExpression]
 
 
-class Blueprint(Chalice):
-    pass
+class Blueprint(DecoratorAPI):
+    current_request = ... # type: Request
+    lambda_context = ... # type: LambdaContext

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -301,6 +301,20 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
+   .. method:: register_blueprint(blueprint, name_prefix=None, url_prefix=None)
+
+      Register a :class:`Blueprint` to a Chalice app.
+      See :doc:`topics/blueprints` for more information.
+
+      :param blueprint: The :class:`Blueprint` to register to the app.
+
+      :param name_prefix: An optional name prefix that's added to all the
+        resources specified in the blueprint.
+
+      :param url_prefix: An optional url prefix that's added to all the
+        routes defined the Blueprint.  This allows you to set the root mount
+        point for all URLs in a Blueprint.
+
 
 Request
 =======
@@ -657,8 +671,8 @@ CORS
      ``Access-Control-Allow-Credentials``.
 
 
-Scheduled Events
-================
+Event Sources
+=============
 
 .. versionadded:: 1.0.0b1
 
@@ -955,3 +969,43 @@ Scheduled Events
       Return the original dictionary associated with the given
       message. This is useful if you need direct
       access to the lambda event.
+
+
+Blueprints
+==========
+
+.. class:: Blueprint(import_name)
+
+  An object used for grouping related handlers together.
+  This is primarily used as a mechanism for organizing your lambda
+  handlers.  Any decorator methods defined in the :class:`Chalice`
+  object are also defined on a ``Blueprint`` object.  You can register
+  a blueprint to a Chalice app using the :meth:`Chalice.register_blueprint`
+  method.
+
+  The ``import_name`` is the module in which the Blueprint is defined.
+  It is used to construct the appropriate handler string when creating
+  the Lambda functions associated with a Blueprint.  This is typically
+  the `__name__` attribute:``mybp = Blueprint(__name__)``.
+
+  See :doc:`topics/blueprints` for more information.
+
+  .. code-block:: python
+
+      # In ./app.py
+
+      from chalice import Chalice
+      from chalicelib import myblueprint
+
+      app = Chalice(app_name='blueprints')
+      app.register_blueprint(myblueprint)
+
+      # In chalicelib/myblueprint.py
+
+      from chalice import Blueprint
+
+      myblueprint = Blueprint(__name__)
+
+      @myblueprint.route('/')
+      def index():
+          return {'hello': 'world'}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,6 +63,7 @@ Topics
    topics/authorizers
    topics/events
    topics/purelambda
+   topics/blueprints
    topics/cd
 
 

--- a/docs/source/topics/blueprints.rst
+++ b/docs/source/topics/blueprints.rst
@@ -1,0 +1,198 @@
+Blueprints
+==========
+
+
+Chalice blueprints are used to organize your application into logical
+components.  Using a blueprint, you define your resources and decorators in
+modules outside of your ``app.py``.  You then register a blueprint in your main
+``app.py`` file.  Any decorator supported on an application object is also
+supported in a blueprint.
+
+
+.. note::
+
+  The Chalice blueprints are conceptually similar to `Blueprints
+  <http://flask.pocoo.org/docs/latest/blueprints/>`__ in Flask.  Flask
+  blueprints allow you to define a set of URL routes separately from the main
+  ``Flask`` object.  This concept is extended to all resources in Chalice.  A
+  Chalice blueprint can have Lambda functions, event handlers, built in
+  authorizers, etc. in addition to a collection of routes.
+
+
+Example
+-------
+
+In this example we'll create a blueprint with part of our routes defined in a
+separate file.  First, let's create an application::
+
+    $ chalice new-project blueprint-demo
+    $ cd blueprint-demo
+    $ mkdir chalicelib
+    $ touch chalicelib/__init__.py
+    $ touch chalicelib/blueprints.py
+
+Next, we'll oen the ``chalicelib/blueprints.py`` file:
+
+.. code-block:: python
+
+    from chalice import Blueprint
+
+
+    extra_routes = Blueprint(__name__)
+
+
+    @extra_routes.route('/foo')
+    def foo():
+        return {'foo': 'bar'}
+
+
+The ``__name__`` is used to denote the import path of the blueprint.  This must
+match the import name of the module so the function can be properly imported
+when running in Lambda.  We'll now import this module in our ``app.py`` and
+register this blueprint.  We'll also add a route in our ``app.py`` directly:
+
+.. code-block:: python
+
+    from chalice import Chalice
+    from chalicelib.blueprints import extra_routes
+
+    app = Chalice(app_name='blueprint-demo')
+    app.register_blueprint(extra_routes)
+
+
+    @app.route('/')
+    def index():
+        return {'hello': 'world'}
+
+At this point we've defined two routes.  One route, ``/``, is directly defined
+in our ``app.py`` file.  The other route, ``/foo`` is defined in
+``chalicelib/blueprints.py``.  It was added to our Chalice app when we
+registered it via ``app.register_blueprint(extra_routes)``.
+
+We can deploy our application to verify this works as expected::
+
+    $ chalice deploy
+    Creating deployment package.
+    Creating IAM role: blueprint-demo-dev
+    Creating lambda function: blueprint-demo-dev
+    Creating Rest API
+    Resources deployed:
+      - Lambda ARN: arn:aws:lambda:us-west-2:1234:function:blueprint-demo-dev
+      - Rest API URL: https://rest-api.execute-api.us-west-2.amazonaws.com/api/
+
+
+We should now be able to request the ``/`` and ``/foo`` routes::
+
+    $ http https://rest-api.execute-api.us-west-2.amazonaws.com/api/
+    HTTP/1.1 200 OK
+    Connection: keep-alive
+    Content-Length: 17
+    Content-Type: application/json
+    Date: Sat, 22 Dec 2018 01:05:48 GMT
+    Via: 1.1 5ab5dc09da67e3ea794ec8a82992cc89.cloudfront.net (CloudFront)
+    X-Amz-Cf-Id: Cdsow9--fnTH5EdjkjWBMWINCCMD4nGmi4S_3iMYMK0rpc8Mpiymgw==
+    X-Amzn-Trace-Id: Root=1-5c1d8dec-f1ef3ee83c7c654ca7fb3a70;Sampled=0
+    X-Cache: Miss from cloudfront
+    x-amz-apigw-id: SSMc6H_yvHcFcEw=
+    x-amzn-RequestId: b7bd0c87-0585-11e9-90cf-59b71c1a1de1
+
+    {
+        "hello": "world"
+    }
+
+    $ http https://rest-api.execute-api.us-west-2.amazonaws.com/api/foo
+    HTTP/1.1 200 OK
+    Connection: keep-alive
+    Content-Length: 13
+    Content-Type: application/json
+    Date: Sat, 22 Dec 2018 01:05:51 GMT
+    Via: 1.1 95b0ac620fa3a80ee590ecf1cda1c698.cloudfront.net (CloudFront)
+    X-Amz-Cf-Id: HX4l1BNdWvYDRXan17PFZya1vaomoJel4rP7d8_stdw2qT50v7Iybg==
+    X-Amzn-Trace-Id: Root=1-5c1d8def-214e7f681ff82c00fd81f37a;Sampled=0
+    X-Cache: Miss from cloudfront
+    x-amz-apigw-id: SSMdXF40vHcF-mg=
+    x-amzn-RequestId: b96f77bf-0585-11e9-b229-01305cd40040
+
+    {
+        "foo": "bar"
+    }
+
+
+Blueprint Registration
+----------------------
+
+The ``app.register_blueprint`` function accepts two optional arguments,
+``name_prefix`` and ``url_prefix``.  This allows you to register the resources
+in your blueprint at a certain url and name prefix.  If you specify
+``url_prefix`` any routes defined in your blueprint will have the
+``url_prefix`` prepended to it.  If you specify the ``name_prefix``, any Lambda
+functions created will have the ``name_prefix`` prepended to the resource name.
+
+
+Advanced Example
+----------------
+
+Let's create a more advanced example.  If this application, let's say we want
+to organize our application into separate modules for our API and our event
+sources.  We can create an app with these files::
+
+    $ ls -la chalicelib/
+    __init__.py
+    api.py
+    events.py
+
+
+The contents of ``api.py`` are:
+
+.. code-block:: python
+
+    from chalice import Blueprint
+
+
+    myapi = Blueprint(__name__)
+
+
+    @myapi.route('/')
+    def index():
+        return {'hello': 'world'}
+
+
+    @myapi.route('/foo')
+    def index():
+        return {'foo': 'bar'}
+
+
+The contents of ``events.py`` are:
+
+.. code-block:: python
+
+    from chalice import Blueprint
+
+
+    myevents = Blueprint(__name__)
+
+
+    @myevents.schedule('rate(5 minutes)')
+    def cron(event):
+        pass
+
+
+    @myevents.on_sns_message('MyTopic')
+    def handle_sns_message(event):
+        pass
+
+In our ``app.py`` we'll register these blueprints:
+
+.. code-block:: python
+
+    from chalice import Chalice
+    from chalicelib.events import myevents
+    from chalicelib.api import myapi
+
+    app = Chalice(app_name='blueprint-demo')
+    app.register_blueprint(myevents)
+    app.register_blueprint(myapi)
+
+
+Now our ``app.py`` only registers the necessary blueprints, and all our
+resources are defined in blueprints.

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,6 +3,7 @@ import base64
 import logging
 import json
 import gzip
+import inspect
 
 import pytest
 from pytest import fixture
@@ -1784,3 +1785,18 @@ def test_runtime_error_if_current_request_access_on_non_registered_blueprint():
     bp = app.Blueprint('app.chalicelib.blueprints.foo')
     with pytest.raises(RuntimeError):
         bp.current_request
+
+
+def test_every_decorator_added_to_blueprint():
+    def is_public_method(obj):
+        return inspect.isfunction(obj) and not obj.__name__.startswith('_')
+    public_api = inspect.getmembers(
+        app.DecoratorAPI,
+        predicate=is_public_method
+    )
+    blueprint_api = [
+        i[0] for i in
+        inspect.getmembers(app.Blueprint, predicate=is_public_method)
+    ]
+    for method_name, _ in public_api:
+        assert method_name in blueprint_api

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1766,6 +1766,20 @@ def test_can_call_current_request_on_blueprint_when_mounted(create_event):
     assert response['method'] == 'GET'
 
 
+def test_can_call_lambda_context_on_blueprint_when_mounted(create_event):
+    myapp = app.Chalice('myapp')
+    bp = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @bp.route('/context')
+    def context():
+        return bp.lambda_context
+
+    myapp.register_blueprint(bp)
+    event = create_event('/context', 'GET', {})
+    response = json_response_body(myapp(event, context={'context': 'foo'}))
+    assert response == {'context': 'foo'}
+
+
 def test_runtime_error_if_current_request_access_on_non_registered_blueprint():
     bp = app.Blueprint('app.chalicelib.blueprints.foo')
     with pytest.raises(RuntimeError):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -894,7 +894,6 @@ def test_can_handle_builtin_auth():
     assert isinstance(authorizer, app.BuiltinAuthConfig)
     assert authorizer.name == 'my_auth'
     assert authorizer.handler_string == 'app.my_auth'
-    assert my_auth.name == 'my_auth'
 
 
 def test_builtin_auth_can_transform_event():
@@ -1607,3 +1606,167 @@ def test_bytes_when_binary_type_is_application_json():
         return Response(body=payload, status_code=200, headers=custom_headers)
 
     return demo
+
+
+def test_can_register_blueprint_on_app():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('foo')
+
+    @foo.route('/foo')
+    def first():
+        pass
+
+    myapp.register_blueprint(foo)
+    assert sorted(list(myapp.routes.keys())) == ['/foo']
+
+
+def test_can_combine_multiple_blueprints_in_single_app():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('foo')
+    bar = app.Blueprint('bar')
+
+    @foo.route('/foo')
+    def myfoo():
+        pass
+
+    @bar.route('/bar')
+    def mybar():
+        pass
+
+    myapp.register_blueprint(foo)
+    myapp.register_blueprint(bar)
+
+    assert sorted(list(myapp.routes)) == ['/bar', '/foo']
+
+
+def test_can_mount_apis_at_url_prefix():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('foo')
+
+    @foo.route('/foo')
+    def myfoo():
+        pass
+
+    @foo.route('/bar')
+    def mybar():
+        pass
+
+    myapp.register_blueprint(foo, url_prefix='/myprefix')
+    assert list(sorted(myapp.routes)) == ['/myprefix/bar', '/myprefix/foo']
+
+
+def test_can_combine_lambda_functions_and_routes_in_blueprints():
+    myapp = app.Chalice('myapp')
+
+    foo = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @foo.route('/foo')
+    def myfoo():
+        pass
+
+    @foo.lambda_function()
+    def myfunction(event, context):
+        pass
+
+    myapp.register_blueprint(foo)
+    assert len(myapp.pure_lambda_functions) == 1
+    lambda_function = myapp.pure_lambda_functions[0]
+    assert lambda_function.name == 'myfunction'
+    assert lambda_function.handler_string == (
+        'app.chalicelib.blueprints.foo.myfunction')
+
+    assert list(myapp.routes) == ['/foo']
+
+
+def test_can_mount_lambda_functions_with_name_prefix():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @foo.lambda_function()
+    def myfunction(event, context):
+        return event, context
+
+    myapp.register_blueprint(foo, name_prefix='myprefix_')
+    assert len(myapp.pure_lambda_functions) == 1
+    lambda_function = myapp.pure_lambda_functions[0]
+    assert lambda_function.name == 'myprefix_myfunction'
+    assert lambda_function.handler_string == (
+        'app.chalicelib.blueprints.foo.myfunction')
+
+    assert myfunction('foo', 'bar') == ('foo', 'bar')
+
+
+def test_can_mount_event_sources_with_blueprint():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @foo.schedule('rate(5 minutes)')
+    def myfunction(event):
+        return event
+
+    myapp.register_blueprint(foo, name_prefix='myprefix_')
+    assert len(myapp.event_sources) == 1
+    event_source = myapp.event_sources[0]
+    assert event_source.name == 'myprefix_myfunction'
+    assert event_source.schedule_expression == 'rate(5 minutes)'
+    assert event_source.handler_string == (
+        'app.chalicelib.blueprints.foo.myfunction')
+
+
+def test_can_mount_all_decorators_in_blueprint():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @foo.route('/foo')
+    def routefoo():
+        pass
+
+    @foo.lambda_function(name='mylambdafunction')
+    def mylambda(event, context):
+        pass
+
+    @foo.schedule('rate(5 minutes)')
+    def bar(event):
+        pass
+
+    @foo.on_s3_event('MyBucket')
+    def on_s3(event):
+        pass
+
+    @foo.on_sns_message('MyTopic')
+    def on_sns(event):
+        pass
+
+    @foo.on_sqs_message('MyQueue')
+    def on_sqs(event):
+        pass
+
+    myapp.register_blueprint(foo, name_prefix='myprefix_', url_prefix='/bar')
+    event_sources = myapp.event_sources
+    assert len(event_sources) == 4
+    lambda_functions = myapp.pure_lambda_functions
+    assert len(lambda_functions) == 1
+    # Handles the name prefix and the name='' override in the decorator.
+    assert lambda_functions[0].name == 'myprefix_mylambdafunction'
+    assert list(myapp.routes) == ['/bar/foo']
+
+
+def test_can_call_current_request_on_blueprint_when_mounted(create_event):
+    myapp = app.Chalice('myapp')
+    bp = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @bp.route('/todict')
+    def todict():
+        return bp.current_request.to_dict()
+
+    myapp.register_blueprint(bp)
+    event = create_event('/todict', 'GET', {})
+    response = json_response_body(myapp(event, context=None))
+    assert isinstance(response, dict)
+    assert response['method'] == 'GET'
+
+
+def test_runtime_error_if_current_request_access_on_non_registered_blueprint():
+    bp = app.Blueprint('app.chalicelib.blueprints.foo')
+    with pytest.raises(RuntimeError):
+        bp.current_request


### PR DESCRIPTION
This adds support for Flask style blueprints.
As part of this change, the internals app.py have been refactored
to remove duplication when registering resources.  This should make
it easier to refactor the event sources into separate classes
in the future.

This builds on the work from @ewdurbin https://github.com/aws/chalice/pull/651 (thanks!)

I still think this needs some discussion, and we'll need to figure out where it goes based on the outcome of https://github.com/aws/chalice/issues/1019