### PR TITLE
[ISSUE-1030]  Removed use of the mock patch linter.

### DIFF
--- a/tests/linter.py
+++ b/tests/linter.py
@@ -4,29 +4,7 @@ from astroid.exceptions import InferenceError
 
 
 def register(linter):
-    linter.register_checker(PatchChecker(linter))
     linter.register_checker(MocksUseSpecArg(linter))
-
-
-class PatchChecker(BaseChecker):
-    __implements__ = (IAstroidChecker,)
-    name = 'patching-banned'
-    msgs = {
-        'C9999': ('Use of mock.patch is not allowed',
-                  'patch-call',
-                  'Use of mock.patch not allowed')
-    }
-    patch_pytype = 'mock.mock._patch'
-
-    def visit_call(self, node):
-        try:
-            for inferred_type in node.infer():
-                if inferred_type.pytype() == self.patch_pytype:
-                    self.add_message('patch-call', node=node)
-        except InferenceError:
-            # It's ok if we can't work out what type the function
-            # call is.
-            pass
 
 
 class MocksUseSpecArg(BaseChecker):


### PR DESCRIPTION
mock patching lends itself to natural patterns like using
`with mock.path` to patch calls to `open`.  The alternative,
passing around mocked up osutils classes makes for a bad
production pattern since it requires an extra level of buffering.

*Issue #1030*

*Description of changes:*

Removed linter class that prevented use of `mock.patch`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
