### PR TITLE
Add python3.7 availability in the documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ First, create a virtual environment for chalice::
 
 Keep in mind that chalice is designed to work with AWS Lambda,
 so you should ensure your virtual environment is created with
-python 2.7 or 3.6, which are the versions of python currently supported by
+python2.7, python3.6, or python3.7, which are the versions of python currently supported by
 AWS Lambda.
 
 Next, you'll need to install chalice.  The easiest way to configure this


### PR DESCRIPTION
*Description of changes:*
Add python3.7 as an option for the virtual environment python version in the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
