### PR TITLE
now project_dir always will be stored as absolute path in the context.

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -90,7 +90,7 @@ def get_system_info():
                       message='%(prog)s %(version)s, {}'
                       .format(get_system_info()))
 @click.option('--project-dir',
-              help='The project directory.  Defaults to CWD')
+              help='The project directory path (absolute or relative). Defaults to CWD')
 @click.option('--debug/--no-debug',
               default=False,
               help='Print debug logs to stderr.')
@@ -99,6 +99,8 @@ def cli(ctx, project_dir, debug=False):
     # type: (click.Context, str, bool) -> None
     if project_dir is None:
         project_dir = os.getcwd()
+    elif not os.path.isabs(project_dir):
+        project_dir = os.path.abspath(project_dir)
     if debug is True:
         _configure_logging(logging.DEBUG)
     ctx.obj['project_dir'] = project_dir

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -90,7 +90,8 @@ def get_system_info():
                       message='%(prog)s %(version)s, {}'
                       .format(get_system_info()))
 @click.option('--project-dir',
-              help='The project directory path (absolute or relative). Defaults to CWD')
+              help='The project directory path (absolute or relative).'
+                   'Defaults to CWD')
 @click.option('--debug/--no-debug',
               default=False,
               help='Print debug logs to stderr.')

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -460,3 +460,28 @@ def test_invoke_does_raise_if_no_function_found(runner, mock_cli_factory):
                                   cli_factory=mock_cli_factory)
         assert result.exit_code == 2
         assert 'foo' in result.output
+
+
+@pytest.mark.parametrize(
+    "runner,path",
+    [
+        (runner(), 'empty'),
+        (runner(), 'relative'),
+        (runner(), 'absolute')
+    ],
+)
+def test_cli_with_absolute_path(runner, path):
+    with runner.isolated_filesystem():
+        if path == 'empty':
+            project_dir = None
+        elif path == 'relative':
+            project_dir = '.'
+        elif path == 'absolute':
+            project_dir = os.getcwd()
+        result = runner.invoke(
+            cli.cli,
+            ['--project-dir', project_dir, 'new-project', 'testproject'],
+            obj={})
+        assert result.exit_code == 0
+        assert os.listdir(os.getcwd()) == ['testproject']
+        assert_chalice_app_structure_created(dirname='testproject')


### PR DESCRIPTION
Requested here: #940 

*Description of changes:*
Now project_dir always will be stored as absolute path in the context. This will allow use absolute or relative paths in the --project-dir CLI parameter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
