### PR TITLE
Provide Lambda context in event object

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -992,7 +992,7 @@ class EventSourceHandler(object):
         self.event_class = event_class
 
     def __call__(self, event, context):
-        event_obj = self.event_class(event)
+        event_obj = self.event_class(event, context)
         return self.func(event_obj)
 
 
@@ -1001,8 +1001,9 @@ class EventSourceHandler(object):
 # part of Chalice's public API and must be backwards compatible.
 
 class BaseLambdaEvent(object):
-    def __init__(self, event_dict):
+    def __init__(self, event_dict, context):
         self._event_dict = event_dict
+        self.context = context
         self._extract_attributes(event_dict)
 
     def _extract_attributes(self, event_dict):
@@ -1047,7 +1048,7 @@ class SQSEvent(BaseLambdaEvent):
 
     def __iter__(self):
         for record in self._event_dict['Records']:
-            yield SQSRecord(record)
+            yield SQSRecord(record, self.context)
 
 
 class SQSRecord(BaseLambdaEvent):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -812,6 +812,12 @@ Scheduled Events
       For scheduled events, this will include the ARN of the CloudWatch
       rule that triggered this event.
 
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
    .. method:: to_dict()
 
       Return the original event dictionary provided
@@ -860,6 +866,12 @@ Scheduled Events
       access to the original URL encoded key name, you can
       access it through the ``to_dict()`` method.
 
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
    .. method:: to_dict()
 
       Return the original event dictionary provided
@@ -896,6 +908,12 @@ Scheduled Events
 
       The string value of the SNS message that was published.
 
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
    .. method:: to_dict()
 
       Return the original event dictionary provided
@@ -927,6 +945,12 @@ Scheduled Events
       the event.  Each element in the iterable is of type
       :class:`SQSRecord`.
 
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
    .. method:: to_dict()
 
       Return the original event dictionary provided
@@ -949,6 +973,11 @@ Scheduled Events
       The receipt handle associated with the message.  This is useful
       if you need to manually delete an SQS message to account for
       partial failures.
+
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda.
 
    .. method:: to_dict()
 


### PR DESCRIPTION
Fixes #856.

Adds a `context` attribute for the `event` argument of Cloudwatch, S3, SNS and SQS Lambda handlers, as suggested [in the issue discussion](https://github.com/aws/chalice/issues/856#issuecomment-395506102). That can be used for logging or other purposes:

```python
@app.on_sns_message(topic='my-demo-topic')
def handle_sns_message(event):
    app.log.debug("Received message with subject: %s, message: %s, request id: ",
                  event.subject, event.message, event.context.aws_request_id)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
