### PR TITLE
Add "python3.7" for the CodeBuild image candidates

### DIFF
--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -41,6 +41,7 @@ class CreatePipelineTemplate(object):
     _CODEBUILD_IMAGE = {
         'python2.7': 'python:2.7.12',
         'python3.6': 'python:3.6.5',
+        'python3.7': 'python:3.7.1',
     }
 
     _BASE_TEMPLATE = {

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -50,12 +50,6 @@ class TestPipelineGen(object):
         with pytest.raises(InvalidCodeBuildPythonVersion):
             self.generate_template('app', 'python2.6')
 
-    def test_python_37_throws_error(self):
-        # This test can be removed when there is a 3.7 codebuild image
-        # available.
-        with pytest.raises(InvalidCodeBuildPythonVersion):
-            self.generate_template('app', 'python3.7')
-
     def test_nonsense_py_version_throws_error(self):
         with pytest.raises(InvalidCodeBuildPythonVersion):
             self.generate_template('app', 'foobar')


### PR DESCRIPTION
(I've not left an issue for it.)

Although I tried to generate `pipeline.json` using `chalice generate-pipeline` command for **Python3.7** application, I faced following error.

```python
Traceback (most recent call last):
  File "/Users/studio3104/.pyenv/versions/3.7.1/envs/myapp/lib/python3.7/site-packages/chalice/pipeline.py", line 87, in _get_codebuild_image
    image_suffix = self._CODEBUILD_IMAGE[params.lambda_python_version]
KeyError: 'python3.7
```

However currently it should've been supported according to the document.
https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

JSON was successfully generated after I changed the corresponding part locally. And I also succeeded in generating the pipeline and setting up the build by the generated JSON.

Therefore I opened a PR.