### PR TITLE
Fix local package installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Fix packaging multiple local directories as dependencies
+  (`#1047 <https://github.com/aws/chalice/pull/1047>`__)
+
+
 1.6.2
 =====
 

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -743,8 +743,8 @@ class PipRunner(object):
                 raise NoSuchPackageError(str(package_name))
             raise PackageDownloadError(error)
         stdout = out.decode()
-        match = re.search(self._LINK_IS_DIR_PATTERN, stdout)
-        if match:
+        matches = re.finditer(self._LINK_IS_DIR_PATTERN, stdout)
+        for match in matches:
             wheel_package_path = str(match.group(1))
             # Looks odd we do not check on the error status of building the
             # wheel here. We can assume this is a valid package path since


### PR DESCRIPTION
When packaging the dependencies only the first local package would be
included in the final bundle. This change adds support for any number
of local directory links to be treated as buildable dependencies. Tests
were also added for the case of 1 or 2 local directory links specified
in the requirements.txt.

