### PR TITLE
Support subscribing to SNS ARNs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 
 * Fix packaging multiple local directories as dependencies
   (`#1047 <https://github.com/aws/chalice/pull/1047>`__)
+* Add support for passing SNS ARNs to ``on_sns_message``
+  (`#1048 <https://github.com/aws/chalice/pull/1048>`__)
 
 
 1.6.2

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -235,8 +235,7 @@ Chalice
               app.log.info("SNS subject: %s", event.subject)
               app.log.info("SNS message: %s", event.message)
 
-      :param topic: The name of the SNS topic you want to subscribe to.
-        This is the name of the topic, not the topic ARN.
+      :param topic: The name or ARN of the SNS topic you want to subscribe to.
 
       :param name: The name of the function to use.  This name is combined
         with the chalice app name as well as the stage name to create the

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -208,6 +208,10 @@ command::
     2018-06-28 17:49:30.513000 547e0f chalice-demo-sns - DEBUG - Received message with subject: TestSubject1, message: TestMessage1
     2018-06-28 17:49:40.391000 547e0f chalice-demo-sns - DEBUG - Received message with subject: TestSubject2, message: TestMessage2
 
+In this example we used the SNS topic name to register our handler, but you can
+also use the topic arn. This can be useful if your topic is in another region
+or account.
+
 
 .. _sqs-events:
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -410,6 +410,27 @@ class TestSAMTemplate(object):
             }
         }
 
+    def test_can_package_sns_arn_handler(self, sample_app):
+        arn = 'arn:aws:sns:space-leo-1:1234567890:foo'
+
+        @sample_app.on_sns_message(topic=arn)
+        def handler(event):
+            pass
+
+        config = Config.create(chalice_app=sample_app,
+                               project_dir='.',
+                               api_gateway_stage='api')
+        template = self.generate_template(config, 'dev')
+        sns_handler = template['Resources']['Handler']
+        assert sns_handler['Properties']['Events'] == {
+            'HandlerSnsSubscription': {
+                'Type': 'SNS',
+                'Properties': {
+                    'Topic': arn,
+                }
+            }
+        }
+
     def test_can_package_sqs_handler(self, sample_app):
         @sample_app.on_sqs_message(queue='foo', batch_size=5)
         def handler(event):


### PR DESCRIPTION
This updates `@app.on_sns_message` to accept either the topic name or
the topic ARN rather than just the name. While accepting the name can
be a simpler experience, it prevents users from subscribing to topics
that are in other regions or other accounts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.