### PR TITLE
Ignore typing when python_version is 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as readme_file:
 install_requires = [
     'click>=6.6,<7.0',
     'botocore>=1.10.48,<2.0.0',
-    'typing==3.6.4',
+    'typing==3.6.4;python_version<'3.7'',
     'six>=1.10.0,<2.0.0',
     'pip>=9,<=18.1',
     'attrs==17.4.0',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as readme_file:
 install_requires = [
     'click>=6.6,<7.0',
     'botocore>=1.10.48,<2.0.0',
-    'typing==3.6.4;python_version<'3.7'',
+    'typing==3.6.4;python_version<"3.7"',
     'six>=1.10.0,<2.0.0',
     'pip>=9,<=18.1',
     'attrs==17.4.0',


### PR DESCRIPTION
*Issue #1050*

*Description of changes:*

Ignore typing at install_requires when python_version is 3.7


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
