### PR TITLE
Bump mypy version to latest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,4 +25,4 @@ hypothesis==3.56.3
 # the top level requirements.
 pluggy<0.7
 
-mypy==0.590; python_version >= '3.6'
+mypy==0.660; python_version >= '3.6'


### PR DESCRIPTION
There's also some interesting stuff in typing_extensions
and mypy-mypyc but I think we should hold on that stuff
until we need it.

0.630 - http://mypy-lang.blogspot.com/2018/09/mypy-0630-released.html
0.641 - http://mypy-lang.blogspot.com/2018/10/mypy-0640-released.html
0.650 - http://mypy-lang.blogspot.com/2018/12/mypy-0650-released.html
0.660 - https://mypy-lang.blogspot.com/2019/01/mypy-0660-released.html
