### PR TITLE
Add files-blacklist config

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -298,6 +298,13 @@ class Config(object):
                                   varies_per_chalice_stage=True,
                                   varies_per_function=True)
 
+    @property
+    def files_blacklist(self):
+        # type: () -> List[str]
+        return self._chain_lookup('files_blacklist',
+                                  varies_per_chalice_stage=True,
+                                  varies_per_function=True)
+
     def scope(self, chalice_stage, function_name):
         # type: (str, str) -> Config
         # Used to create a new config object that's scoped to a different

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -745,7 +745,8 @@ class DeploymentPackager(BaseDeployStep):
         # type: (Config, models.DeploymentPackage) -> None
         if isinstance(resource.filename, models.Placeholder):
             zip_filename = self._packager.create_deployment_package(
-                config.project_dir, config.lambda_python_version
+                config.project_dir, config.lambda_python_version,
+                files_blacklist=config.files_blacklist
             )
             resource.filename = zip_filename
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tarfile
 import subprocess
+import fnmatch
 
 import click
 from typing import IO, Dict, List, Any, Tuple, Iterator, BinaryIO  # noqa
@@ -113,6 +114,19 @@ def create_zip_file(source_dir, outfile):
                 full_name = os.path.join(root, filename)
                 archive_name = os.path.relpath(full_name, source_dir)
                 z.write(full_name, archive_name)
+
+
+def is_file_blacklisted(filename, blacklist):
+    # type: (str, List[str]) -> bool
+    """Verify if the filename is in the blacklist.
+
+    This method is based on the Unix filename pattern matching
+
+    """
+    for pattern in blacklist:
+        if fnmatch.fnmatch(filename, pattern):
+            return True
+    return False
 
 
 class OSUtils(object):

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -130,6 +130,9 @@ be checked.
   concurrency allocations. For more information, see `AWS Documentation on
   managing concurrency`_.
 
+* ``files_blacklist`` - A list of filename patterns that will be excluded
+  from the packaged lambda. Supports Unix filename pattern matching, e.g
+  ``*.pyc``. By default, no files are excluded.
 
 
 .. _lambda-config:


### PR DESCRIPTION
*Issue* #1065

*Description of changes:*
This adds a configuration parameter to ignore files in the deployed package. The goal was mostly to be able to ignore `*.pyc` files since they don't give a lot more performances on cold start for the added size. Since this is optional, users can decide to add them or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
