### PR TITLE
docs: Update docs to fix typo

### DIFF
--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -210,7 +210,7 @@ If we add the appropriate authorization header, we'll see the call succeed::
 The low level API for API Gateway's custom authorizer feature requires
 that an IAM policy must be returned.  The :class:`AuthResponse` class we're
 using is a wrapper over building the IAM policy ourself.  If you want
-low level control and would prefer to contruct the IAM policy yourself
+low level control and would prefer to construct the IAM policy yourself
 you can return a dictionary of the IAM policy instead of an instance of
 :class:`AuthResponse`.  If you do that, the dictionary is returned
 without modification back to API Gateway.

--- a/docs/source/topics/blueprints.rst
+++ b/docs/source/topics/blueprints.rst
@@ -46,7 +46,7 @@ separate file.  First, let's create an application::
     $ touch chalicelib/__init__.py
     $ touch chalicelib/blueprints.py
 
-Next, we'll oen the ``chalicelib/blueprints.py`` file:
+Next, we'll open the ``chalicelib/blueprints.py`` file:
 
 .. code-block:: python
 

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -227,7 +227,7 @@ The message visibility timeout of your SQS queue must be greater than or
 equal to the lambda timeout.  The default message visibility timeout
 when you create an SQS queue is 30 seconds, and the default timeout
 for a Lambda function is 60 seconds, so you'll need to modify one of these
-values in order to succesfully connect an SQS queue to a Lambda function.
+values in order to successfully connect an SQS queue to a Lambda function.
 
 You can check the visibility timeout of your queue using the
 ``GetQueueAttributes`` API call.  Using the
@@ -294,7 +294,7 @@ function to the ``my-queue`` SQS queue.
             app.log.debug("Received message with contents: ", record.body)
 
 
-Whenver a message is sent to the SQS queue our function will be automatically
+Whenever a message is sent to the SQS queue our function will be automatically
 invoked.  The function argument is an :class:`SQSEvent` object, and each
 ``record`` in the example above is of type :class:`SQSRecord`.  Lambda takes
 care of automatically scaling your function as needed.  See `Understanding

--- a/docs/source/topics/routing.rst
+++ b/docs/source/topics/routing.rst
@@ -1,7 +1,7 @@
 Routing
 =======
 
-The :meth:`Chalice.route` method is used to contruct which routes
+The :meth:`Chalice.route` method is used to construct which routes
 you want to create for your API.  The concept is the same
 mechanism used by `Flask <http://flask.pocoo.org/>`__ and
 `bottle <http://bottlepy.org/docs/dev/index.html>`__.


### PR DESCRIPTION
I noticed "contruct" was used at the docs/source/topics/routing.rst and docs/source/topics/authorizers.rst instead of "construct".
I noticed "oen" was used at the docs/source/topics/blueprints.rst instead of "open".
I noticed "succesfully" was used at the docs/source/topics/events.rst instead of "successfully".
I noticed "Whenver" was used at the docs/source/topics/events.rst instead of "Whenever".

If that was intentional then ignore this change.
