### PR TITLE
Handle multiple content types

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -69,13 +69,8 @@ def _matches_content_type(content_type, valid_content_types):
     content_type_matches = False
     if '*/*' in content_type or '*/*' in valid_content_types:
         content_type_matches = True
-
-    elif ';' in content_type:
-        for section in content_type.split(';'):
-            for mime_type in section.split(','):
-                if mime_type.lower().strip() in valid_content_types:
-                    content_type_matches = True
-    elif content_type in valid_content_types:
+    elif set(valid_content_types)\
+            .intersection(re.split('[,;]', content_type.lower())):
         content_type_matches = True
 
     return content_type_matches

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -65,15 +65,10 @@ def error_response(message, error_code, http_status_code, headers=None):
 
 def _matches_content_type(content_type, valid_content_types):
     # If '*/*' is in the Accept header or the valid types,
-    # then all content_types match
-    content_type_matches = False
-    if '*/*' in content_type or '*/*' in valid_content_types:
-        content_type_matches = True
-    elif set(valid_content_types)\
-            .intersection(re.split('[,;]', content_type.lower())):
-        content_type_matches = True
-
-    return content_type_matches
+    # then all content_types match. Otherwise see of there are any common types
+    return ('*/*' in content_type or '*/*' in valid_content_types) or\
+        set(valid_content_types).intersection(re.split('[,;]',
+                                                       content_type.lower()))
 
 
 class ChaliceError(Exception):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -72,8 +72,8 @@ def _matches_content_type(content_type, valid_content_types):
 
     elif ';' in content_type:
         for section in content_type.split(';'):
-            for type in section.split(','):
-                if type.lower().strip() in valid_content_types:
+            for mime_type in section.split(','):
+                if mime_type.lower().strip() in valid_content_types:
                     content_type_matches = True
     elif content_type in valid_content_types:
         content_type_matches = True

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -64,9 +64,21 @@ def error_response(message, error_code, http_status_code, headers=None):
 
 
 def _matches_content_type(content_type, valid_content_types):
-    if ';' in content_type:
-        content_type = content_type.split(';', 1)[0].strip()
-    return content_type in valid_content_types
+    # If '*/*' is in the Accept header or the valid types,
+    # then all content_types match
+    content_type_matches = False
+    if '*/*' in content_type or '*/*' in valid_content_types:
+        content_type_matches = True
+
+    elif ';' in content_type:
+        for section in content_type.split(';'):
+            for type in section.split(','):
+                if type.lower().strip() in valid_content_types:
+                    content_type_matches = True
+    elif content_type in valid_content_types:
+        content_type_matches = True
+
+    return content_type_matches
 
 
 class ChaliceError(Exception):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -66,9 +66,10 @@ def error_response(message, error_code, http_status_code, headers=None):
 def _matches_content_type(content_type, valid_content_types):
     # If '*/*' is in the Accept header or the valid types,
     # then all content_types match. Otherwise see of there are any common types
-    return ('*/*' in content_type or '*/*' in valid_content_types) or\
-        set(valid_content_types).intersection(re.split('[,;]',
-                                                       content_type.lower()))
+    content_type = content_type.lower()
+    valid_content_types = [x.lower() for x in valid_content_types]
+    return '*/*' in content_type or '*/*' in valid_content_types or\
+        set(valid_content_types).intersection(re.split('[,;]', content_type))
 
 
 class ChaliceError(Exception):

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -369,6 +369,17 @@ def test_can_round_trip_binary_custom_content_type(smoke_test_app):
     assert response.content == bin_data
 
 
+def test_can_return_default_binary_data_to_a_browser(smoke_test_app):
+    base64encoded_response = b'3q2+7w=='
+    accept = 'text/html,application/xhtml+xml;q=0.9,image/webp,*/*;q=0.8'
+    response = requests.get(smoke_test_app.url + '/get-binary',
+                            headers={
+                                'Accept': accept,
+                             })
+    response.raise_for_status()
+    assert response.content == base64encoded_response
+
+
 def _assert_contains_access_control_allow_methods(headers, methods):
     actual_methods = headers['Access-Control-Allow-Methods'].split(',')
     assert sorted(methods) == sorted(actual_methods), (

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -171,6 +171,16 @@ def custom_binary_round_trip():
         status_code=200)
 
 
+@app.route('/get-binary', methods=['GET'])
+def binary_response():
+    return Response(
+        body=b'\xDE\xAD\xBE\xEF',
+        headers={
+            'Content-Type': 'application/octet-stream'
+        },
+        status_code=200)
+
+
 @app.route('/shared', methods=['GET'])
 def shared_get():
     return {'method': 'GET'}

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -599,6 +599,26 @@ def test_can_base64_encode_binary_media_types_bytes(create_event):
     assert response['headers']['Content-Type'] == 'application/octet-stream'
 
 
+def test_can_base64_encode_binary_multiple_media_types(create_event):
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/index')
+    def index_view():
+        return app.Response(
+            status_code=200,
+            body=b'\u2713',
+            headers={'Content-Type': 'application/octet-stream'})
+
+    event = create_event('/index', 'GET', {})
+    event['headers']['Accept'] = 'text/html,application/xhtml+xml,'\
+                                 'application/xml;q=0.9,image/webp,*/*;q=0.8'
+    response = demo(event, context=None)
+    assert response['statusCode'] == 200
+    assert response['isBase64Encoded'] is True
+    assert response['body'] == 'XHUyNzEz'
+    assert response['headers']['Content-Type'] == 'application/octet-stream'
+
+
 def test_can_return_text_even_with_binary_content_type_configured(
         create_event):
     demo = app.Chalice('demo-app')


### PR DESCRIPTION
This is related to issue #391. 

I've been developing a Chalice app that generates a binary image and returns the image. The app was failing because Chalice was checking if the Response header was binary (in this case image/png), but the Accept header was from a browser so had multiple media types.

However, the Response object only checks the first media type in the request Accept header and ignores all others. This means that a browser-based request fail with binary data as browser is rarely going to have the exact media type first in the list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.