### PR TITLE
be able to create chalice project on existing directory

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -52,6 +52,9 @@ def _configure_logging(level, format_string=None):
 def create_new_project_skeleton(project_name, profile=None):
     # type: (str, Optional[str]) -> None
     chalice_dir = os.path.join(project_name, '.chalice')
+    if os.path.isdir(chalice_dir):
+        click.echo(".chalice directory already exists inside the project: %s" % project_name, err=True)
+        raise click.Abort()
     os.makedirs(chalice_dir)
     config = os.path.join(project_name, '.chalice', 'config.json')
     cfg = {
@@ -309,12 +312,14 @@ def gen_policy(ctx, filename):
 
 @cli.command('new-project')
 @click.argument('project_name', required=False)
+@click.option('--exist-dir', is_flag=True, default=False,
+              help="create a chalice project on an already existing project directory")
 @click.option('--profile', required=False)
-def new_project(project_name, profile):
+def new_project(project_name, profile, exist_dir):
     # type: (str, str) -> None
     if project_name is None:
         project_name = getting_started_prompt(click)
-    if os.path.isdir(project_name):
+    if os.path.isdir(project_name) and not exist_dir:
         click.echo("Directory already exists: %s" % project_name, err=True)
         raise click.Abort()
     create_new_project_skeleton(project_name, profile)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -91,6 +91,15 @@ def test_error_raised_if_dir_already_exists(runner):
         assert 'Directory already exists: testproject' in result.output
 
 
+def test_force_if_dir_already_exists(runner):
+    with runner.isolated_filesystem():
+        os.mkdir('testproject')
+        result = runner.invoke(cli.new_project, ['--exist-dir', 'testproject'], obj={})
+        assert result.exit_code == 0
+        assert os.listdir(os.getcwd()) == ['testproject']
+        assert_chalice_app_structure_created(dirname='testproject')
+
+
 def test_can_load_project_config_after_project_creation(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(cli.new_project, ['testproject'])


### PR DESCRIPTION
added a new option to chalice new-project cli, --exist-dir, when used it will create the chalice project structure even if the project directory already exist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
