### PR TITLE
Clarify dependency install in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -74,7 +74,8 @@ AWS Lambda.
 Next, you'll need to install chalice.  The easiest way to configure this
 is to  use::
 
-    $ pip install -e .
+    $ pip install -e ".[event-file-poller]"
+
 
 Run this command the root directory of the chalice repo.
 


### PR DESCRIPTION
*Issue #, if available:*
Closes #1067

*Description of changes:*
The Contributing guide currently directs the user to install Chalice without the optional `watchdog` dependency, which causes `make prcheck` to fail. This PR updates the documentation to instruct the user to install this "required" dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
