### PR TITLE
Change suggested venv dir in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,8 +63,8 @@ Development Environment Setup
 
 First, create a virtual environment for chalice::
 
-    $ virtualenv venv-chalice
-    $ source venv-chalice/bin/activate
+    $ virtualenv venv
+    $ source venv/bin/activate
 
 Keep in mind that chalice is designed to work with AWS Lambda,
 so you should ensure your virtual environment is created with


### PR DESCRIPTION
*Issue #, if available:*
No issue

*Description of changes:*
The Contributing guide currently suggests the user set up the virtual environment in `venv-chalice/`. This directory isn't in `.gitignore`, and thus Git shows it as unstaged. However, as `.gitignore` already has `venv`, the simplest solution is to simply change the instructions, which is what this commit does.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
