### PR TITLE
Update attrs dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'typing==3.6.4;python_version<"3.7"',
     'six>=1.10.0,<2.0.0',
     'pip>=9,<=19.2',
-    'attrs>=17.4.0',
+    'attrs>=17.4.0,<20.0.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',
     'wheel',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'typing==3.6.4;python_version<"3.7"',
     'six>=1.10.0,<2.0.0',
     'pip>=9,<=19.2',
-    'attrs==17.4.0',
+    'attrs>=17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',
     'wheel',


### PR DESCRIPTION
*Issue #, if available:*
No current issue
Past occurrence of the same problem: #813 

*Description of changes:*
This PR updates the attrs dependency requirement version from pinned at 17.4.0 to anything greater than 17.4.0. All tests and checks pass locally (and soon hopefully on CI), so it seems reasonably safe. However, if the maintainers feel this is too broad of version range, I'd be happy to change it to something more conservative.

For reference, the clashing package is Black, which currently requires 18.1.0 or greater, and the latest attrs release is 19.1.0.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
