### PR TITLE
Blueprint feature flag docs

### DIFF
--- a/docs/source/topics/blueprints.rst
+++ b/docs/source/topics/blueprints.rst
@@ -10,7 +10,7 @@ Blueprints
   .. code-block:: python
 
     app = Chalice('myapp')
-    app.experimental_feature_flags.extend([
+    app.experimental_feature_flags.update([
         'BLUEPRINTS'
     ])
 
@@ -73,6 +73,9 @@ imported when running in Lambda.  We'll now import this module in our
     from chalicelib.blueprints import extra_routes
 
     app = Chalice(app_name='blueprint-demo')
+    app.experimental_feature_flags.update([
+        'BLUEPRINTS'
+    ])
     app.register_blueprint(extra_routes)
 
 
@@ -206,6 +209,9 @@ In our ``app.py`` we'll register these blueprints:
     from chalicelib.api import myapi
 
     app = Chalice(app_name='blueprint-demo')
+    app.experimental_feature_flags.update([
+        'BLUEPRINTS'
+    ])
     app.register_blueprint(myevents)
     app.register_blueprint(myapi)
 


### PR DESCRIPTION
* Fix method call on `experimental_feature_flags` set
* Modify docs to cover setting feature flags

*Issue #, if available:*

*Description of changes:*

Doc updates for blueprints to reflect the design decision to use feature flags and and implement them as a set, follows in the spirit of https://github.com/aws/chalice/blob/master/docs/source/topics/experimental.rst


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
