### PR TITLE
Fixed handle_decimals to raise a TypeError if it can't encode the object

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -52,7 +52,7 @@ def handle_decimals(obj):
     # to support that as well.
     if isinstance(obj, decimal.Decimal):
         return float(obj)
-    return obj
+    raise TypeError('Object of type %s is not JSON serializable' % obj.__class__.__name__)
 
 
 def error_response(message, error_code, http_status_code, headers=None):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -52,7 +52,8 @@ def handle_decimals(obj):
     # to support that as well.
     if isinstance(obj, decimal.Decimal):
         return float(obj)
-    raise TypeError('Object of type %s is not JSON serializable' % obj.__class__.__name__)
+    raise TypeError('Object of type %s is not JSON serializable'
+                    % obj.__class__.__name__)
 
 
 def error_response(message, error_code, http_status_code, headers=None):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -152,6 +152,16 @@ def test_invalid_binary_response_body_throws_value_error(sample_app):
         response.to_dict(sample_app.api.binary_types)
 
 
+def test_invalid_JSON_response_body_throws_type_error(sample_app):
+    response = app.Response(
+        status_code=200,
+        body={'foo': object()},
+        headers={'Content-Type': 'application/json'}
+    )
+    with pytest.raises(TypeError):
+        response.to_dict()
+
+
 def test_can_encode_binary_body_as_base64(sample_app):
     response = app.Response(
         status_code=200,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
default Json Encoders should raise a TypeError if they can't properly encode an object.

At the moment when you try to encode an object that is not JSON serializable you get:
[ERROR] ValueError: Circular reference detected
Traceback (most recent call last):
  File "/var/task/chalice/app.py", line 820, in __call__
    response = response.to_dict(self.api.binary_types)
  File "/var/task/chalice/app.py", line 352, in to_dict
    default=handle_decimals)
  File "/var/lang/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/var/lang/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/lang/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)

Now you get:
[ERROR] TypeError: Object of type dict_values is not JSON serializable
Traceback (most recent call last):
  File "/var/task/chalice/app.py", line 820, in __call__
    response = response.to_dict(self.api.binary_types)
  File "/var/task/chalice/app.py", line 352, in to_dict
    default=handle_decimals)
  File "/var/lang/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/var/lang/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/lang/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/var/task/chalice/app.py", line 55, in handle_decimals
    raise TypeError('Object of type %s is not JSON serializable' % obj.__class__.__name__)

which conforms to what Python expects:

https://docs.python.org/2/library/json.html#json.JSONEncoder

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
