### PR TITLE
In order to get make prcheck to run on a new setup you need watchdog …

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -82,10 +82,11 @@ Next, you have a few options.  There are various requirements files
 depending on what you'd like to do.
 
 For example, if you'd like to work on chalice, either fixing bugs or
-adding new features, install ``requirements-dev.txt``::
+adding new features, install both ``requirements-docs.txt`` and ``requirements-dev.txt``::
 
 
     $ pip install -r requirements-dev.txt
+    $ pip install -r requirements-docs.txt
 
 
 If you'd like to just build the docs, install ``requirements-docs.txt``::

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ pylint==1.9.3 ; python_version <= '2.7'
 astroid==1.6.5 ; python_version <= '2.7'
 pytest-cov==2.5.1
 pydocstyle==2.0.0
+watchdog==0.9.0
 
 # Test requirements
 pytest==3.5.0


### PR DESCRIPTION
…and you must install the requirements-docs as well as the requirements-dev

*Issue #, if available:*

*Description of changes:*
Added watchdog to the requirements-dev file and updated the contributing file to let people know to install both requirements-dev and requirements-docs when fixing code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
