### PR TITLE
Fix installation with latest pip version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'botocore>=1.12.86,<2.0.0',
     'typing==3.6.4;python_version<"3.7"',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<=18.1',
+    'pip>=9',
     'attrs==17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',


### PR DESCRIPTION
### Unable to install chalice with latest pip version

Hi, I have tried installing chalice (in a virtual environment). Whenever, I use `pip install -r requirements.txt`, it breaks with following error:

![image](https://user-images.githubusercontent.com/11090613/55774005-c8b9b800-5aac-11e9-969a-35e3b3f24145.png)

I have updated the code so that it will be compatible with latest version of pip and now it works smoothly. Let me know if any other change is required.

Thanks

 