### PR TITLE
Add support for `chalice package --force` option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Next Release (TBD)
 * Raise TypeError when trying to serialize an unserializable
   type
   (`#1100 <https://github.com/aws/chalice/issues/1100>`__)
+* Add support for ``chalice package --force`` option to ignore use of
+  ``@app.on_s3_event`` and other unsupported situations.
 
 
 1.8.0

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -374,22 +374,26 @@ def generate_sdk(ctx, sdk_type, stage, outdir):
                     "this argument is specified, a single "
                     "zip file will be created instead."))
 @click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('--force', is_flag=True, default=False,
+              help=("Ignore unsupported situations "
+                    "(use of @on_s3_event) and package "
+                    "anyway."))
 @click.argument('out')
 @click.pass_context
-def package(ctx, single_file, stage, out):
-    # type: (click.Context, bool, str, str) -> None
+def package(ctx, single_file, stage, force, out):
+    # type: (click.Context, bool, str, bool, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
     config = factory.create_config_obj(stage)
     packager = factory.create_app_packager(config)
     if single_file:
         dirname = tempfile.mkdtemp()
         try:
-            packager.package_app(config, dirname, stage)
+            packager.package_app(config, dirname, stage, force)
             create_zip_file(source_dir=dirname, outfile=out)
         finally:
             shutil.rmtree(dirname)
     else:
-        packager.package_app(config, out, stage)
+        packager.package_app(config, out, stage, force)
 
 
 @cli.command('generate-pipeline')


### PR DESCRIPTION
When specified, ignores use of `@app.on_s3_event` and other unsupported situations.

My company conceptualizes Chalice as providing three benefits:

* AWS Lambda request handling framework
* Packaging of Lambda functions
* Deploying of Lambda functions and related infrastructure

We, however, have chosen to use only the first two benefits and pass on the third. Instead we use Terraform to manage all our infrastructure, including the Lambda function itself.

Therefore the incompatibility between the use of `@app.on_s3_event` and the use of the `chalice package` command does not concern us. Rather, the fact that it dies from a `NotImplementedError` exception is causing a hindrance for us.

Would you be willing to adopt such a `chalice package --force` option?  If so, I'm willing to bring this PR into an acceptable shape, including unit tests and any documentation that you deem necessary.