### PR TITLE
cloud watch events support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Next Release (TBD)
 * Add support for stage independent lambda configuration
   (`#1162 <https://github.com/aws/chalice/pull/1162>`__)
 
-* Add support for subscribing to cloud watch events
+* Add support for subscribing to CloudWatch Events
   (`#1126 <https://github.com/aws/chalice/pull/1126>`__)
 
 1.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,10 @@ Next Release (TBD)
 ==================
 
 * Add support for stage independent lambda configuration
-  (#1162 <https://github.com/aws/chalice/pull/1162>`__)
+  (`#1162 <https://github.com/aws/chalice/pull/1162>`__)
 
+* Add support for subscribing to cloud watch events
+  (`#1126 <https://github.com/aws/chalice/pull/1126>`__)
 
 1.10.0
 ======

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -589,6 +589,13 @@ class DecoratorAPI(object):
             registration_kwargs={'queue': queue, 'batch_size': batch_size}
         )
 
+    def on_cw_event(self, event_pattern, name=None):
+        return self._create_registration_function(
+            handler_type='on_cw_event',
+            name=name,
+            registration_kwargs={'event_pattern': event_pattern}
+        )
+
     def schedule(self, expression, name=None):
         return self._create_registration_function(
             handler_type='schedule',
@@ -653,6 +660,7 @@ class DecoratorAPI(object):
             'on_s3_event': S3Event,
             'on_sns_message': SNSEvent,
             'on_sqs_message': SQSEvent,
+            'on_cw_event': CloudWatchEvent,
             'schedule': CloudWatchEvent,
         }
         if handler_type in event_classes:
@@ -797,8 +805,16 @@ class _HandlerRegistration(object):
         )
         self.event_sources.append(sqs_config)
 
-    def _register_schedule(self, name, handler_string, kwargs, **unused):
+    def _register_on_cw_event(self, name, handler_string, kwargs, **unused):
         event_source = CloudWatchEventConfig(
+            name=name,
+            event_pattern=kwargs['event_pattern'],
+            handler_string=handler_string
+        )
+        self.event_sources.append(event_source)
+
+    def _register_schedule(self, name, handler_string, kwargs, **unused):
+        event_source = ScheduledEventConfig(
             name=name,
             schedule_expression=kwargs['expression'],
             handler_string=handler_string,
@@ -1257,10 +1273,16 @@ class BaseEventSourceConfig(object):
         self.handler_string = handler_string
 
 
-class CloudWatchEventConfig(BaseEventSourceConfig):
+class ScheduledEventConfig(BaseEventSourceConfig):
     def __init__(self, name, handler_string, schedule_expression):
-        super(CloudWatchEventConfig, self).__init__(name, handler_string)
+        super(ScheduledEventConfig, self).__init__(name, handler_string)
         self.schedule_expression = schedule_expression
+
+
+class CloudWatchEventConfig(BaseEventSourceConfig):
+    def __init__(self, name, handler_string, event_pattern):
+        super(CloudWatchEventConfig, self).__init__(name, handler_string)
+        self.event_pattern = event_pattern
 
 
 class ScheduleExpression(object):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -267,8 +267,12 @@ class SQSEventConfig(BaseEventSourceConfig):
     batch_size = ... # type: int
 
 
-class CloudWatchEventConfig(BaseEventSourceConfig):
+class ScheduledEventConfig(BaseEventSourceConfig):
     schedule_expression = ...  # type: Union[str, ScheduleExpression]
+
+
+class CloudWatchEventConfig(BaseEventSourceConfig):
+    event_pattern = ...  # type: Dict
 
 
 class Blueprint(DecoratorAPI):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -760,8 +760,7 @@ class TypedAWSClient(object):
         events.put_targets(Rule=rule_name,
                            Targets=[{'Id': '1', 'Arn': function_arn}])
 
-    def add_permission_for_cloud_watch_event(self, rule_arn,
-                                             function_arn):
+    def add_permission_for_cloudwatch_event(self, rule_arn, function_arn):
         # type: (str, str) -> None
         self._add_lambda_permission_if_needed(
             source_arn=rule_arn,

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -729,13 +729,21 @@ class TypedAWSClient(object):
             SourceArn=source_arn,
         )
 
-    def get_or_create_rule_arn(self, rule_name, schedule_expression):
-        # type: (str, str) -> str
+    def get_or_create_rule_arn(
+            self, rule_name, schedule_expression=None, event_pattern=None):
+        # type: (str, str, str) -> str
         events = self._client('events')
         # put_rule is idempotent so we can safely call it even if it already
         # exists.
-        rule_arn = events.put_rule(Name=rule_name,
-                                   ScheduleExpression=schedule_expression)
+        params = {'Name': rule_name}
+        if schedule_expression:
+            params['ScheduleExpression'] = schedule_expression
+        elif event_pattern:
+            params['EventPattern'] = event_pattern
+        else:
+            raise ValueError(
+                "schedule_expression or event_pattern required")
+        rule_arn = events.put_rule(**params)
         return rule_arn['RuleArn']
 
     def delete_rule(self, rule_name):
@@ -752,8 +760,8 @@ class TypedAWSClient(object):
         events.put_targets(Rule=rule_name,
                            Targets=[{'Id': '1', 'Arn': function_arn}])
 
-    def add_permission_for_scheduled_event(self, rule_arn,
-                                           function_arn):
+    def add_permission_for_cloud_watch_event(self, rule_arn,
+                                             function_arn):
         # type: (str, str) -> None
         self._add_lambda_permission_if_needed(
             source_arn=rule_arn,

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -188,7 +188,7 @@ class CloudWatchEventBase(FunctionEventSubscriber):
 
 @attrs
 class CloudWatchEvent(CloudWatchEventBase):
-    resource_type = 'cloud_watch_event'
+    resource_type = 'cloudwatch_event'
     event_pattern = attrib()    # type: str
 
 

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -182,16 +182,19 @@ class FunctionEventSubscriber(ManagedModel):
 
 
 @attrs
-class CloudWatchEvent(FunctionEventSubscriber):
-    resource_type = 'cw_event'
+class CloudWatchEventBase(FunctionEventSubscriber):
     rule_name = attrib()        # type: str
+
+
+@attrs
+class CloudWatchEvent(CloudWatchEventBase):
+    resource_type = 'cloud_watch_event'
     event_pattern = attrib()    # type: str
 
 
 @attrs
-class ScheduledEvent(FunctionEventSubscriber):
+class ScheduledEvent(CloudWatchEventBase):
     resource_type = 'scheduled_event'
-    rule_name = attrib()            # type: str
     schedule_expression = attrib()  # type: str
 
 

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -173,15 +173,26 @@ class LambdaFunction(ManagedModel):
 
 
 @attrs
-class ScheduledEvent(ManagedModel):
-    resource_type = 'scheduled_event'
-    rule_name = attrib()            # type: str
-    schedule_expression = attrib()  # type: str
-    lambda_function = attrib()      # type: LambdaFunction
+class FunctionEventSubscriber(ManagedModel):
+    lambda_function = attrib()  # type: LambdaFunction
 
     def dependencies(self):
         # type: () -> List[Model]
         return [self.lambda_function]
+
+
+@attrs
+class CloudWatchEvent(FunctionEventSubscriber):
+    resource_type = 'cw_event'
+    rule_name = attrib()        # type: str
+    event_pattern = attrib()    # type: str
+
+
+@attrs
+class ScheduledEvent(FunctionEventSubscriber):
+    resource_type = 'scheduled_event'
+    rule_name = attrib()            # type: str
+    schedule_expression = attrib()  # type: str
 
 
 @attrs
@@ -223,37 +234,22 @@ class WebsocketAPI(ManagedModel):
 
 
 @attrs
-class S3BucketNotification(ManagedModel):
+class S3BucketNotification(FunctionEventSubscriber):
     resource_type = 's3_event'
     bucket = attrib()           # type: str
     events = attrib()           # type: List[str]
     prefix = attrib()           # type: Optional[str]
     suffix = attrib()           # type: Optional[str]
-    lambda_function = attrib()  # type: LambdaFunction
-
-    def dependencies(self):
-        # type: () -> List[Model]
-        return [self.lambda_function]
 
 
 @attrs
-class SNSLambdaSubscription(ManagedModel):
+class SNSLambdaSubscription(FunctionEventSubscriber):
     resource_type = 'sns_event'
     topic = attrib()            # type: str
-    lambda_function = attrib()  # type: LambdaFunction
-
-    def dependencies(self):
-        # type: () -> List[Model]
-        return [self.lambda_function]
 
 
 @attrs
-class SQSEventSource(ManagedModel):
+class SQSEventSource(FunctionEventSubscriber):
     resource_type = 'sqs_event'
     queue = attrib()            # type: str
     batch_size = attrib()       # type: int
-    lambda_function = attrib()  # type: LambdaFunction
-
-    def dependencies(self):
-        # type: () -> List[Model]
-        return [self.lambda_function]

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -561,18 +561,25 @@ class PlanStage(object):
             ),
         ]
 
-    def _plan_cloudwatchevent(self, resource):
-        # type: (models.CloudWatchEvent) -> Sequence[InstructionMsg]
+    def _create_cloudwatchevent(self, resource):
+        # type: (models.CloudWatchEventBase) -> Sequence[InstructionMsg]
 
         function_arn = Variable(
             '%s_lambda_arn' % resource.lambda_function.resource_name
         )
 
+        params = {'rule_name': resource.rule_name}
+        if isinstance(resource, models.ScheduledEvent):
+            resource = cast(models.ScheduledEvent, resource)
+            params['schedule_expression'] = resource.schedule_expression
+        else:
+            resource = cast(models.CloudWatchEvent, resource)
+            params['event_pattern'] = resource.event_pattern
+
         plan = [
             models.APICall(
                 method_name='get_or_create_rule_arn',
-                params={'rule_name': resource.rule_name,
-                        'event_pattern': resource.event_pattern},
+                params=params,
                 output_var='rule-arn',
             ),
             models.APICall(
@@ -595,44 +602,14 @@ class PlanStage(object):
             )
         ]
         return plan
+
+    def _plan_cloudwatchevent(self, resource):
+        # type: (models.CloudWatchEvent) -> Sequence[InstructionMsg]
+        return self._create_cloudwatchevent(resource)
 
     def _plan_scheduledevent(self, resource):
         # type: (models.ScheduledEvent) -> Sequence[InstructionMsg]
-        function_arn = Variable(
-            '%s_lambda_arn' % resource.lambda_function.resource_name
-        )
-        # Because the underlying API calls have PUT semantics,
-        # we don't have to check if the resource exists and have
-        # a separate code path for updates.  We could however
-        # check if the resource exists to avoid unnecessary API
-        # calls, but that's a later optimization.
-        plan = [
-            models.APICall(
-                method_name='get_or_create_rule_arn',
-                params={'rule_name': resource.rule_name,
-                        'schedule_expression': resource.schedule_expression},
-                output_var='rule-arn',
-            ),
-            models.APICall(
-                method_name='connect_rule_to_lambda',
-                params={'rule_name': resource.rule_name,
-                        'function_arn': function_arn}
-            ),
-            models.APICall(
-                method_name='add_permission_for_cloud_watch_event',
-                params={'rule_arn': Variable('rule-arn'),
-                        'function_arn': function_arn},
-            ),
-            # You need to remove targets (which have IDs)
-            # before you can delete a rule.
-            models.RecordResourceValue(
-                resource_type='cloudwatch_event',
-                resource_name=resource.resource_name,
-                name='rule_name',
-                value=resource.rule_name,
-            )
-        ]
-        return plan
+        return self._create_cloudwatchevent(resource)
 
     def _create_websocket_function_configs(self, resource):
         # type: (models.WebsocketAPI) -> Dict[str, Dict[str, Any]]

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -588,7 +588,7 @@ class PlanStage(object):
                         'function_arn': function_arn}
             ),
             models.APICall(
-                method_name='add_permission_for_cloud_watch_event',
+                method_name='add_permission_for_cloudwatch_event',
                 params={'rule_arn': Variable('rule-arn'),
                         'function_arn': function_arn},
             ),

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -736,6 +736,17 @@ class TerraformGenerator(TemplateGenerator):
                 'source_arn': topic_arn
         }
 
+    def _generate_cloudwatchevent(self, resource, template):
+        # type: (models.CloudWatchEvent, Dict[str, Any]) -> None
+
+        template['resource'].setdefault(
+            'aws_cloudwatch_event_rule', {})[
+                resource.resource_name] = {
+                    'name': resource.resource_name,
+                    'event_pattern': resource.event_pattern
+        }
+        self._cwe_helper(resource, template)
+
     def _generate_scheduledevent(self, resource, template):
         # type: (models.ScheduledEvent, Dict[str, Any]) -> None
 
@@ -745,6 +756,10 @@ class TerraformGenerator(TemplateGenerator):
                     'name': resource.resource_name,
                     'schedule_expression': resource.schedule_expression
         }
+        self._cwe_helper(resource, template)
+
+    def _cwe_helper(self, resource, template):
+        # type: (models.CloudWatchEventBase, Dict[str, Any]) -> None
         template['resource'].setdefault(
             'aws_cloudwatch_event_target', {})[
                 resource.resource_name] = {

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1,7 +1,8 @@
 # pylint: disable=too-many-lines
+
+import copy
 import json
 import os
-import copy
 
 from typing import Any, Optional, Dict, List, Set, Union  # noqa
 from typing import cast
@@ -157,6 +158,24 @@ class SAMTemplateGenerator(TemplateGenerator):
                 'Type': 'Schedule',
                 'Properties': {
                     'Schedule': resource.schedule_expression,
+                }
+            }
+        }
+
+    def _generate_cloudwatchevent(self, resource, template):
+        # type: (models.CloudWatchEvent, Dict[str, Any]) -> None
+        function_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        function_cfn = template['Resources'][function_cfn_name]
+        event_cfn_name = self._register_cfn_resource_name(
+            resource.resource_name)
+        function_cfn['Properties']['Events'] = {
+            event_cfn_name: {
+                'Type': 'CloudWatchEvent',
+                'Properties': {
+                    # For api calls we need serialized string form, for
+                    # SAM Templates we need datastructures.
+                    'Pattern': json.loads(resource.event_pattern)
                 }
             }
         }

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -176,6 +176,20 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
+   .. method:: on_cw_event(pattern, name=None)
+
+      Create a lambda function and configure it to be invoked whenever
+      an event that matches the given pattern flows through Cloud Watch Events
+      or Event Bridge.
+
+      :param pattern: The event pattern to use to filter subscribed events.
+        See the Cloud Watch Events docs for examples https://amzn.to/2OlqZso
+
+      :param name: The name of the function to create.  This name is combined
+        with the chalice app name as well as the stage name to create the
+        entire lambda function name.  This parameter is optional.  If it is
+        not provided, the name of the python function will be used.
+
    .. method:: on_s3_event(bucket, events=None, prefix=None, suffix=None, name=None)
 
       Create a lambda function and configure it to be automatically invoked
@@ -869,7 +883,7 @@ Event Sources
 
 .. class:: CloudWatchEvent()
 
-   This is the input argument for a scheduled event.
+   This is the input argument for a scheduled or cloud watch events.
 
    .. code-block:: python
 
@@ -895,6 +909,7 @@ Event Sources
 
    .. attribute:: detail
 
+      For cloud watch events this will be the event payload.
       For scheduled events, this will be an empty dictionary.
 
    .. attribute:: detail_type

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -179,11 +179,11 @@ Chalice
    .. method:: on_cw_event(pattern, name=None)
 
       Create a lambda function and configure it to be invoked whenever
-      an event that matches the given pattern flows through Cloud Watch Events
+      an event that matches the given pattern flows through CloudWatch Events
       or Event Bridge.
 
       :param pattern: The event pattern to use to filter subscribed events.
-        See the Cloud Watch Events docs for examples https://amzn.to/2OlqZso
+        See the CloudWatch Events docs for examples https://amzn.to/2OlqZso
 
       :param name: The name of the function to create.  This name is combined
         with the chalice app name as well as the stage name to create the
@@ -883,7 +883,7 @@ Event Sources
 
 .. class:: CloudWatchEvent()
 
-   This is the input argument for a scheduled or cloud watch events.
+   This is the input argument for a scheduled or CloudWatch events.
 
    .. code-block:: python
 
@@ -909,7 +909,7 @@ Event Sources
 
    .. attribute:: detail
 
-      For cloud watch events this will be the event payload.
+      For CloudWatch events this will be the event payload.
       For scheduled events, this will be an empty dictionary.
 
    .. attribute:: detail_type

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -72,13 +72,13 @@ and ``every_two_hours`` to be invoked once every two hours.
 
 .. _cwe-events:
 
-Cloud Watch Events
+CloudWatch Events
 ==================
 
 You can configure a lambda function to subscribe to
-any `Cloud Watch Event <https://amzn.to/2SCgWA6>`.
+any `CloudWatch Event <https://amzn.to/2SCgWA6>`.
 
-To subscribe to a cloud watch event in chalice, you use the
+To subscribe to a CloudWatch Event in chalice, you use the
 ``@app.on_cw_event()`` decorator.  Let's look at an example.
 
 
@@ -94,7 +94,7 @@ In this example, we have a single lambda function that we subscribe to all
 events from the AWS Code Commit service. The first parameter to the decorator
 is the event pattern that will be used to filter the events sent to the function.
 
-See the Cloud Watch Event pattern docs for additional syntax and examples
+See the CloudWatch Event pattern docs for additional syntax and examples
 https://amzn.to/2OlqZso
 
 The function you decorate must accept a single argument,

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -94,6 +94,9 @@ In this example, we have a single lambda function that we subscribe to all
 events from the AWS Code Commit service. The first parameter to the decorator
 is the event pattern that will be used to filter the events sent to the function.
 
+See the Cloud Watch Event pattern docs for additional syntax and examples
+https://amzn.to/2OlqZso
+
 The function you decorate must accept a single argument,
 which will be of type :class:`CloudWatchEvent`.
 

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -70,6 +70,33 @@ and configure ``every_hour`` to be invoked once an hour,
 and ``every_two_hours`` to be invoked once every two hours.
 
 
+.. _cwe-events:
+
+Cloud Watch Events
+==================
+
+You can configure a lambda function to subscribe to
+any `Cloud Watch Event <https://amzn.to/2SCgWA6>`.
+
+To subscribe to a cloud watch event in chalice, you use the
+``@app.on_cw_event()`` decorator.  Let's look at an example.
+
+
+.. code-block:: python
+
+    app = chalice.Chalice(app_name='foo')
+
+    @app.on_cw_event({"source": ["aws.codecommit"]})
+    def on_code_commit_changes(event):
+        print(event.to_dict())
+
+In this example, we have a single lambda function that we subscribe to all
+events from the AWS Code Commit service. The first parameter to the decorator
+is the event pattern that will be used to filter the events sent to the function.
+
+The function you decorate must accept a single argument,
+which will be of type :class:`CloudWatchEvent`.
+
 .. _s3-events:
 
 S3 Events

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -1778,7 +1778,7 @@ def test_add_permission_for_scheduled_event(stubbed_session):
     stubbed_session.activate_stubs()
 
     awsclient = TypedAWSClient(stubbed_session)
-    awsclient.add_permission_for_cloud_watch_event(
+    awsclient.add_permission_for_cloudwatch_event(
         'rule-arn', 'function-arn')
 
     stubbed_session.verify_stubs()
@@ -1807,7 +1807,7 @@ def test_skip_if_permission_already_granted(stubbed_session):
 
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
-    awsclient.add_permission_for_cloud_watch_event(
+    awsclient.add_permission_for_cloudwatch_event(
         'rule-arn', 'function-arn')
     stubbed_session.verify_stubs()
 

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -131,6 +131,12 @@ def test_can_iterate_logs(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_rule_arn_requires_expression_or_pattern(stubbed_session):
+    client = TypedAWSClient(stubbed_session)
+    with pytest.raises(ValueError):
+        client.get_or_create_rule_arn("foo")
+
+
 class TestLambdaFunctionExists(object):
 
     def test_can_query_lambda_function_exists(self, stubbed_session):
@@ -1713,6 +1719,23 @@ def test_update_rest_api(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_can_get_or_create_rule_arn_with_pattern(stubbed_session):
+    events = stubbed_session.stub('events')
+    events.put_rule(
+        Name='rule-name',
+        EventPattern='{"source": ["aws.ec2"]}').returns({
+            'RuleArn': 'rule-arn',
+        })
+
+    stubbed_session.activate_stubs()
+    awsclient = TypedAWSClient(stubbed_session)
+    result = awsclient.get_or_create_rule_arn(
+        rule_name='rule-name',
+        event_pattern='{"source": ["aws.ec2"]}')
+    stubbed_session.verify_stubs()
+    assert result == 'rule-arn'
+
+
 def test_can_get_or_create_rule_arn(stubbed_session):
     events = stubbed_session.stub('events')
     events.put_rule(
@@ -1755,7 +1778,7 @@ def test_add_permission_for_scheduled_event(stubbed_session):
     stubbed_session.activate_stubs()
 
     awsclient = TypedAWSClient(stubbed_session)
-    awsclient.add_permission_for_scheduled_event(
+    awsclient.add_permission_for_cloud_watch_event(
         'rule-arn', 'function-arn')
 
     stubbed_session.verify_stubs()
@@ -1784,7 +1807,7 @@ def test_skip_if_permission_already_granted(stubbed_session):
 
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
-    awsclient.add_permission_for_scheduled_event(
+    awsclient.add_permission_for_cloud_watch_event(
         'rule-arn', 'function-arn')
     stubbed_session.verify_stubs()
 

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -277,8 +277,8 @@ def scheduled_event_app():
 
 
 @fixture
-def cloud_watch_event_app():
-    app = Chalice('cloud-watch-event')
+def cloudwatch_event_app():
+    app = Chalice('cloudwatch-event')
 
     @app.on_cw_event({'source': {'source': ['aws.ec2']}})
     def foo(event):
@@ -703,9 +703,9 @@ class TestApplicationGraphBuilder(object):
             policy=models.AutoGenIAMPolicy(models.Placeholder.BUILD_STAGE),
         )
 
-    def test_cloud_watch_event_models(self, cloud_watch_event_app):
-        config = self.create_config(cloud_watch_event_app,
-                                    app_name='cloud-watch-event',
+    def test_cloudwatch_event_models(self, cloudwatch_event_app):
+        config = self.create_config(cloudwatch_event_app,
+                                    app_name='cloudwatch-event',
                                     autogen_policy=True)
         builder = ApplicationGraphBuilder()
         application = builder.build(config, stage_name='dev')
@@ -713,7 +713,7 @@ class TestApplicationGraphBuilder(object):
         event = application.resources[0]
         assert isinstance(event, models.CloudWatchEvent)
         assert event.resource_name == 'foo-event'
-        assert event.rule_name == 'cloud-watch-event-dev-foo-event'
+        assert event.rule_name == 'cloudwatch-event-dev-foo-event'
         assert isinstance(event.lambda_function, models.LambdaFunction)
         assert event.lambda_function.resource_name == 'foo'
 

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -277,6 +277,17 @@ def scheduled_event_app():
 
 
 @fixture
+def cloud_watch_event_app():
+    app = Chalice('cloud-watch-event')
+
+    @app.on_cw_event({'source': {'source': ['aws.ec2']}})
+    def foo(event):
+        return event
+
+    return app
+
+
+@fixture
 def rest_api_app():
     app = Chalice('rest-api')
 
@@ -691,6 +702,20 @@ class TestApplicationGraphBuilder(object):
             trust_policy=LAMBDA_TRUST_POLICY,
             policy=models.AutoGenIAMPolicy(models.Placeholder.BUILD_STAGE),
         )
+
+    def test_cloud_watch_event_models(self, cloud_watch_event_app):
+        config = self.create_config(cloud_watch_event_app,
+                                    app_name='cloud-watch-event',
+                                    autogen_policy=True)
+        builder = ApplicationGraphBuilder()
+        application = builder.build(config, stage_name='dev')
+        assert len(application.resources) == 1
+        event = application.resources[0]
+        assert isinstance(event, models.CloudWatchEvent)
+        assert event.resource_name == 'foo-event'
+        assert event.rule_name == 'cloud-watch-event-dev-foo-event'
+        assert isinstance(event.lambda_function, models.LambdaFunction)
+        assert event.lambda_function.resource_name == 'foo'
 
     def test_scheduled_event_models(self, scheduled_event_app):
         config = self.create_config(scheduled_event_app,

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -443,6 +443,55 @@ class TestPlanS3Events(BasePlannerTests):
         )
 
 
+class TestPlanCloudWatchEvent(BasePlannerTests):
+
+    def test_can_plan_cloud_watch_event(self):
+        function = create_function_resource('function_name')
+        event = models.CloudWatchEvent(
+            resource_name='bar',
+            rule_name='myrulename',
+            event_pattern='"source": ["aws.ec2"]',
+            lambda_function=function,
+        )
+        plan = self.determine_plan(event)
+        assert len(plan) == 4
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='get_or_create_rule_arn',
+                params={
+                    'rule_name': 'myrulename',
+                    'event_pattern': '"source": ["aws.ec2"]'
+                },
+                output_var='rule-arn',
+            )
+        )
+        self.assert_apicall_equals(
+            plan[1],
+            models.APICall(
+                method_name='connect_rule_to_lambda',
+                params={'rule_name': 'myrulename',
+                        'function_arn': Variable('function_name_lambda_arn')}
+            )
+        )
+        self.assert_apicall_equals(
+            plan[2],
+            models.APICall(
+                method_name='add_permission_for_cloud_watch_event',
+                params={
+                    'rule_arn': Variable('rule-arn'),
+                    'function_arn': Variable('function_name_lambda_arn'),
+                },
+            )
+        )
+        assert plan[3] == models.RecordResourceValue(
+            resource_type='cloudwatch_event',
+            resource_name='bar',
+            name='rule_name',
+            value='myrulename',
+        )
+
+
 class TestPlanScheduledEvent(BasePlannerTests):
     def test_can_plan_scheduled_event(self):
         function = create_function_resource('function_name')
@@ -476,7 +525,7 @@ class TestPlanScheduledEvent(BasePlannerTests):
         self.assert_apicall_equals(
             plan[2],
             models.APICall(
-                method_name='add_permission_for_scheduled_event',
+                method_name='add_permission_for_cloud_watch_event',
                 params={
                     'rule_arn': Variable('rule-arn'),
                     'function_arn': Variable('function_name_lambda_arn'),

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -445,7 +445,7 @@ class TestPlanS3Events(BasePlannerTests):
 
 class TestPlanCloudWatchEvent(BasePlannerTests):
 
-    def test_can_plan_cloud_watch_event(self):
+    def test_can_plan_cloudwatch_event(self):
         function = create_function_resource('function_name')
         event = models.CloudWatchEvent(
             resource_name='bar',
@@ -477,7 +477,7 @@ class TestPlanCloudWatchEvent(BasePlannerTests):
         self.assert_apicall_equals(
             plan[2],
             models.APICall(
-                method_name='add_permission_for_cloud_watch_event',
+                method_name='add_permission_for_cloudwatch_event',
                 params={
                     'rule_arn': Variable('rule-arn'),
                     'function_arn': Variable('function_name_lambda_arn'),
@@ -525,7 +525,7 @@ class TestPlanScheduledEvent(BasePlannerTests):
         self.assert_apicall_equals(
             plan[2],
             models.APICall(
-                method_name='add_permission_for_cloud_watch_event',
+                method_name='add_permission_for_cloudwatch_event',
                 params={
                     'rule_arn': Variable('rule-arn'),
                     'function_arn': Variable('function_name_lambda_arn'),

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -729,6 +729,33 @@ class TestSAMTemplate(TemplateTestBase):
             },
         }
 
+    def test_can_generate_cloud_watch_event(self):
+        function = self.lambda_function()
+        event = models.CloudWatchEvent(
+            resource_name='foo-event',
+            rule_name='myrule',
+            event_pattern='{"source": ["aws.ec2"]}',
+            lambda_function=function,
+        )
+        template = self.template_gen.generate(
+            [function, event]
+        )
+        resources = template['Resources']
+        assert len(resources) == 1
+        cfn_resource = list(resources.values())[0]
+        assert cfn_resource['Properties']['Events'] == {
+            'FooEvent': {
+                'Type': 'CloudWatchEvent',
+                'Properties': {
+                    'Pattern': {
+                        'source': [
+                            'aws.ec2'
+                        ]
+                    }
+                },
+            },
+        }
+
     def test_can_generate_scheduled_event(self):
         function = self.lambda_function()
         event = models.ScheduledEvent(


### PR DESCRIPTION
Issue #1124

*Support subscribing functions to cloud watch events.*

with this pr the intent is that you can now subscribe to any of the dozen of event types that are sent through cloud watch events https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html

Example usage, in this case subscribing to ec2 instance state change notifications

```python
@sample_app.on_cw_event({'source': ['aws.ec2']})
def instance_change(event, context):
    print(event)
```
