### PR TITLE
terraform support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Next Release (TBD)
   (`#1160 https://github.com/aws/chalice/pull/1160`__)
 * Add --merge-template option to package command
   (`#1195 https://github.com/aws/chalice/pull/1195`__)
+* Add support for packaging via terraform
+  (`#1129 https://github.com/aws/chalice/pull/1129`__)
 
 
 1.9.1

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -368,6 +368,14 @@ def generate_sdk(ctx, sdk_type, stage, outdir):
 
 
 @cli.command('package')
+@click.option('--pkg-format', default='cloudformation',
+              help=('Specify the provisioning engine to use for '
+                    'template output. Chalice supports both '
+                    'CloudFormation and Terraform. Default '
+                    'is CloudFormation.'),
+              type=click.Choice(['cloudformation', 'terraform']))
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+              help="Chalice Stage to package.")
 @click.option('--single-file', is_flag=True,
               default=False,
               help=("Create a single packaged file. "
@@ -375,22 +383,26 @@ def generate_sdk(ctx, sdk_type, stage, outdir):
                     "specifies a directory in which the "
                     "package assets will be placed.  If "
                     "this argument is specified, a single "
-                    "zip file will be created instead."))
-@click.option('--stage', default=DEFAULT_STAGE_NAME)
+                    "zip file will be created instead. CloudFormation Only."))
 @click.option('--merge-template',
               help=('Specify a JSON template to be merged '
                     'into the generated template. This is useful '
                     'for adding resources to a Chalice template or '
-                    'modify values in the template.'))
+                    'modify values in the template. CloudFormation Only.'))
 @click.argument('out')
 @click.pass_context
-def package(ctx, single_file, stage, merge_template, out):
-    # type: (click.Context, bool, str, str, str) -> None
+def package(ctx, single_file, stage, merge_template,
+            out, pkg_format):
+    # type: (click.Context, bool, str, str, str, str) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
-    config = factory.create_config_obj(
-        chalice_stage_name=stage,
-    )
-    packager = factory.create_app_packager(config, merge_template)
+    config = factory.create_config_obj(stage)
+    packager = factory.create_app_packager(config, pkg_format, merge_template)
+    if pkg_format == 'terraform' and (merge_template or single_file):
+        click.echo((
+            "Terraform format does not support "
+            "merge-template or single-file options"))
+        raise click.Abort()
+
     if single_file:
         dirname = tempfile.mkdtemp()
         try:

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -179,9 +179,10 @@ class CLIFactory(object):
         except ValueError:
             raise UnknownConfigFileVersion(string_version)
 
-    def create_app_packager(self, config, merge_template=None):
-        # type: (Config, OptStr) -> AppPackager
-        return create_app_packager(config, merge_template=merge_template)
+    def create_app_packager(self, config, package_format, merge_template=None):
+        # type: (Config, str, OptStr) -> AppPackager
+        return create_app_packager(
+            config, package_format, merge_template=merge_template)
 
     def create_log_retriever(self, session, lambda_arn):
         # type: (Session, str) -> LogRetriever

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -286,3 +286,18 @@ class TemplatedSwaggerGenerator(SwaggerGenerator):
             '/functions/{%s}/invocations' % varname,
             ['region_name', varname],
         )
+
+
+class TerraformSwaggerGenerator(SwaggerGenerator):
+
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def _uri(self, lambda_arn=None):
+        # type: (Optional[str]) -> Any
+        return '${aws_lambda_function.api_handler.invoke_arn}'
+
+    def _auth_uri(self, authorizer):
+        # type: (ChaliceAuthorizer) -> Any
+        return '${aws_lambda_function.%s.invoke_arn}' % (authorizer.name)

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1,11 +1,13 @@
+# pylint: disable=too-many-lines
+import json
 import os
 import copy
-import json
 
 from typing import Any, Optional, Dict, List, Set, Union  # noqa
 from typing import cast
 
-from chalice.deploy.swagger import CFNSwaggerGenerator
+from chalice.deploy.swagger import (
+    CFNSwaggerGenerator, TerraformSwaggerGenerator)
 from chalice.utils import OSUtils, UI, serialize_to_json, to_cfn_resource_name
 from chalice.config import Config  # noqa
 from chalice.deploy import models
@@ -15,31 +17,41 @@ from chalice.deploy.deployer import BuildStage  # noqa
 from chalice.deploy.deployer import create_build_stage
 
 
-def create_app_packager(config, merge_template=None):
-    # type: (Config, Optional[str]) -> AppPackager
+def create_app_packager(
+        config, package_format='cloudformation', merge_template=None):
+    # type: (Config, str, Optional[str]) -> AppPackager
     osutils = OSUtils()
     ui = UI()
     application_builder = ApplicationGraphBuilder()
     deps_builder = DependencyBuilder()
-    build_stage = create_build_stage(
-        osutils, ui, CFNSwaggerGenerator()
-    )
-    resource_builder = ResourceBuilder(application_builder,
-                                       deps_builder, build_stage)
-    processors = [
-        ReplaceCodeLocationPostProcessor(osutils=osutils),
-        TemplateMergePostProcessor(
-            osutils=osutils,
-            merger=TemplateDeepMerger(),
-            merge_template=merge_template,
-        ),
-    ]
+    post_processors = []  # type: List[TemplatePostProcessor]
+    generator = None  # type: Union[None, TemplateGenerator]
+
+    if package_format == 'cloudformation':
+        build_stage = create_build_stage(
+            osutils, ui, CFNSwaggerGenerator())
+        post_processors.extend([
+            SAMCodeLocationPostProcessor(osutils=osutils),
+            TemplateMergePostProcessor(
+                osutils=osutils,
+                merger=TemplateDeepMerger(),
+                merge_template=merge_template)])
+        generator = SAMTemplateGenerator(config)
+    else:
+        build_stage = create_build_stage(
+            osutils, ui, TerraformSwaggerGenerator())
+        generator = TerraformGenerator(config)
+        post_processors.append(
+            TerraformCodeLocationPostProcessor(osutils=osutils))
+
+    resource_builder = ResourceBuilder(
+        application_builder, deps_builder, build_stage)
+
     return AppPackager(
-        SAMTemplateGenerator(),
+        generator,
         resource_builder,
-        CompositePostProcessor(processors),
-        osutils,
-    )
+        CompositePostProcessor(post_processors),
+        osutils)
 
 
 class UnsupportedFeatureError(Exception):
@@ -70,7 +82,47 @@ class ResourceBuilder(object):
         return resources
 
 
-class SAMTemplateGenerator(object):
+class TemplateGenerator(object):
+
+    template_file = None  # type: str
+
+    def __init__(self, config):
+        # type: (Config) -> None
+        self._config = config
+
+    def dispatch(self, resource, template):
+        # type: (models.Model, Dict[str, Any]) -> None
+        name = '_generate_%s' % resource.__class__.__name__.lower()
+        handler = getattr(self, name, self._default)
+        handler(resource, template)
+
+    def generate(self, resources):
+        # type: (List[models.Model]) -> Dict[str, Any]
+        raise NotImplementedError()
+
+    def _generate_filebasediampolicy(self, resource, template):
+        # type: (models.FileBasedIAMPolicy, Dict[str, Any]) -> None
+        pass
+
+    def _generate_autogeniampolicy(self, resource, template):
+        # type: (models.AutoGenIAMPolicy, Dict[str, Any]) -> None
+        pass
+
+    def _generate_deploymentpackage(self, resource, template):
+        # type: (models.DeploymentPackage, Dict[str, Any]) -> None
+        pass
+
+    def _generate_precreatediamrole(self, resource, template):
+        # type: (models.PreCreatedIAMRole, Dict[str, Any]) -> None
+        pass
+
+    def _default(self, resource, template):
+        # type: (models.Model, Dict[str, Any]) -> None
+        raise UnsupportedFeatureError(resource)
+
+
+class SAMTemplateGenerator(TemplateGenerator):
+
     _BASE_TEMPLATE = {
         'AWSTemplateFormatVersion': '2010-09-09',
         'Transform': 'AWS::Serverless-2016-10-31',
@@ -78,18 +130,19 @@ class SAMTemplateGenerator(object):
         'Resources': {},
     }
 
-    def __init__(self):
-        # type: () -> None
+    template_file = "sam.json"
+
+    def __init__(self, config):
+        # type: (Config) -> None
+        super(SAMTemplateGenerator, self).__init__(config)
         self._seen_names = set([])  # type: Set[str]
 
-    def generate_sam_template(self, resources):
+    def generate(self, resources):
         # type: (List[models.Model]) -> Dict[str, Any]
         template = copy.deepcopy(self._BASE_TEMPLATE)
         self._seen_names.clear()
         for resource in resources:
-            name = '_generate_%s' % resource.__class__.__name__.lower()
-            handler = getattr(self, name, self._default)
-            handler(resource, template)
+            self.dispatch(resource, template)
         return template
 
     def _generate_scheduledevent(self, resource, template):
@@ -295,7 +348,7 @@ class SAMTemplateGenerator(object):
                         ('arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}'
                          ':${WebsocketAPIId}/*'),
                         {'WebsocketAPIId': api_ref},
-                    ]
+                    ],
                 },
             }
         }
@@ -449,22 +502,6 @@ class SAMTemplateGenerator(object):
             }
         }
 
-    def _generate_filebasediampolicy(self, resource, template):
-        # type: (models.FileBasedIAMPolicy, Dict[str, Any]) -> None
-        pass
-
-    def _generate_autogeniampolicy(self, resource, template):
-        # type: (models.AutoGenIAMPolicy, Dict[str, Any]) -> None
-        pass
-
-    def _generate_deploymentpackage(self, resource, template):
-        # type: (models.DeploymentPackage, Dict[str, Any]) -> None
-        pass
-
-    def _generate_precreatediamrole(self, resource, template):
-        # type: (models.PreCreatedIAMRole, Dict[str, Any]) -> None
-        pass
-
     def _generate_s3bucketnotification(self, resource, template):
         # type: (models.S3BucketNotification, Dict[str, Any]) -> None
         message = (
@@ -523,10 +560,6 @@ class SAMTemplateGenerator(object):
             }
         }
 
-    def _default(self, resource, template):
-        # type: (models.Model, Dict[str, Any]) -> None
-        raise NotImplementedError(resource)
-
     def _register_cfn_resource_name(self, name):
         # type: (str) -> str
         cfn_name = to_cfn_resource_name(name)
@@ -539,15 +572,303 @@ class SAMTemplateGenerator(object):
         return cfn_name
 
 
+class TerraformGenerator(TemplateGenerator):
+
+    template_file = "chalice.tf.json"
+
+    def generate(self, resources):
+        # type: (List[models.Model]) -> Dict[str, Any]
+        template = {
+            'resource': {},
+            'terraform': {
+                'required_version': '> 0.11.0, < 0.13.0'
+            },
+            'provider': {
+                'template': {'version': '~> 2'},
+                'aws': {'version': '~> 2'},
+                'null': {'version': '~> 2'},
+            },
+            'data': {
+                'aws_caller_identity': {'chalice': {}},
+                'aws_region': {'chalice': {}},
+                'null_data_provider': {
+                    'chalice': {
+                        'inputs': {
+                            'app': self._config.app_name,
+                            'stage': self._config.chalice_stage
+                        }
+                    }
+                }
+            }
+        }
+
+        for resource in resources:
+            self.dispatch(resource, template)
+        return template
+
+    def _fref(self, lambda_function, attr='arn'):
+        # type: (models.ManagedModel, str) -> str
+        return '${aws_lambda_function.%s.%s}' % (
+            lambda_function.resource_name, attr)
+
+    def _arnref(self, arn_template, **kw):
+        # type: (str, str) -> str
+        d = dict(
+            region='${data.aws_region.chalice.name}',
+            account_id='${data.aws_caller_identity.chalice.account_id}')
+        d.update(kw)
+        return arn_template % d
+
+    def _generate_managediamrole(self, resource, template):
+        # type: (models.ManagedIAMRole, Dict[str, Any]) -> None
+        template['resource'].setdefault('aws_iam_role', {})[
+            resource.resource_name] = {
+                'name': resource.role_name,
+                'assume_role_policy': json.dumps(resource.trust_policy)
+        }
+
+        template['resource'].setdefault('aws_iam_role_policy', {})[
+            resource.resource_name] = {
+                'name': resource.resource_name + 'Policy',
+                'policy': json.dumps(resource.policy.document),
+                'role': '${aws_iam_role.%s.id}' % resource.resource_name,
+        }
+
+    def _generate_websocketapi(self, resource, template):
+        # type: (models.WebsocketAPI, Dict[str, Any]) -> None
+
+        message = (
+            "Unable to package chalice apps that use experimental "
+            "Websocket decorators. Terraform AWS Provider "
+            "support for websocket is pending see "
+            "https://git.io/fj9X8 for details and progress. "
+            "You can deploy this app using `chalice deploy`."
+        )
+        raise NotImplementedError(message)
+
+    def _generate_s3bucketnotification(self, resource, template):
+        # type: (models.S3BucketNotification, Dict[str, Any]) -> None
+
+        bnotify = {
+            'events': resource.events,
+            'lambda_function_arn': self._fref(resource.lambda_function)
+        }
+
+        if resource.prefix:
+            bnotify['filter_prefix'] = resource.prefix
+        if resource.suffix:
+            bnotify['filter_suffix'] = resource.suffix
+
+        # we use the bucket name here because we need to aggregate
+        # all the notifications subscribers for a bucket.
+        # Due to cyclic references to buckets created in terraform
+        # we also try to detect and resolve.
+        if '{aws_s3_bucket.' in resource.bucket:
+            bucket_name = resource.bucket.split('.')[1]
+        else:
+            bucket_name = resource.bucket
+        template['resource'].setdefault(
+            'aws_s3_bucket_notification', {}).setdefault(
+                bucket_name + '_notify',
+                {'bucket': resource.bucket}).setdefault(
+                    'lambda_function', []).append(bnotify)
+
+        template['resource'].setdefault('aws_lambda_permission', {})[
+            resource.resource_name] = {
+                'statement_id': resource.resource_name,
+                'action': 'lambda:InvokeFunction',
+                'function_name': resource.lambda_function.function_name,
+                'principal': 's3.amazonaws.com',
+                'source_arn': 'arn:aws:s3:::%s' % resource.bucket
+        }
+
+    def _generate_sqseventsource(self, resource, template):
+        # type: (models.SQSEventSource, Dict[str, Any]) -> None
+        template['resource'].setdefault('aws_lambda_event_source_mapping', {})[
+            resource.resource_name] = {
+                'event_source_arn': self._arnref(
+                    "arn:aws:sqs:%(region)s:%(account_id)s:%(queue)s",
+                    queue=resource.queue),
+                'batch_size': resource.batch_size,
+                'function_name': resource.lambda_function.function_name,
+        }
+
+    def _generate_snslambdasubscription(self, resource, template):
+        # type: (models.SNSLambdaSubscription, Dict[str, Any]) -> None
+
+        if resource.topic.startswith('arn:aws'):
+            topic_arn = resource.topic
+        else:
+            topic_arn = self._arnref(
+                'arn:aws:sns:%(region)s:%(account_id)s:%(topic)s',
+                topic=resource.topic)
+
+        template['resource'].setdefault('aws_sns_topic_subscription', {})[
+            resource.resource_name] = {
+                'topic_arn': topic_arn,
+                'protocol': 'lambda',
+                'endpoint': self._fref(resource.lambda_function)
+        }
+        template['resource'].setdefault('aws_lambda_permission', {})[
+            resource.resource_name] = {
+                'function_name': resource.lambda_function.function_name,
+                'action': 'lambda:InvokeFunction',
+                'principal': 'sns.amazonaws.com',
+                'source_arn': topic_arn
+        }
+
+    def _generate_scheduledevent(self, resource, template):
+        # type: (models.ScheduledEvent, Dict[str, Any]) -> None
+
+        template['resource'].setdefault(
+            'aws_cloudwatch_event_rule', {})[
+                resource.resource_name] = {
+                    'name': resource.resource_name,
+                    'schedule_expression': resource.schedule_expression
+        }
+        template['resource'].setdefault(
+            'aws_cloudwatch_event_target', {})[
+                resource.resource_name] = {
+                    'rule': '${aws_cloudwatch_event_rule.%s.name}' % (
+                        resource.resource_name),
+                    'target_id': resource.resource_name,
+                    'arn': self._fref(resource.lambda_function)
+        }
+        template['resource'].setdefault(
+            'aws_lambda_permission', {})[
+                resource.resource_name] = {
+                    'function_name': resource.lambda_function.function_name,
+                    'action': 'lambda:InvokeFunction',
+                    'principal': 'events.amazonaws.com',
+                    'source_arn': "${aws_cloudwatch_event_rule.%s.arn}" % (
+                        resource.resource_name)
+        }
+
+    def _generate_lambdafunction(self, resource, template):
+        # type: (models.LambdaFunction, Dict[str, Any]) -> None
+
+        func_definition = {
+            'function_name': resource.function_name,
+            'runtime': resource.runtime,
+            'handler': resource.handler,
+            'memory_size': resource.memory_size,
+            'tags': resource.tags,
+            'timeout': resource.timeout,
+            'source_code_hash': '${filebase64sha256("%s")}' % (
+                resource.deployment_package.filename),
+            'filename': resource.deployment_package.filename}
+
+        if resource.security_group_ids and resource.subnet_ids:
+            func_definition['vpc_config'] = {
+                'subnet_ids': resource.subnet_ids,
+                'security_group_ids': resource.security_group_ids
+            }
+        if resource.reserved_concurrency is not None:
+            func_definition['reserved_concurrent_executions'] = (
+                resource.reserved_concurrency
+            )
+        if resource.environment_variables:
+            func_definition['environment'] = {
+                'variables': resource.environment_variables
+            }
+        if resource.layers:
+            func_definition['layers'] = list(resource.layers)
+
+        if isinstance(resource.role, models.ManagedIAMRole):
+            func_definition['role'] = '${aws_iam_role.%s.arn}' % (
+                resource.role.resource_name)
+        else:
+            # resource is a PreCreatedIAMRole.
+            role = cast(models.PreCreatedIAMRole, resource.role)
+            func_definition['role'] = role.role_arn
+
+        template['resource'].setdefault('aws_lambda_function', {})[
+            resource.resource_name] = func_definition
+
+    def _generate_restapi(self, resource, template):
+        # type: (models.RestAPI, Dict[str, Any]) -> None
+
+        # typechecker happiness
+        swagger_doc = cast(Dict, resource.swagger_doc)
+        template['data'].setdefault(
+            'template_file', {}).setdefault(
+                'chalice_api_swagger', {})['template'] = json.dumps(
+                    swagger_doc)
+
+        template['resource'].setdefault('aws_api_gateway_rest_api', {})[
+            resource.resource_name] = {
+                'body': '${data.template_file.chalice_api_swagger.rendered}',
+                # Terraform will diff explicitly configured attributes
+                # to the current state of the resource. Attributes configured
+                # via swagger on the REST api need to be duplicated here, else
+                # terraform will set them back to empty.
+                'name': swagger_doc['info']['title'],
+                'binary_media_types': swagger_doc[
+                    'x-amazon-apigateway-binary-media-types'],
+                'endpoint_configuration': {'types': [resource.endpoint_type]}
+        }
+
+        if 'x-amazon-apigateway-policy' in swagger_doc:
+            template['resource'][
+                'aws_api_gateway_rest_api'][
+                    resource.resource_name]['policy'] = swagger_doc[
+                        'x-amazon-apigateway-policy']
+        if resource.minimum_compression.isdigit():
+            template['resource'][
+                'aws_api_gateway_rest_api'][
+                    resource.resource_name][
+                        'minimum_compression_size'] = int(
+                            resource.minimum_compression)
+
+        template['resource'].setdefault('aws_api_gateway_deployment', {})[
+            resource.resource_name] = {
+                'stage_name': resource.api_gateway_stage,
+                # Ensure that the deployment gets redeployed if we update
+                # the swagger description for the api by using its checksum
+                # in the stage description.
+                'stage_description': (
+                    "${md5(data.template_file.chalice_api_swagger.rendered)}"),
+                'rest_api_id': '${aws_api_gateway_rest_api.%s.id}' % (
+                    resource.resource_name),
+        }
+
+        template['resource'].setdefault('aws_lambda_permission', {})[
+            resource.resource_name + '_invoke'] = {
+                'function_name': resource.lambda_function.function_name,
+                'action': 'lambda:InvokeFunction',
+                'principal': 'apigateway.amazonaws.com',
+                'source_arn':
+                    "${aws_api_gateway_rest_api.%s.execution_arn}/*" % (
+                        resource.resource_name)
+        }
+
+        template.setdefault('output', {})[
+            'EndpointURL'] = {
+                'value': '${aws_api_gateway_deployment.%s.invoke_url}' % (
+                    resource.resource_name)
+        }
+
+        for auth in resource.authorizers:
+            template['resource']['aws_lambda_permission'][
+                auth.resource_name + '_invoke'] = {
+                    'function_name': auth.function_name,
+                    'action': 'lambda:InvokeFunction',
+                    'principal': 'apigateway.amazonaws.com',
+                    'source_arn': (
+                        "${aws_api_gateway_rest_api.%s.execution_arn}" % (
+                            resource.resource_name) + "/*")
+            }
+
+
 class AppPackager(object):
     def __init__(self,
-                 sam_templater,     # type: SAMTemplateGenerator
+                 templater,         # type: TemplateGenerator
                  resource_builder,  # type: ResourceBuilder
                  post_processor,    # type: TemplatePostProcessor
                  osutils,           # type: OSUtils
                  ):
         # type: (...) -> None
-        self._sam_templater = sam_templater
+        self._templater = templater
         self._resource_builder = resource_builder
         self._template_post_processor = post_processor
         self._osutils = osutils
@@ -562,16 +883,14 @@ class AppPackager(object):
         resources = self._resource_builder.construct_resources(
             config, chalice_stage_name)
 
-        # SAM template
-        sam_template = self._sam_templater.generate_sam_template(
-            resources)
+        template = self._templater.generate(resources)
         if not self._osutils.directory_exists(outdir):
             self._osutils.makedirs(outdir)
         self._template_post_processor.process(
-            sam_template, config, outdir, chalice_stage_name)
+            template, config, outdir, chalice_stage_name)
         self._osutils.set_file_contents(
-            filename=os.path.join(outdir, 'sam.json'),
-            contents=self._to_json(sam_template),
+            filename=os.path.join(outdir, self._templater.template_file),
+            contents=self._to_json(template),
             binary=False
         )
 
@@ -583,10 +902,11 @@ class TemplatePostProcessor(object):
 
     def process(self, template, config, outdir, chalice_stage_name):
         # type: (Dict[str, Any], Config, str, str) -> None
-        raise NotImplementedError('process')
+        raise NotImplementedError()
 
 
-class ReplaceCodeLocationPostProcessor(TemplatePostProcessor):
+class SAMCodeLocationPostProcessor(TemplatePostProcessor):
+
     def process(self, template, config, outdir, chalice_stage_name):
         # type: (Dict[str, Any], Config, str, str) -> None
         self._fixup_deployment_package(template, outdir)
@@ -609,6 +929,21 @@ class ReplaceCodeLocationPostProcessor(TemplatePostProcessor):
                 self._osutils.copy(original_location, new_location)
                 copied = True
             resource['Properties']['CodeUri'] = './deployment.zip'
+
+
+class TerraformCodeLocationPostProcessor(TemplatePostProcessor):
+
+    def process(self, template, config, outdir, chalice_stage_name):
+        # type: (Dict[str, Any], Config, str, str) -> None
+
+        copied = False
+        for r in template['resource'].get('aws_lambda_function', {}).values():
+            if not copied:
+                asset_path = os.path.join(outdir, 'deployment.zip')
+                self._osutils.copy(r['filename'], asset_path)
+                copied = True
+            r['filename'] = "./deployment.zip"
+            r['source_code_hash'] = '${filebase64sha256("./deployment.zip")}'
 
 
 class TemplateMergePostProcessor(TemplatePostProcessor):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,7 @@ Topics
    topics/packaging
    topics/pyversion
    topics/cfn
+   topics/tf
    topics/authorizers
    topics/events
    topics/purelambda

--- a/docs/source/topics/tf.rst
+++ b/docs/source/topics/tf.rst
@@ -1,0 +1,128 @@
+Terraform Support
+=================
+
+When you run ``chalice deploy``, chalice will deploy your application using the
+`AWS SDK for Python <http://boto3.readthedocs.io/en/docs/>`__).  Chalice also
+provides functionality that allows you to manage deployments yourself using
+terraform.  This is provided via the ``chalice package --pkg-format terraform``
+command.
+
+When you run this command, chalice will generate the AWS Lambda
+deployment package that contains your application and a `Terraform
+<https://www.terraform.io>`__ configuration file. You can then use the
+terraform cli to deploy your chalice application.
+
+Considerations
+--------------
+
+Using the ``chalice package`` command is useful when you don't want to
+use ``chalice deploy`` to manage your deployments.  There's several reasons
+why you might want to do this:
+
+* You have pre-existing infrastructure and tooling set up to manage
+  Terraform deployments.
+* You want to integrate with other Terraform resources to manage all
+  your application resources, including resources outside of your
+  chalice app.
+* You'd like to integrate with `AWS CodePipeline
+  <https://aws.amazon.com/codepipeline/>`__ to automatically deploy
+  changes when you push to a git repo.
+
+Keep in mind that you can't switch between ``chalice deploy`` and
+``chalice package`` + Terraform for deploying your app.
+
+If you choose to use ``chalice package`` and Terraform to deploy
+your app, you won't be able to switch back to ``chalice deploy``.
+Running ``chalice deploy`` would create an entirely new set of AWS
+resources (API Gateway Rest API, AWS Lambda function, etc).
+
+Example
+-------
+
+In this example, we'll create a chalice app and deploy it using
+the AWS CLI.
+
+First install the necessary packages::
+
+    $ virtualenv /tmp/venv
+    $ . /tmp/venv/bin/activate
+    $ pip install chalice awscli
+    $ chalice new-project test-tf-deploy
+    $ cd test-tf-deploy
+
+At this point we've installed chalice and the AWS CLI and we have
+a basic app created locally.  Next we'll run the ``package`` command::
+
+    $ chalice package --pkg-format terraform /tmp/packaged-app/
+    Creating deployment package.
+    $ ls -la /tmp/packaged-app/
+    -rw-r--r--   1 j         wheel  3355270 May 25 14:20 deployment.zip
+    -rw-r--r--   1 j         wheel     3068 May 25 14:20 chalice.tf.json
+
+    $ unzip -l /tmp/packaged-app/deployment.zip  | tail -n 5
+        17292  05-25-17 14:19   chalice/app.py
+          283  05-25-17 14:19   chalice/__init__.py
+          796  05-25-17 14:20   app.py
+     --------                   -------
+      9826899                   723 files
+
+
+As you can see in the above example, the ``package --pkg-format``
+command created a directory that contained two files, a
+``deployment.zip`` file, which is the Lambda deployment package, and a
+``chalice.tf.json`` file, which is the Terraform template that can be
+deployed using Terraform.  Next we're going to use the Terraform CLI
+to deploy our app.
+
+Note terraform will deploy run against all terraform files in this
+directory, so we can add additional resources for our application by
+adding terraform additional files here. The Chalice terraform template
+includes two static data values (`app` and `stage` names) that we can
+optionally use when constructing these additional resources,
+ie. `${data.null_data_source.chalice.outputs.app}`
+
+First let's run Terraform init to install the AWS Terraform Provider::
+
+    $ cd /tmp/packaged-app
+    $ terraform init
+
+Now we can deploy our app using the ``terraform apply`` command::
+
+  $ terraform apply
+  data.aws_region.chalice: Refreshing state...
+  data.aws_caller_identity.chalice: Refreshing state...
+
+  An execution plan has been generated and is shown below.
+  Resource actions are indicated with the following symbols:
+  + create
+
+  ... (omit plan output)
+
+  Plan: 14 to add, 0 to change, 0 to destroy.
+
+  Do you want to perform these actions?
+    Terraform will perform the actions described above.
+    Only 'yes' will be accepted to approve.
+  Enter a value: yes
+
+  ... (omit apply output)
+
+  Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
+
+  Outputs:
+
+  EndpointURL = https://7bnxriulj5.execute-api.us-east-1.amazonaws.com/dev
+
+This will take a minute to complete, but once it's done, the endpoint url
+will be available as an output which we can then curl::
+
+    $ http "$(terraform output EndpointURL)"
+    HTTP/1.1 200 OK
+    Connection: keep-alive
+    Content-Length: 18
+    Content-Type: application/json
+    ...
+
+    {
+        "hello": "world"
+    }

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -152,6 +152,23 @@ def test_can_package_with_single_file(runner):
             assert sorted(f.namelist()) == ['deployment.zip', 'sam.json']
 
 
+def test_package_terraform_err_with_single_file_or_merge(runner):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        result = _run_cli_command(
+            runner, cli.package, ['--pkg-format', 'terraform',
+                                  '--single-file', 'module'])
+        assert result.exit_code == 1, result.output
+        assert "Terraform format does not support" in result.output
+
+        result = _run_cli_command(
+            runner, cli.package, ['--pkg-format', 'terraform',
+                                  '--merge-template', 'foo.json', 'module'])
+        assert result.exit_code == 1, result.output
+        assert "Terraform format does not support" in result.output
+
+
 def test_debug_flag_enables_logging(runner):
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')


### PR DESCRIPTION
Issue: closes #1121 

This adds in terraform support for chalice package. There's a few goals underlying.. one was to provide provisioning flexibility and extensibility instead of having to layer in multiple provisioning executions for an app (ie reference an s3 bucket, or use chalice lambda function for a step function, etc). Another was to enable chalice use more naturally in orgs that mandate/prefer terraform for infrastructure provisioning. 

I've done a few manual e2e tests on a sample app (api gw, 5 lambdas, scheduled func, managed role). The end result is actually a bit faster than chalice's direct api calls for deploy/destroy.

 https://gist.github.com/kapilt/1794c092cd2f17e0faadb3e00a44bc33

