### PR TITLE
Multi value query string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Next Release (TBD)
   (`#1100 <https://github.com/aws/chalice/issues/1100>`__)
 * Update ``policies.json`` file
   (`#1110 <https://github.com/aws/chalice/issues/1110>`__)
+* Support repeating values in the query string
+  (`#1131 <https://github.com/aws/chalice/issues/1131>`__)
 
 
 1.8.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -172,7 +172,7 @@ class MultiDict(Mapping):
     def getlist(self, k):
         return list(self._dict[k])
 
-    def __len__(self) -> int:
+    def __len__(self):
         return len(self._dict)
 
     def __iter__(self):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -52,6 +52,12 @@ def handle_extra_types(obj):
     # to support that as well.
     if isinstance(obj, decimal.Decimal):
         return float(obj)
+    # MultiDict is an object used to represent query parameters,
+    # which used to be a dict.
+    # This is added for backwards compatibility.
+    # It will keep only the last value for every key as it used to.
+    if isinstance(obj, MultiDict):
+        return dict(obj)
     raise TypeError('Object of type %s is not JSON serializable'
                     % obj.__class__.__name__)
 
@@ -144,6 +150,36 @@ ALL_ERRORS = [
     ConflictError,
     UnprocessableEntityError,
     TooManyRequestsError]
+
+
+class MultiDict(Mapping):
+    """A read only mapping of key to list of values.
+
+    Accessing it in the usual way will return the last value in the list.
+    Calling getlist will return a list of values with the same key.
+    """
+
+    def __init__(self, mapping):
+        self._dict = mapping or {}
+
+    def __getitem__(self, k):
+        lst = self._dict[k]
+        try:
+            return lst[-1]
+        except IndexError:
+            raise KeyError(k)
+
+    def getlist(self, k):
+        return list(self._dict[k])
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __repr__(self):
+        return 'MultiDict(%s)' % repr(self._dict)
 
 
 class CaseInsensitiveMapping(Mapping):
@@ -302,7 +338,8 @@ class Request(object):
 
     def __init__(self, query_params, headers, uri_params, method, body,
                  context, stage_vars, is_base64_encoded):
-        self.query_params = query_params
+        self.query_params = None if query_params is None \
+            else MultiDict(query_params)
         self.headers = CaseInsensitiveMapping(headers)
         self.uri_params = uri_params
         self.method = method
@@ -350,6 +387,8 @@ class Request(object):
         # We want the output of `to_dict()` to be
         # JSON serializable, so we need to remove the CaseInsensitive dict.
         copied['headers'] = dict(copied['headers'])
+        if copied['query_params'] is not None:
+            copied['query_params'] = dict(copied['query_params'])
         return copied
 
 
@@ -787,14 +826,16 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
         function_args = {name: event['pathParameters'][name]
                          for name in route_entry.view_args}
         self.lambda_context = context
-        self.current_request = Request(event['queryStringParameters'],
-                                       event['headers'],
-                                       event['pathParameters'],
-                                       event['requestContext']['httpMethod'],
-                                       event['body'],
-                                       event['requestContext'],
-                                       event['stageVariables'],
-                                       event.get('isBase64Encoded', False))
+        self.current_request = Request(
+            event['multiValueQueryStringParameters'],
+            event['headers'],
+            event['pathParameters'],
+            event['requestContext']['httpMethod'],
+            event['body'],
+            event['requestContext'],
+            event['stageVariables'],
+            event.get('isBase64Encoded', False)
+        )
         # We're getting the CORS headers before validation to be able to
         # output desired headers with
         cors_headers = None

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -52,8 +52,6 @@ def handle_extra_types(obj):
     # to support that as well.
     if isinstance(obj, decimal.Decimal):
         return float(obj)
-    # MultiDict is an object used to represent query parameters,
-    # which used to be a dict.
     # This is added for backwards compatibility.
     # It will keep only the last value for every key as it used to.
     if isinstance(obj, MultiDict):
@@ -160,12 +158,16 @@ class MultiDict(Mapping):
     """
 
     def __init__(self, mapping):
-        self._dict = mapping or {}
+        if mapping is None:
+            mapping = {}
+
+        self._dict = mapping
 
     def __getitem__(self, k):
-        lst = self._dict[k]
+        values_list = self._dict[k]
+
         try:
-            return lst[-1]
+            return values_list[-1]
         except IndexError:
             raise KeyError(k)
 
@@ -177,9 +179,6 @@ class MultiDict(Mapping):
 
     def __iter__(self):
         return iter(self._dict)
-
-    def __repr__(self):
-        return 'MultiDict(%s)' % repr(self._dict)
 
 
 class CaseInsensitiveMapping(Mapping):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -170,7 +170,7 @@ class MultiDict(Mapping):
             raise KeyError(k)
 
     def getlist(self, k):
-        return list(self._dict[k])
+        return list(self._dict.get(k, []))
 
     def __len__(self):
         return len(self._dict)

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -124,8 +124,7 @@ class RouteMatcher(object):
         """
         # Otherwise we need to check for param substitution
         parsed_url = urlparse(url)
-        parsed_qs = parse_qs(parsed_url.query, keep_blank_values=True)
-        query_params = {k: v[-1] for k, v in parsed_qs.items()}
+        query_params = parse_qs(parsed_url.query, keep_blank_values=True)
         path = parsed_url.path
         # API Gateway removes the trailing slash if the route is not the root
         # path. We do the same here so our route matching works the same way.
@@ -180,11 +179,11 @@ class LambdaEventConverter(object):
             'stageVariables': {},
         }
         if view_route.query_params:
-            event['queryStringParameters'] = view_route.query_params
+            event['multiValueQueryStringParameters'] = view_route.query_params
         else:
             # If no query parameters are provided, API gateway maps
             # this to None so we're doing this for parity.
-            event['queryStringParameters'] = None
+            event['multiValueQueryStringParameters'] = None
         if self._is_binary(headers) and body is not None:
             event['body'] = base64.b64encode(body).decode('ascii')
             event['isBase64Encoded'] = True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,7 +89,7 @@ def create_event():
                 'Content-Type': content_type,
             },
             'pathParameters': path,
-            'multiValueQueryStringParameters': {},
+            'multiValueQueryStringParameters': None,
             'body': "",
             'stageVariables': {},
         }
@@ -107,7 +107,7 @@ def create_empty_header_event():
             },
             'headers': None,
             'pathParameters': path,
-            'multiValueQueryStringParameters': {},
+            'multiValueQueryStringParameters': None,
             'body': "",
             'stageVariables': {},
         }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,7 +89,7 @@ def create_event():
                 'Content-Type': content_type,
             },
             'pathParameters': path,
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'body': "",
             'stageVariables': {},
         }
@@ -107,7 +107,7 @@ def create_empty_header_event():
             },
             'headers': None,
             'pathParameters': path,
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'body': "",
             'stageVariables': {},
         }

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -22,11 +22,15 @@ from chalice.deploy.validate import validate_feature_flags
 
 # These are used to generate sample data for hypothesis tests.
 STR_MAP = st.dictionaries(st.text(), st.text())
+STR_TO_LIST_MAP = st.dictionaries(
+    st.text(),
+    st.lists(elements=st.text(), min_size=1, max_size=5)
+)
 HTTP_METHOD = st.sampled_from(['GET', 'POST', 'PUT', 'PATCH',
                                'OPTIONS', 'HEAD', 'DELETE'])
 HTTP_BODY = st.none() | st.text()
 HTTP_REQUEST = st.fixed_dictionaries({
-    'query_params': STR_MAP,
+    'query_params': STR_TO_LIST_MAP,
     'headers': STR_MAP,
     'uri_params': STR_MAP,
     'method': HTTP_METHOD,

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -549,7 +549,7 @@ def test_can_create_lambda_event():
         },
         'headers': {'content-type': 'application/json'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': None,
+        'multiValueQueryStringParameters': None,
         'body': None,
         'stageVariables': {},
     }
@@ -574,7 +574,7 @@ def test_parse_query_string():
         },
         'headers': {'content-type': 'application/json'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': {'a': '1', 'b': '', 'c': '3'},
+        'multiValueQueryStringParameters': {'a': ['1'], 'b': [''], 'c': ['3']},
         'body': None,
         'stageVariables': {},
     }
@@ -600,7 +600,7 @@ def test_can_create_lambda_event_for_put_request():
         },
         'headers': {'content-type': 'application/json'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': None,
+        'multiValueQueryStringParameters': None,
         'body': '{"foo": "bar"}',
         'stageVariables': {},
     }
@@ -627,7 +627,7 @@ def test_can_create_lambda_event_for_post_with_formencoded_body():
         },
         'headers': {'content-type': 'application/x-www-form-urlencoded'},
         'pathParameters': {'capture': 'other'},
-        'queryStringParameters': None,
+        'multiValueQueryStringParameters': None,
         'body': form_body,
         'stageVariables': {},
     }


### PR DESCRIPTION
*Issue #, if available:*
Issue #1131 
*Description of changes:*
Parse 'multiValueQueryStringParameters' header instead of 'queryStringParameters' for query params.
Replaced query_params dict with a new Mapping: MultiDict
Behaviour should be identical for regular use (last key will be returned). For multiple values usage, getlist will return all of the values captured by api gateway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

edit: closes #1131 