### PR TITLE
Fix an error printing a stack trace from a failed chalice invoke.

### DIFF
--- a/chalice/invoke.py
+++ b/chalice/invoke.py
@@ -83,8 +83,8 @@ class LambdaResponseFormatter(object):
         error_type = loaded_error.get('errorType')
         stack_trace = loaded_error.get('stackTrace')
 
-        if stack_trace is not None:
-            self._format_stacktrace(formatted, stack_trace)
+        for line in stack_trace:
+            formatted.write(line)
 
         if error_type is not None:
             formatted.write('{}: {}\n'.format(error_type, error_message))


### PR DESCRIPTION
Running `chalice invoke` fails to print a stack trace when the Lambda invocation fails:

```
$ chalice invoke -n xxx < payload.json
Traceback (most recent call last):
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/cli/__init__.py", line 462, in main
    return cli(obj={})
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/cli/__init__.py", line 225, in invoke
    invoke_handler.invoke(payload)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/invoke.py", line 43, in invoke
    formatted_response = self._formatter.format_response(response)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/invoke.py", line 73, in format_response
    self._format_error(formatted, payload)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/invoke.py", line 86, in _format_error
    self._format_stacktrace(formatted, stack_trace)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/invoke.py", line 97, in _format_stacktrace
    self._format_frame(formatted, frame)
  File "/Users/jacob/Library/Caches/pypoetry/virtualenvs/camber-prototype-py3.7/lib/python3.7/site-packages/chalice/invoke.py", line 101, in _format_frame
    path, lineno, function, code = frame
ValueError: too many values to unpack (expected 4)
```

This is invoking a raw lambda (e.g. `@app.lambda_function`), my runtime is Python 3.7.

I think this is because because `chalice.invoke.LambdaResponseFormatter._format_error` expects `payload["stackTrace"]` to be a a list of `(path, lineno, function, code)` frame objects, but instead the return appears to be just a simple list of strings.

So this pull request changes this to print the stacktrace directly instead.

I haven't got a full setup to run tests, nor have I trimmed the now-vestigal `_format_stacktrace`. I want to validate the approach first; if this is the correct fix I'm happy to do the rest of the clean up, just lmk. 

--- 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
