### PR TITLE
Always log uncaught exceptions as level ERROR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Next Release (TBD)
   (`#1130 <https://github.com/aws/chalice/issues/1130>`__)
 * Fix bug with route ``name`` kwarg raising a ``TypeError``
   (`#1112 <https://github.com/aws/chalice/issues/1112>`__)
+* Change exceptions to always be logged at the ERROR level
+  (`#969 <https://github.com/aws/chalice/issues/969>`__)
 
 
 1.8.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -907,12 +907,12 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
                                 status_code=e.STATUS_CODE)
         except Exception:
             headers = {}
+            self.log.error("Caught exception for %s", view_function,
+                           exc_info=True)
             if self.debug:
                 # If the user has turned on debug mode,
-                # we'll let the original exception propogate so
+                # we'll let the original exception propagate so
                 # they get more information about what went wrong.
-                self.log.debug("Caught exception for %s", view_function,
-                               exc_info=True)
                 stack_trace = ''.join(traceback.format_exc())
                 body = stack_trace
                 headers['Content-Type'] = 'text/plain'


### PR DESCRIPTION
#969 

*Description of changes:"
Uncaught exception handling improvement

The fork which @dmulter changes were based on has moved ahead a little on its master branch which made PRs include those changes, so I cherry picked the change to allow it to (hopefully) be accepted upstream here. Logging details of an exception in production is very much something I would like to see on by default - not just for debug mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
