### PR TITLE
Add support for absolute --project-dir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Next Release (TBD)
   (`#1139 <https://github.com/aws/chalice/issues/1139>`__)
 * Add support for API Gateway compression
   (`#672 <https://github.com/aws/chalice/issues/672>`__)
+* Add support for both relative and absolute paths for
+  ``--package-dir``
+  (`#940 <https://github.com/aws/chalice/issues/940>`__)
 
 
 1.8.0

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -91,7 +91,8 @@ def get_system_info():
                       message='%(prog)s %(version)s, {}'
                       .format(get_system_info()))
 @click.option('--project-dir',
-              help='The project directory.  Defaults to CWD')
+              help='The project directory path (absolute or relative).'
+                   'Defaults to CWD')
 @click.option('--debug/--no-debug',
               default=False,
               help='Print debug logs to stderr.')
@@ -100,6 +101,8 @@ def cli(ctx, project_dir, debug=False):
     # type: (click.Context, str, bool) -> None
     if project_dir is None:
         project_dir = os.getcwd()
+    elif not os.path.isabs(project_dir):
+        project_dir = os.path.abspath(project_dir)
     if debug is True:
         _configure_logging(logging.DEBUG)
     ctx.obj['project_dir'] = project_dir

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -482,3 +482,24 @@ def test_error_message_displayed_when_missing_feature_opt_in(runner):
         result = _run_cli_command(runner, cli.package, ['out'])
         assert isinstance(result.exception, ExperimentalFeatureError)
         assert 'MYTESTFEATURE' in str(result.exception)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        None,
+        '.',
+        os.getcwd,
+    ],
+)
+def test_cli_with_absolute_path(runner, path):
+    with runner.isolated_filesystem():
+        if callable(path):
+            path = path()
+        result = runner.invoke(
+            cli.cli,
+            ['--project-dir', path, 'new-project', 'testproject'],
+            obj={})
+        assert result.exit_code == 0
+        assert os.listdir(os.getcwd()) == ['testproject']
+        assert_chalice_app_structure_created(dirname='testproject')


### PR DESCRIPTION
The --project-dir command line argument can now be a relative or
absolute path.

closes #1037 #940 