### PR TITLE
schedule: Add a description for cloudwatch event rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,11 @@ Next Release (TBD)
 
 * Add support for stage independent lambda configuration
   (`#1162 <https://github.com/aws/chalice/pull/1162>`__)
-
 * Add support for subscribing to CloudWatch Events
   (`#1126 <https://github.com/aws/chalice/pull/1126>`__)
+* Add a ``description`` argument to CloudWatch schedule events
+  (`#1155 <https://github.com/aws/chalice/pull/1155>`__)
+
 
 1.10.0
 ======

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -596,11 +596,12 @@ class DecoratorAPI(object):
             registration_kwargs={'event_pattern': event_pattern}
         )
 
-    def schedule(self, expression, name=None):
+    def schedule(self, expression, name=None, description=''):
         return self._create_registration_function(
             handler_type='schedule',
             name=name,
-            registration_kwargs={'expression': expression},
+            registration_kwargs={'expression': expression,
+                                 'description': description},
         )
 
     def route(self, path, **kwargs):
@@ -817,6 +818,7 @@ class _HandlerRegistration(object):
         event_source = ScheduledEventConfig(
             name=name,
             schedule_expression=kwargs['expression'],
+            description=kwargs["description"],
             handler_string=handler_string,
         )
         self.event_sources.append(event_source)
@@ -879,7 +881,6 @@ class _HandlerRegistration(object):
 
 
 class Chalice(_HandlerRegistration, DecoratorAPI):
-
     FORMAT_STRING = '%(name)s - %(levelname)s - %(message)s'
 
     def __init__(self, app_name, debug=False, configure_logs=True, env=None):
@@ -1274,9 +1275,10 @@ class BaseEventSourceConfig(object):
 
 
 class ScheduledEventConfig(BaseEventSourceConfig):
-    def __init__(self, name, handler_string, schedule_expression):
+    def __init__(self, name, handler_string, schedule_expression, description):
         super(ScheduledEventConfig, self).__init__(name, handler_string)
         self.schedule_expression = schedule_expression
+        self.description = description
 
 
 class CloudWatchEventConfig(BaseEventSourceConfig):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -153,7 +153,8 @@ class DecoratorAPI(object):
 
     def schedule(self,
                  expression: str,
-                 name: Optional[str]=None) -> Callable[..., Any]: ...
+                 name: Optional[str]=None,
+                 description: Optional[str]="") -> Callable[..., Any]: ...
 
     def route(self, path: str, **kwargs: Any) -> Callable[..., Any]: ...
 
@@ -269,6 +270,7 @@ class SQSEventConfig(BaseEventSourceConfig):
 
 class ScheduledEventConfig(BaseEventSourceConfig):
     schedule_expression = ...  # type: Union[str, ScheduleExpression]
+    description = ...  # type: str
 
 
 class CloudWatchEventConfig(BaseEventSourceConfig):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -730,8 +730,9 @@ class TypedAWSClient(object):
         )
 
     def get_or_create_rule_arn(
-            self, rule_name, schedule_expression=None, event_pattern=None):
-        # type: (str, str, str) -> str
+            self, rule_name, schedule_expression=None, event_pattern=None,
+            rule_description=None):
+        # type: (str, str, str, str) -> str
         events = self._client('events')
         # put_rule is idempotent so we can safely call it even if it already
         # exists.
@@ -743,6 +744,8 @@ class TypedAWSClient(object):
         else:
             raise ValueError(
                 "schedule_expression or event_pattern required")
+        if rule_description is not None:
+            params['Description'] = rule_description
         rule_arn = events.put_rule(**params)
         return rule_arn['RuleArn']
 

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -601,6 +601,7 @@ class ApplicationGraphBuilder(object):
         scheduled_event = models.ScheduledEvent(
             resource_name=resource_name,
             rule_name=rule_name,
+            rule_description=event_source.description,
             schedule_expression=expression,
             lambda_function=lambda_function,
         )

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -196,6 +196,7 @@ class CloudWatchEvent(CloudWatchEventBase):
 class ScheduledEvent(CloudWatchEventBase):
     resource_type = 'scheduled_event'
     schedule_expression = attrib()  # type: str
+    rule_description = attrib(default=None)     # type: str
 
 
 @attrs

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -572,6 +572,8 @@ class PlanStage(object):
         if isinstance(resource, models.ScheduledEvent):
             resource = cast(models.ScheduledEvent, resource)
             params['schedule_expression'] = resource.schedule_expression
+            if resource.rule_description is not None:
+                params['rule_description'] = resource.rule_description
         else:
             resource = cast(models.CloudWatchEvent, resource)
             params['event_pattern'] = resource.event_pattern

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -754,7 +754,8 @@ class TerraformGenerator(TemplateGenerator):
             'aws_cloudwatch_event_rule', {})[
                 resource.resource_name] = {
                     'name': resource.resource_name,
-                    'schedule_expression': resource.schedule_expression
+                    'schedule_expression': resource.schedule_expression,
+                    'description': resource.rule_description,
         }
         self._cwe_helper(resource, template)
 

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -1740,13 +1740,18 @@ def test_can_get_or_create_rule_arn(stubbed_session):
     events = stubbed_session.stub('events')
     events.put_rule(
         Name='rule-name',
+        Description='rule-description',
         ScheduleExpression='rate(1 hour)').returns({
             'RuleArn': 'rule-arn',
         })
 
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
-    result = awsclient.get_or_create_rule_arn('rule-name', 'rate(1 hour)')
+    result = awsclient.get_or_create_rule_arn(
+        'rule-name',
+        schedule_expression='rate(1 hour)',
+        rule_description='rule-description'
+    )
     stubbed_session.verify_stubs()
     assert result == 'rule-arn'
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -498,6 +498,7 @@ class TestPlanScheduledEvent(BasePlannerTests):
         event = models.ScheduledEvent(
             resource_name='bar',
             rule_name='myrulename',
+            rule_description="my rule description",
             schedule_expression='rate(5 minutes)',
             lambda_function=function,
         )
@@ -509,6 +510,7 @@ class TestPlanScheduledEvent(BasePlannerTests):
                 method_name='get_or_create_rule_arn',
                 params={
                     'rule_name': 'myrulename',
+                    'rule_description': 'my rule description',
                     'schedule_expression': 'rate(5 minutes)',
                 },
                 output_var='rule-arn',
@@ -537,6 +539,27 @@ class TestPlanScheduledEvent(BasePlannerTests):
             resource_name='bar',
             name='rule_name',
             value='myrulename',
+        )
+
+    def test_can_plan_scheduled_event_can_omit_description(self):
+        function = create_function_resource('function_name')
+        event = models.ScheduledEvent(
+            resource_name='bar',
+            rule_name='myrulename',
+            schedule_expression='rate(5 minutes)',
+            lambda_function=function,
+        )
+        plan = self.determine_plan(event)
+        self.assert_apicall_equals(
+            plan[0],
+            models.APICall(
+                method_name='get_or_create_rule_arn',
+                params={
+                    'rule_name': 'myrulename',
+                    'schedule_expression': 'rate(5 minutes)',
+                },
+                output_var='rule-arn',
+            )
         )
 
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -359,7 +359,7 @@ class TestTerraformTemplate(TemplateTestBase):
         assert target == {
             'target_id': 'foo-event',
             'rule': '${aws_cloudwatch_event_rule.foo-event.name}',
-            'arn': '${aws_lambda_function.foo.arn}'
+            'arn': '${aws_lambda_function.foo.arn}',
         }
 
     def test_can_generate_scheduled_event(self):
@@ -369,6 +369,7 @@ class TestTerraformTemplate(TemplateTestBase):
             rule_name='myrule',
             schedule_expression='rate(5 minutes)',
             lambda_function=function,
+            rule_description='description',
         )
         template = self.template_gen.generate(
             [function, event]
@@ -378,7 +379,9 @@ class TestTerraformTemplate(TemplateTestBase):
 
         assert rule == {
             'name': event.resource_name,
-            'schedule_expression': 'rate(5 minutes)'}
+            'schedule_expression': 'rate(5 minutes)',
+            'description': 'description',
+        }
 
     def test_can_generate_rest_api(self, sample_app_with_auth):
         config = Config.create(chalice_app=sample_app_with_auth,

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -785,6 +785,7 @@ class TestSAMTemplate(TemplateTestBase):
         event = models.ScheduledEvent(
             resource_name='foo-event',
             rule_name='myrule',
+            rule_description="my rule description",
             schedule_expression='rate(5 minutes)',
             lambda_function=function,
         )


### PR DESCRIPTION
*Description of changes:*
This PR adds support for CloudWatch Event description when creating a schedule:
```python
from chalice import Chalice, Rate

app = Chalice(app_name="helloworld")

# Automatically runs every 5 minutes
@app.schedule(Rate(5, unit=Rate.MINUTES), description="Hello world event")
def periodic_task(event):
    return {"hello": "world"}
```
By the default, the `description` is set to an empty string. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
