### PR TITLE
Fixed BadRequest spelling

### DIFF
--- a/docs/source/topics/views.rst
+++ b/docs/source/topics/views.rst
@@ -100,7 +100,7 @@ was instantiated.  For example:
     from chalice import Chalice
     from chalice import BadRequestError
 
-    app = Chalice(app_name="badrequset")
+    app = Chalice(app_name="badrequest")
 
     @app.route('/badrequest')
     def badrequest():


### PR DESCRIPTION
Although "Bad Request" being spelled wrong might have been a feature.