### PR TITLE
allow for stage-independent lambda function config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,19 +2,26 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Add support for stage independent lambda configuration
+  (#1162 <https://github.com/aws/chalice/pull/1162>`__)
+
+
 1.10.0
 ======
 
 * Add experimental support for websockets
   (`#1017 <https://github.com/aws/chalice/issues/1017>`__)
 * API Gateway Endpoint Type Configuration
-  (`#1160 https://github.com/aws/chalice/pull/1160`__)
+  (`#1160 <https://github.com/aws/chalice/pull/1160>`__)
 * API Gateway Resource Policy Configuration
-  (`#1160 https://github.com/aws/chalice/pull/1160`__)
+  (`#1160 <https://github.com/aws/chalice/pull/1160>`__)
 * Add --merge-template option to package command
-  (`#1195 https://github.com/aws/chalice/pull/1195`__)
+  (`#1195 <https://github.com/aws/chalice/pull/1195>`__)
 * Add support for packaging via terraform
-  (`#1129 https://github.com/aws/chalice/pull/1129`__)
+  (`#1129 <https://github.com/aws/chalice/pull/1129>`__)
 
 
 1.9.1

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -173,15 +173,22 @@ class Config(object):
                       varies_per_function=False):
         # type: (str, bool, bool) -> Any
         search_dicts = [self._user_provided_params]
-        if varies_per_function:
-            search_dicts.append(
-                self._config_from_disk.get('stages', {}).get(
-                    self.chalice_stage, {}).get('lambda_functions', {}).get(
-                        self.function_name, {}))
         if varies_per_chalice_stage:
             search_dicts.append(
                 self._config_from_disk.get('stages', {}).get(
                     self.chalice_stage, {}))
+        if varies_per_function:
+            # search order:
+            # config['stages']['lambda_functions']
+            # config['stages']
+            # config['lambda_functions']
+            search_dicts.insert(
+                0, self._config_from_disk.get('stages', {}).get(
+                    self.chalice_stage, {}).get('lambda_functions', {}).get(
+                        self.function_name, {}))
+            search_dicts.append(
+                self._config_from_disk.get('lambda_functions', {}).get(
+                    self.function_name, {}))
         search_dicts.extend([self._config_from_disk, self._default_params])
         for cfg_dict in search_dicts:
             if isinstance(cfg_dict, dict) and cfg_dict.get(name) is not None:

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -210,9 +210,13 @@ Lambda Specific Configuration
 
 In addition to a chalice stage, there are also some configuration values
 that can be specified per Lambda function.  A chalice app can have many
-stages, and a stage can have many Lambda functions.  To configure
-per lambda configuration, you add a ``lambda_functions`` key in your
-stage configuration::
+stages, and a stage can have many Lambda functions.
+
+You have the option to specify configuration for a lambda function across
+all your stages, or for a lambda function in a specific stage.
+
+To configure per lambda configuration for a specific stage, you add a
+``lambda_functions`` key in your stage configuration::
 
   {
     "version": "2.0",
@@ -227,6 +231,20 @@ stage configuration::
       }
     }
   }
+
+To specify per lambda configuration across all stages, you add
+a top level ``lambda_functions`` key::
+
+  {
+    "version": "2.0",
+    "app_name": "app",
+    "lambda_functions": {
+      "foo": {
+        "lamba_timeout": 120
+      }
+    }
+  }
+
 
 Each key in the ``lambda_functions`` dictionary is the name of a Lambda
 function in your app.  The value is a dictionary of configuration that

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -139,20 +139,58 @@ def test_can_chain_chalice_stage_values():
 def test_can_chain_function_values():
     disk_config = {
         'lambda_timeout': 10,
+        'lambda_functions': {
+            'api_handler': {
+                'lambda_timeout': 15,
+                }
+            },
         'stages': {
             'dev': {
                 'lambda_timeout': 20,
                 'lambda_functions': {
                     'api_handler': {
                         'lambda_timeout': 30,
+                        }
                     }
                 }
             }
         }
-    }
     c = Config(chalice_stage='dev',
                config_from_disk=disk_config)
     assert c.lambda_timeout == 30
+
+
+def test_can_set_stage_independent_function_values():
+    disk_config = {
+        'lambda_timeout': 10,
+        'lambda_functions': {
+            'api_handler': {
+                'lambda_timeout': 15,
+                }
+            }
+        }
+    c = Config(chalice_stage='dev',
+               config_from_disk=disk_config)
+    assert c.lambda_timeout == 15
+
+
+def test_stage_overrides_function_values():
+    disk_config = {
+        'lambda_timeout': 10,
+        'lambda_functions': {
+            'api_handler': {
+                'lambda_timeout': 15,
+                }
+            },
+        'stages': {
+            'dev': {
+                'lambda_timeout': 20,
+                }
+            }
+        }
+    c = Config(chalice_stage='dev',
+               config_from_disk=disk_config)
+    assert c.lambda_timeout == 20
 
 
 def test_can_create_scope_obj_with_new_function():


### PR DESCRIPTION
*Description of changes:*
Allow for stage-independent lambda function config
You can now specify lambda config under the top-level key `lambda_functions` as well as in specific stages

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
