### PR TITLE
Make MultiDict mutable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Make MultiDict mutable
+  (`#1158 <https://github.com/aws/chalice/issues/1158>`__)
+
+
 1.9.0
 =====
 


### PR DESCRIPTION
fixes #1158 

Make `MultiDict` mutable again. The initial pull request made it readonly which is not backwards compatible with the raw `dict` it used to be.
