### PR TITLE
Default wildcard (*/*) binary response validation

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -885,6 +885,13 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
             'content-type', 'application/json')
         response_is_binary = _matches_content_type(response_content_type,
                                                    self.api.binary_types)
+
+        # if wildcard is included as binary type
+        # but no request accept header exists
+        # default to the wildcard accept header
+        if "*/*" in self.api.binary_types and request_accept_header is None:
+            request_accept_header = "*/*"
+
         expects_binary_response = False
         if request_accept_header is not None:
             expects_binary_response = _matches_content_type(

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -889,8 +889,8 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
         # if wildcard is included as binary type
         # but no request accept header exists
         # default to the wildcard accept header
-        if "*/*" in self.api.binary_types and request_accept_header is None:
-            request_accept_header = "*/*"
+        if '*/*' in self.api.binary_types and request_accept_header is None:
+            request_accept_header = '*/*'
 
         expects_binary_response = False
         if request_accept_header is not None:


### PR DESCRIPTION
Description of changes:
Sets `request_accept_header` to `*/*` for binary validation 

This only occurs when...
1. `*/*` has been configured as an available binary type w/ `app.api.binary_types.append("*/*")`
2. And request accept header is not present

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.