### PR TITLE
Set minimumCompressionSize before API gateway stage is deployed

### DIFF
--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -760,17 +760,6 @@ class PlanStage(object):
         # the update and create case.
         shared_plan_epilogue = [
             models.APICall(
-                method_name='update_rest_api',
-                params={
-                    'rest_api_id': Variable('rest_api_id'),
-                    'patch_operations': [{
-                        'op': 'replace',
-                        'path': '/minimumCompressionSize',
-                        'value': resource.minimum_compression,
-                    }],
-                },
-            ),
-            models.APICall(
                 method_name='add_permission_for_apigateway',
                 params={'function_name': function_name,
                         'region_name': Variable('region_name'),
@@ -816,6 +805,17 @@ class PlanStage(object):
                     variable_name='rest_api_id',
                 ),
                 models.APICall(
+                    method_name='update_rest_api',
+                    params={
+                        'rest_api_id': Variable('rest_api_id'),
+                        'patch_operations': [{
+                            'op': 'replace',
+                            'path': '/minimumCompressionSize',
+                            'value': resource.minimum_compression,
+                        }],
+                    },
+                ),
+                models.APICall(
                     method_name='deploy_rest_api',
                     params={'rest_api_id': Variable('rest_api_id'),
                             'api_gateway_stage': resource.api_gateway_stage},
@@ -840,6 +840,17 @@ class PlanStage(object):
                         'swagger_document': resource.swagger_doc,
                     },
                 ), "Updating rest API\n"),
+                models.APICall(
+                    method_name='update_rest_api',
+                    params={
+                        'rest_api_id': Variable('rest_api_id'),
+                        'patch_operations': [{
+                            'op': 'replace',
+                            'path': '/minimumCompressionSize',
+                            'value': resource.minimum_compression,
+                        }],
+                    },
+                ),
                 models.APICall(
                     method_name='deploy_rest_api',
                     params={'rest_api_id': Variable('rest_api_id'),

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -534,9 +534,6 @@ class TestPlanRestAPI(BasePlannerTests):
                 name='rest_api_id',
                 variable_name='rest_api_id',
             ),
-            models.APICall(method_name='deploy_rest_api',
-                           params={'rest_api_id': Variable('rest_api_id'),
-                                   'api_gateway_stage': 'api'}),
             models.APICall(
                 method_name='update_rest_api',
                 params={
@@ -548,6 +545,9 @@ class TestPlanRestAPI(BasePlannerTests):
                     }],
                 },
             ),
+            models.APICall(method_name='deploy_rest_api',
+                           params={'rest_api_id': Variable('rest_api_id'),
+                                   'api_gateway_stage': 'api'}),
             models.APICall(
                 method_name='add_permission_for_apigateway',
                 params={
@@ -607,6 +607,17 @@ class TestPlanRestAPI(BasePlannerTests):
                 },
             ),
             models.APICall(
+                method_name='update_rest_api',
+                params={
+                    'rest_api_id': Variable('rest_api_id'),
+                    'patch_operations': [{
+                        'op': 'replace',
+                        'path': '/minimumCompressionSize',
+                        'value': '',
+                    }],
+                },
+            ),
+            models.APICall(
                 method_name='deploy_rest_api',
                 params={'rest_api_id': Variable('rest_api_id'),
                         'api_gateway_stage': 'api'},
@@ -617,17 +628,6 @@ class TestPlanRestAPI(BasePlannerTests):
                         'region_name': Variable('region_name'),
                         'account_id': Variable('account_id'),
                         'rest_api_id': Variable('rest_api_id')},
-            ),
-            models.APICall(
-                method_name='update_rest_api',
-                params={
-                    'rest_api_id': Variable('rest_api_id'),
-                    'patch_operations': [{
-                        'op': 'replace',
-                        'path': '/minimumCompressionSize',
-                        'value': '',
-                    }],
-                },
             ),
             models.APICall(
                 method_name='add_permission_for_apigateway',


### PR DESCRIPTION
*Description of changes:*
This makes setting `minimumCompressionSize` happen before API Gateway stage is deployed and fixes #1171.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
