### PR TITLE
Add support for packaging Chalice app with websockets

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,6 +78,25 @@ def sample_app_lambda_only():
 
 
 @fixture
+def sample_websocket_app():
+    app = Chalice('sample')
+
+    @app.on_ws_connect()
+    def foo():
+        pass
+
+    @app.on_ws_message()
+    def bar():
+        pass
+
+    @app.on_ws_disconnect()
+    def baz():
+        pass
+
+    return app
+
+
+@fixture
 def create_event():
     def create_event_inner(uri, method, path, content_type='application/json'):
         return {


### PR DESCRIPTION
Add websocket (API Gateway v2) support to `chalice package` command
through CloudFormation. Removes the test indicating that
CloudFormation does not support websocket APIs.
