### PR TITLE
Fix the version websockets were released in to 1.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Add experimental support for websockets
+  (`#1017 <https://github.com/aws/chalice/issues/1017>`__)
+
+
 1.9.1
 =====
 
@@ -38,8 +45,6 @@ CHANGELOG
 * Add support for both relative and absolute paths for
   ``--package-dir``
   (`#940 <https://github.com/aws/chalice/issues/940>`__)
-* Add support for websockets
-  (`#1017 <https://github.com/aws/chalice/issues/1017>`__)
 
 
 1.8.0

--- a/docs/source/topics/experimental.rst
+++ b/docs/source/topics/experimental.rst
@@ -86,7 +86,7 @@ The status of an experimental API can be:
       `#651 <https://github.com/aws/chalice/pull/651>`__
   * - :doc:`websockets`
     - ``WEBSOCKETS``
-    - 1.9.0
+    - 1.10.0
     - Trial
     - `#1041 <https://github.com/aws/chalice/pull/1041>`__,
       `#1017 <https://github.com/aws/chalice/issues/1017>`__


### PR DESCRIPTION
Forgot to update the docs when we shipped 1.9 without websockets.