### PR TITLE
ci - pin docutils else doc8 will fail

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ flake8==3.6.0
 tox==3.0.0
 wheel==0.26.0
 doc8==0.8.0
+docutils==0.14.0
 # The latest version of pylint only works on python3.
 pylint==2.2.2 ; python_version >= '3.6'
 astroid==2.1.0 ; python_version >= '3.6'


### PR DESCRIPTION

doc8 is not compatible with docutils 0.15 released today (july 21, 2019). This pins docutils to the previously working version (0.14).

