### PR TITLE
Remove Duplicate Log Entry

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1072,8 +1072,6 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
                 body = stack_trace
                 headers['Content-Type'] = 'text/plain'
             else:
-                self.log.error("Internal Error for %s", view_function,
-                               exc_info=True)
                 body = {'Code': 'InternalServerError',
                         'Message': 'An internal server error occurred.'}
             response = Response(body=body, headers=headers, status_code=500)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1483,7 +1483,7 @@ def test_internal_exception_debug_false(capsys, create_event):
     test_app(event, context=None)
     out, err = capsys.readouterr()
     assert 'logger-test-5' in out
-    assert 'Caught Exception' in out
+    assert 'Caught exception' in out
     assert 'Something bad happened' in out
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1483,7 +1483,7 @@ def test_internal_exception_debug_false(capsys, create_event):
     test_app(event, context=None)
     out, err = capsys.readouterr()
     assert 'logger-test-5' in out
-    assert 'Internal Error' in out
+    assert 'Caught Exception' in out
     assert 'Something bad happened' in out
 
 


### PR DESCRIPTION
Issue # 1183

Remove the second Log entry for the same exception when reporting to app.log.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
