### PR TITLE
Csp report json body

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -353,6 +353,11 @@ class CORSConfig(object):
 class Request(object):
     """The current request from API gateway."""
 
+    ACCEPTABLE_JSON_CONTENT_TYPES = (
+        'application/json',
+        'application/csp-report'
+    )
+
     def __init__(self, query_params, headers, uri_params, method, body,
                  context, stage_vars, is_base64_encoded):
         self.query_params = None if query_params is None \
@@ -389,7 +394,12 @@ class Request(object):
 
     @property
     def json_body(self):
-        if self.headers.get('content-type', '').startswith('application/json'):
+        content_type = self.headers.get('content-type', '')
+        acceptable = any([
+            True for acceptable_type
+            in self.ACCEPTABLE_JSON_CONTENT_TYPES
+            if content_type.startswith(acceptable_type)])
+        if acceptable:
             if self._json_body is None:
                 try:
                     self._json_body = json.loads(self.raw_body)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -523,7 +523,8 @@ def test_json_body_available_with_right_content_type(create_event):
 def test_json_body_available_with_csp_report_content_type(create_event):
     demo = app.Chalice("demo-app")
 
-    @demo.route("/", methods=["POST"])
+    @demo.route("/", methods=["POST"],
+                content_types=['application/csp-report', 'application/json'])
     def index():
         return demo.current_request.json_body
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -520,6 +520,25 @@ def test_json_body_available_with_right_content_type(create_event):
     assert result == {'foo': 'bar'}
 
 
+def test_json_body_available_with_csp_report_content_type(create_event):
+    demo = app.Chalice("demo-app")
+
+    @demo.route("/", methods=["POST"])
+    def index():
+        return demo.current_request.json_body
+
+    event = create_event(
+        "/",
+        "POST",
+        {},
+        content_type="application/csp-report")
+    event["body"] = json.dumps({"foo": "bar"})
+
+    result = demo(event, context=None)
+    result = json_response_body(result)
+    assert result == {"foo": "bar"}
+
+
 def test_json_body_none_with_malformed_json(create_event):
     demo = app.Chalice('demo-app')
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/chalice/issues/1188

*Description of changes:*

This branch allows `Request`s with either the headers `application/json` or `application/csp-report` to return json data from `Request.json_body` (currently `application/json` is suported).

This is to allow apps created using Chalice to be Content Security Policy report violation endpoints (i.e. `report-uri` in the `Content-Security-Policy` or `Content-Security-Policy-Report-Only` headers).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
