### PR TITLE
Enable invocation via runpy

### DIFF
--- a/chalice/__main__.py
+++ b/chalice/__main__.py
@@ -1,0 +1,5 @@
+import chalice.cli
+
+
+if __name__ == '__main__':
+    chalice.cli.main()


### PR DESCRIPTION
*Issue #1191

*Description of changes:*

This change enables the project to be invoked via runpy as described in the ticket. Here I demonstrate the effect of the change locally:

```
draft $ git --git-dir=~/p/chalice/.git rev-parse --short HEAD                                                                                
c729b3c
draft $ pip-run -q ~/p/chalice -- -m chalice --help                                                                                          
Usage: __main__.py [OPTIONS] COMMAND [ARGS]...

Options:
  --version             Show the version and exit.
  --project-dir TEXT    The project directory path (absolute or
                        relative).Defaults to CWD
  --debug / --no-debug  Print debug logs to stderr.
  --help                Show this message and exit.

Commands:
  delete
  deploy
  gen-policy
  generate-pipeline  Generate a cloudformation template for a...
  generate-sdk
  invoke             Invoke the deployed lambda function NAME.
  local
  logs
  new-project
  package
  url
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
