### PR TITLE
Fix use of null_data_source

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -591,7 +591,7 @@ class TerraformGenerator(TemplateGenerator):
             'data': {
                 'aws_caller_identity': {'chalice': {}},
                 'aws_region': {'chalice': {}},
-                'null_data_provider': {
+                'null_data_source': {
                     'chalice': {
                         'inputs': {
                             'app': self._config.app_name,

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -439,7 +439,7 @@ class TestTerraformTemplate(TemplateTestBase):
                                api_gateway_stage='dev')
 
         template = self.generate_template(config, 'dev')
-        assert template['data']['null_data_provider']['chalice']['inputs'] == {
+        assert template['data']['null_data_source']['chalice']['inputs'] == {
             'app': 'myfoo',
             'stage': 'dev'
         }


### PR DESCRIPTION
The name of the data provider is `null_data_source` and not `null_data_provider`. I ran into this when trying out after we merged support for terraform. Specifically, I was running into the following error for the general `new-project` app:
```
Error: Invalid data source

  on chalice.tf.json line 85, in data:
  85:     "null_data_provider": {

The provider provider.null does not support data source "null_data_provider".
```
The fix here allows me to success `terraform apply` the template. It is also what the docs say to use for the name: https://www.terraform.io/docs/providers/null/data_source.html

@kapilt @jamesls 
