### PR TITLE
fix for _generate_arn in AuthResponse

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1211,7 +1211,7 @@ class AuthResponse(object):
         return allowed_resources
 
     def _generate_arn(self, route, request, method='*'):
-        incoming_arn = request.method_arn
+        incoming_arn = request.method_arn.split('?')[0]
         parts = incoming_arn.rsplit(':', 1)
         # "arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET/needs/auth"
         # Then we pull out the rest-api-id and stage, such that:


### PR DESCRIPTION
CustomAuthorizer fails when querystring params contain : or /

If the user passes pathParams that contain : or / and the Chalice app uses a CustomAuthorizer then the incoming_arn will be incorrect. Adding .split('?')[0] fixes this issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
