### PR TITLE
Add support for multi value header responses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 
 * Fix mouting blueprints with root routes
   (`#1230 <https://github.com/aws/chalice/pull/1230>`__)
+* Add support for multi-value headers responses
+  (`#1205 <https://github.com/aws/chalice/pull/1205>`__)
 
 
 1.11.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -410,11 +410,15 @@ class Request(object):
 
 
 class Response(object):
-    def __init__(self, body, headers=None, status_code=200):
+    def __init__(self, body, headers=None, status_code=200,
+                 multi_value_headers=None):
         self.body = body
         if headers is None:
             headers = {}
         self.headers = headers
+        if multi_value_headers is None:
+            multi_value_headers = {}
+        self.multi_value_headers = multi_value_headers
         self.status_code = status_code
 
     def to_dict(self, binary_types=None):
@@ -424,6 +428,7 @@ class Response(object):
                               default=handle_extra_types)
         response = {
             'headers': self.headers,
+            'multiValueHeaders': self.multi_value_headers,
             'statusCode': self.status_code,
             'body': body
         }

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -72,8 +72,7 @@ class Request:
 
 
 class Response:
-    headers = ... # type: Dict[str, str]
-    multi_value_headers = ... # type: Dict[str, List[str]]
+    headers = ... # type: Dict[str, Union[str, List[str]]]
     body = ...  # type: Any
     status_code = ... # type: int
 

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -73,6 +73,7 @@ class Request:
 
 class Response:
     headers = ... # type: Dict[str, str]
+    multi_value_headers = ... # type: Dict[str, List[str]]
     body = ...  # type: Any
     status_code = ... # type: int
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -460,6 +460,8 @@ def test_custom_response(smoke_test_app):
     response.raise_for_status()
     # Custom header
     assert response.headers['Content-Type'] == 'text/plain'
+    # Multi headers
+    assert response.headers['Set-Cookie'] == 'key=value, foo=bar'
     # Custom status code
     assert response.status_code == 204
 

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -146,8 +146,12 @@ def multifile():
 
 @app.route('/custom-response', methods=['GET'])
 def custom_response():
-    return Response(status_code=204, body='',
-                    headers={'Content-Type': 'text/plain'})
+    return Response(
+        status_code=204,
+        body='',
+        headers={'Content-Type': 'text/plain'},
+        multi_value_headers={'Set-Cookie': ['key=value', 'foo=bar']}
+    )
 
 
 @app.route('/api-key-required', methods=['GET'], api_key_required=True)

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -149,8 +149,10 @@ def custom_response():
     return Response(
         status_code=204,
         body='',
-        headers={'Content-Type': 'text/plain'},
-        multi_value_headers={'Set-Cookie': ['key=value', 'foo=bar']}
+        headers={
+            'Content-Type': 'text/plain',
+            'Set-Cookie': ['key=value', 'foo=bar'],
+        },
     )
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -642,8 +642,10 @@ def test_can_return_response_object(create_event):
         return app.Response(
             status_code=200,
             body={'foo': 'bar'},
-            headers={'Content-Type': 'application/json'},
-            multi_value_headers={'Set-Cookie': ['key=value', 'foo=bar']}
+            headers={
+                'Content-Type': 'application/json',
+                'Set-Cookie': ['key=value', 'foo=bar'],
+            },
         )
 
     event = create_event('/index', 'GET', {})

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -639,13 +639,22 @@ def test_can_return_response_object(create_event):
 
     @demo.route('/index')
     def index_view():
-        return app.Response(status_code=200, body={'foo': 'bar'},
-                            headers={'Content-Type': 'application/json'})
+        return app.Response(
+            status_code=200,
+            body={'foo': 'bar'},
+            headers={'Content-Type': 'application/json'},
+            multi_value_headers={'Set-Cookie': ['key=value', 'foo=bar']}
+        )
 
     event = create_event('/index', 'GET', {})
     response = demo(event, context=None)
-    assert response == {'statusCode': 200, 'body': '{"foo":"bar"}',
-                        'headers': {'Content-Type': 'application/json'}}
+    assert response == {
+        'statusCode': 200,
+        'body': '{"foo":"bar"}',
+
+        'headers': {'Content-Type': 'application/json'},
+        'multiValueHeaders': {'Set-Cookie': ['key=value', 'foo=bar']},
+    }
 
 
 def test_headers_have_basic_validation(create_event):


### PR DESCRIPTION
API Gateway added support for a multi-value header dictionary whcih can
be returned. This commit adds support for it in Chalice.

implements #1205 

API Gateway docs: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format