### PR TITLE
Click.option-s should have help text

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -271,7 +271,8 @@ def delete(ctx, profile, stage):
 @click.option('--include-lambda-messages/--no-include-lambda-messages',
               default=False,
               help='Controls whether or not lambda log messages are included.')
-@click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+              help='Name of the Chalice stage to get logs for.')
 @click.option('-n', '--name',
               help='The name of the lambda function to retrieve logs from.',
               default=DEFAULT_HANDLER_NAME)
@@ -325,7 +326,8 @@ def new_project(project_name, profile):
 
 
 @cli.command('url')
-@click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+              help='Name of the Chalice stage to get url for.')
 @click.pass_context
 def url(ctx, stage):
     # type: (click.Context, str) -> None
@@ -345,7 +347,8 @@ def url(ctx, stage):
 @cli.command('generate-sdk')
 @click.option('--sdk-type', default='javascript',
               type=click.Choice(['javascript']))
-@click.option('--stage', default=DEFAULT_STAGE_NAME)
+@click.option('--stage', default=DEFAULT_STAGE_NAME,
+               help='Name of the Chalice stage to generate_sdk for.')
 @click.argument('outdir')
 @click.pass_context
 def generate_sdk(ctx, sdk_type, stage, outdir):


### PR DESCRIPTION

*Description of changes:*
Adds `help` text to click.option-s.

The reason is click.option-s should ideally have a `help` text defined to be useful.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
