### PR TITLE
Remove trailing slash when using url_prefix on register_blueprint.

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -847,7 +847,7 @@ class _HandlerRegistration(object):
         url_prefix = kwargs.pop('url_prefix', None)
         if url_prefix is not None:
             path = '/'.join([url_prefix.rstrip('/'),
-                             path.strip('/')])
+                             path.strip('/')]).rstrip('/') or '/'
         methods = actual_kwargs.pop('methods', ['GET'])
         route_kwargs = {
             'authorizer': actual_kwargs.pop('authorizer', None),


### PR DESCRIPTION
The _HandlerRegistration._register_route have a logic that ends with a trailing slash on the route when we use the url_prefix parameter on register_blueprint.
With this PR, the trailing slash is removed and, if it results on an empty string, it will be a simple '/'.

For example, if we have a code as follows:
```python
>users_routes.py
bp_users = Blueprint(__name__)
@bp_users.route('/')
def handle_get_all_users():
    pass

@bp_users.route('/{user_id}')
def handle_get_user_by_id(user_id):
    pass

>app.py
...
from users_routes import bp_users
app = Chalice(app_name='the app')
app.register_blueprint(bp_users, url_prefix='user')
```
When deploying the above code, an error raises because the resulting route for ```/{user_id}``` is ```"/user/{user_id}/"```.
Now this last slash is removed and the deploy can be made.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
