### PR TITLE
chalice.package.TerraformGenerator: use create_before_destroy

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -865,6 +865,7 @@ class TerraformGenerator(TemplateGenerator):
                     "${md5(data.template_file.chalice_api_swagger.rendered)}"),
                 'rest_api_id': '${aws_api_gateway_rest_api.%s.id}' % (
                     resource.resource_name),
+                'lifecycle': {'create_before_destroy': True}
         }
 
         template['resource'].setdefault('aws_lambda_permission', {})[

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -433,7 +433,8 @@ class TestTerraformTemplate(TemplateTestBase):
             'rest_api_id': '${aws_api_gateway_rest_api.rest_api.id}',
             'stage_description': (
                 '${md5(data.template_file.chalice_api_swagger.rendered)}'),
-            'stage_name': 'api'
+            'stage_name': 'api',
+            'lifecycle': {'create_before_destroy': True}
         }
 
         # We should also create the auth lambda function.


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1237

*Description of changes:*

In the Terraform aws_api_gateway_deployment resource, use the
`lifecycle.create_before_destroy: True` option as described in
https://github.com/hashicorp/terraform/issues/10674.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
