### PR TITLE
Use hyphen instead of underscore for routes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -872,7 +872,7 @@ Code sample defining more CORS headers:
         expose_headers=['X-Special-Header'],
         allow_credentials=True
     )
-    @app.route('/custom_cors', methods=['GET'], cors=cors_config)
+    @app.route('/custom-cors', methods=['GET'], cors=cors_config)
     def supports_custom_cors():
         return {'cors': True}
 


### PR DESCRIPTION
Nothing's wrong with this, but we use `-` for word
separators in other parts of the tutorial.