### PR TITLE
Add websocket support for closing and getting info about a socket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 
 * Add ``generate-models`` command
   (`#1245 <https://github.com/aws/chalice/pull/1245>`__)
+* Add ``close`` and ``info`` commands to websocket api
+  (`#1259 <https://github.com/aws/chalice/pull/1259>`__)
 
 
 1.11.1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -707,7 +707,7 @@ WebsocketAPI
       Configure prepares the :class:`WebsocketAPI` to call the :meth:`send`
       method. Without first calling this method calls to :meth:`send` will fail
       with the message ``WebsocketAPI needs to be configured before sending
-      messages.``. This is because a boto3 ``apigatewaymanagmentapi`` client
+      messages.``. This is because a boto3 ``apigatewaymanagementapi`` client
       must be created from the :attr:`session` with a custom endpoint in order
       to properly communicate with our API Gateway WebsocketAPI. This method is
       called on your behalf before each of the websocket handlers:
@@ -721,6 +721,33 @@ WebsocketAPI
       Method to send a message to a client. The ``connection_id`` is the unique
       identifier of the socket to send the ``message`` to. The ``message`` must
       be a utf-8 string.
+
+      If the socket is disconnected it raises a :class:`WebsocketDisconnectedError`
+      error.
+
+   .. method:: close(connection_id)
+
+      Method to close a WebSocket connection. The ``connection_id`` is the
+      unique identifier of the socket to close.
+
+      If the socket is already disconnected it raises a
+      :class:`WebsocketDisconnectedError` error.
+
+   .. method:: info(connection_id)
+
+      Method to get info about a WebSocket. The ``connection_id`` is the unique
+      identifier of the socket to get info about.
+
+      The following is an example of the format this method returns::
+
+       {
+           'ConnectedAt': datetime(2015, 1, 1),
+           'Identity': {
+               'SourceIp': 'string',
+               'UserAgent': 'string'
+           },
+           'LastActiveAt': datetime(2015, 1, 1)
+       }
 
       If the socket is disconnected it raises a :class:`WebsocketDisconnectedError`
       error.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -718,6 +718,8 @@ WebsocketAPI
 
    .. method:: send(connection_id, message)
 
+      *requires* ``boto3>=1.9.91``
+
       Method to send a message to a client. The ``connection_id`` is the unique
       identifier of the socket to send the ``message`` to. The ``message`` must
       be a utf-8 string.
@@ -727,6 +729,8 @@ WebsocketAPI
 
    .. method:: close(connection_id)
 
+      *requires* ``boto3>=1.9.221``
+
       Method to close a WebSocket connection. The ``connection_id`` is the
       unique identifier of the socket to close.
 
@@ -734,6 +738,8 @@ WebsocketAPI
       :class:`WebsocketDisconnectedError` error.
 
    .. method:: info(connection_id)
+
+      *requires* ``boto3>=1.9.221``
 
       Method to get info about a WebSocket. The ``connection_id`` is the unique
       identifier of the socket to get info about.

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -115,7 +115,7 @@ class FakeClient(object):
             return info
 
     def _call(self, name, *args):
-        self.calls[name].append((*args,))
+        self.calls[name].append(tuple(args))
         if self._errors:
             error = self._errors.pop()
             raise error

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2421,7 +2421,51 @@ def test_can_close_websocket_connection(create_websocket_event):
     assert connection_id == 'connection_id'
 
 
-def test_can_get_info_about_websocket_connection(create_websocket_event):
+def test_close_does_fail_if_already_disconnected(create_websocket_event):
+    demo = app.Chalice('app-name')
+    client = FakeClient(errors=[FakeGoneException])
+    demo.websocket_api.session = FakeSession(client)
+
+    @demo.on_ws_message()
+    def message_handler(event):
+        with pytest.raises(WebsocketDisconnectedError) as e:
+            demo.websocket_api.close('connection_id')
+        assert e.value.connection_id == 'connection_id'
+
+    event = create_websocket_event('$default', body='foo bar')
+    handler = websocket_handler_for_route('$default', demo)
+    handler(event, context=None)
+
+    calls = client.calls['close']
+    assert len(calls) == 1
+    call = calls[0]
+    connection_id = call[0]
+    assert connection_id == 'connection_id'
+
+
+def test_info_does_fail_if_already_disconnected(create_websocket_event):
+    demo = app.Chalice('app-name')
+    client = FakeClient(errors=[FakeGoneException])
+    demo.websocket_api.session = FakeSession(client)
+
+    @demo.on_ws_message()
+    def message_handler(event):
+        with pytest.raises(WebsocketDisconnectedError) as e:
+            demo.websocket_api.info('connection_id')
+        assert e.value.connection_id == 'connection_id'
+
+    event = create_websocket_event('$default', body='foo bar')
+    handler = websocket_handler_for_route('$default', demo)
+    handler(event, context=None)
+
+    calls = client.calls['info']
+    assert len(calls) == 1
+    call = calls[0]
+    connection_id = call[0]
+    assert connection_id == 'connection_id'
+
+
+def test_can__about_websocket_connection(create_websocket_event):
     demo = app.Chalice('app-name')
     client = FakeClient(infos=[{'foo': 'bar'}])
     demo.websocket_api.session = FakeSession(client)


### PR DESCRIPTION
Methods were added to apigatewaymanagementapi to close a socket and get
info about it. This PR adds support for them in the app.websocket_api
object.

