### PR TITLE
Fix lambda_timeout config argument naming

### DIFF
--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -240,7 +240,7 @@ a top level ``lambda_functions`` key::
     "app_name": "app",
     "lambda_functions": {
       "foo": {
-        "lamba_timeout": 120
+        "lambda_timeout": 120
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix `lambda_timeout` typo on documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
