### PR TITLE
Fix packager.py name normalization.

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -534,8 +534,7 @@ class Package(object):
 
     def _normalize_name(self, name):
         # type: (str) -> str
-        # Taken directly from PEP 503
-        return re.sub(r"[-_.]+", "-", name).lower()
+        return re.sub(r"[-_.]+", "-", name)
 
     @property
     def identifier(self):


### PR DESCRIPTION
Issue #1288.

Fix packager.py name normalization.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
