### PR TITLE
add support for lambda invoke role in CustomAuthorizer

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -276,11 +276,12 @@ class CustomAuthorizer(Authorizer):
     _AUTH_TYPE = 'custom'
 
     def __init__(self, name, authorizer_uri, ttl_seconds=300,
-                 header='Authorization'):
+                 header='Authorization', invoke_role_arn=''):
         self.name = name
         self._header = header
         self._authorizer_uri = authorizer_uri
         self._ttl_seconds = ttl_seconds
+        self._invoke_role_arn = invoke_role_arn
 
     def to_swagger(self):
         return {
@@ -292,6 +293,7 @@ class CustomAuthorizer(Authorizer):
                 'type': 'token',
                 'authorizerUri': self._authorizer_uri,
                 'authorizerResultTtlInSeconds': self._ttl_seconds,
+                'authorizerCredentials': self._invoke_role_arn,
             }
         }
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -379,7 +379,8 @@ def test_can_add_api_key(sample_app, swagger_gen):
 
 def test_can_use_authorizer_object(sample_app, swagger_gen):
     authorizer = CustomAuthorizer(
-        'MyAuth', authorizer_uri='auth-uri', header='Authorization')
+        'MyAuth', authorizer_uri='auth-uri', header='Authorization',
+        invoke_role_arn='role-arn')
 
     @sample_app.route('/auth', authorizer=authorizer)
     def auth():
@@ -398,7 +399,8 @@ def test_can_use_authorizer_object(sample_app, swagger_gen):
         'x-amazon-apigateway-authorizer': {
             'authorizerUri': 'auth-uri',
             'type': 'token',
-            'authorizerResultTtlInSeconds': 300
+            'authorizerResultTtlInSeconds': 300,
+            'authorizerCredentials': 'role-arn'
         }
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1056,7 +1056,8 @@ def test_typecheck_list_type():
 
 def test_can_serialize_custom_authorizer():
     auth = app.CustomAuthorizer(
-        'Name', 'myuri', ttl_seconds=10, header='NotAuth'
+        'Name', 'myuri', ttl_seconds=10, header='NotAuth',
+        invoke_role_arn='role-arn'
     )
     assert auth.to_swagger() == {
         'in': 'header',
@@ -1067,6 +1068,7 @@ def test_can_serialize_custom_authorizer():
             'type': 'token',
             'authorizerUri': 'myuri',
             'authorizerResultTtlInSeconds': 10,
+            'authorizerCredentials': 'role-arn',
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
`CustomAuthorizer` can now be set with a Lambda Invoke Role via the `invoke_role_arn` argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
