### PR TITLE
Enable name for pure lambda function in chalice package

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -187,6 +187,7 @@ class SAMTemplateGenerator(TemplateGenerator):
         lambdafunction_definition = {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': resource.function_name,
                 'Runtime': resource.runtime,
                 'Handler': resource.handler,
                 'CodeUri': resource.deployment_package.filename,

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -684,6 +684,7 @@ class TestSAMTemplate(TemplateTestBase):
         assert cfn_resource == {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': 'app-dev-foo',
                 'CodeUri': 'foo.zip',
                 'Handler': 'app.app',
                 'MemorySize': 128,
@@ -763,6 +764,7 @@ class TestSAMTemplate(TemplateTestBase):
         assert cfn_resource == {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': 'app-dev-foo',
                 'CodeUri': 'foo.zip',
                 'Handler': 'app.app',
                 'MemorySize': 128,


### PR DESCRIPTION
Add function name to lambda for output template. This is required If you want to have a static name for your lambda which may be called by other client libraries.

*Issue #, if available:*

*Description of changes:*

`chalice deploy` allows one to define a name for your lambda function by simply passing name=<FN_NAME> as a parameter to your @app.lambda_function decorator. 
You could invoke the same deployed function by --<FN_NAME> from aws cli.

However, if one were to `chalice package` and bundle the template with other resources for deployment it does not retain the Function name. I figured out that during AWS template generation it does not add resource name in the cloud formation template builder.

<img width="604" alt="Screenshot 2019-11-19 at 10 15 22 PM" src="https://user-images.githubusercontent.com/54466596/69171089-48b6fe80-0b21-11ea-859d-d58e32fb5fb7.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


