### PR TITLE
Fix packager to download missing sdists before trying to build them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Next Release (TBD)
   (`#1252 <https://github.com/aws/chalice/issues/1252>`__)
 * Add global CORS configuration
   (`#70 <https://github.com/aws/chalice/pull/70>`__)
+* Fix packaging simplejson
+  (`#1304 <https://github.com/aws/chalice/pull/1304>`__)
 
 
 1.12.0

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -337,6 +337,20 @@ class DependencyBuilder(object):
         self._pip.download_manylinux_wheels(
             abi, [pkg.identifier for pkg in packages], directory)
 
+    def _download_sdists(self, packages, directory):
+        # type: (Set[Package], str) -> None
+        logger.debug("Downloading missing sdists: %s", packages)
+        self._pip.download_sdists(
+            [pkg.identifier for pkg in packages], directory)
+
+    def _find_sdists(self, directory):
+        # type: (str) -> Set[Package]
+        packages = [Package(directory, filename) for filename
+                    in self._osutils.get_directory_contents(directory)]
+        sdists = {package for package in packages
+                  if package.dist_type == 'sdist'}
+        return sdists
+
     def _build_sdists(self, sdists, directory, compile_c=True):
         # type: (Set[Package], str, bool) -> None
         logger.debug("Build missing wheels from sdists "
@@ -359,6 +373,21 @@ class DependencyBuilder(object):
                 incompatible_wheels.add(wheel)
         return compatible_wheels, incompatible_wheels
 
+    def _categorize_deps(self, abi, deps):
+        # type: (str, Set[Package]) -> Any
+        compatible_wheels = set()
+        incompatible_wheels = set()
+        sdists = set()
+        for package in deps:
+            if package.dist_type == 'sdist':
+                sdists.add(package)
+            else:
+                if self._is_compatible_wheel_filename(abi, package.filename):
+                    compatible_wheels.add(package)
+                else:
+                    incompatible_wheels.add(package)
+        return sdists, compatible_wheels, incompatible_wheels
+
     def _download_dependencies(self, abi, directory, requirements_filename):
         # type: (str, str, str) -> Tuple[Set[Package], Set[Package]]
         # Download all dependencies we can, letting pip choose what to
@@ -378,17 +407,8 @@ class DependencyBuilder(object):
         # platform lambda runs on (linux_x86_64/manylinux) then the downloaded
         # wheel file may not be compatible with lambda. Pure python wheels
         # still will be compatible because they have no platform dependencies.
-        compatible_wheels = set()
-        incompatible_wheels = set()
-        sdists = set()
-        for package in deps:
-            if package.dist_type == 'sdist':
-                sdists.add(package)
-            else:
-                if self._is_compatible_wheel_filename(abi, package.filename):
-                    compatible_wheels.add(package)
-                else:
-                    incompatible_wheels.add(package)
+        sdists, compatible_wheels, incompatible_wheels = self._categorize_deps(
+            abi, deps)
         logger.debug("initial compatible: %s", compatible_wheels)
         logger.debug("initial incompatible: %s", incompatible_wheels | sdists)
 
@@ -403,6 +423,14 @@ class DependencyBuilder(object):
         # that has an sdist but not a valid wheel file is still not going to
         # work on lambda and we must now try and build the sdist into a wheel
         # file ourselves.
+        # There also may be the case where no sdist was ever downloaded. For
+        # example if we are on MacOS, and the package in question has a mac
+        # compatible wheel file but no linux ones, we will only have an
+        # incompatible wheel file and no sdist. So we need to get any missing
+        # sdists before we can build them.
+        missing_sdists = incompatible_wheels - sdists
+        self._download_sdists(missing_sdists, directory)
+        sdists = self._find_sdists(directory)
         compatible_wheels, incompatible_wheels = self._categorize_wheel_files(
             abi, directory)
         logger.debug(
@@ -772,4 +800,11 @@ class PipRunner(object):
             arguments = ['--only-binary=:all:', '--no-deps', '--platform',
                          'manylinux1_x86_64', '--implementation', 'cp',
                          '--abi', abi, '--dest', directory, package]
+            self._execute('download', arguments)
+
+    def download_sdists(self, packages, directory):
+        # type: (List[str], str) -> None
+        for package in packages:
+            arguments = ["--no-binary=:all:", "--no-deps", "--dest",
+                         directory, package]
             self._execute('download', arguments)

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -40,9 +40,9 @@ def _get_random_package_name():
 
 
 class TestPackage(object):
-    def test_can_package_with_dashes_in_name(self, runner, app_skeleton):
+    def assert_can_package_dependency(
+            self, runner, app_skeleton, package, contents):
         req = os.path.join(app_skeleton, 'requirements.txt')
-        package = 'googleapis-common-protos==1.5.2'
         with open(req, 'w') as f:
             f.write('%s\n' % package)
         cli_factory = factory.CLIFactory(app_skeleton)
@@ -57,7 +57,28 @@ class TestPackage(object):
         package_path = os.path.join(app_skeleton, 'pkg', 'deployment.zip')
         package_file = ZipFile(package_path)
         package_content = package_file.namelist()
-        assert 'google/api/__init__.py' in package_content
+        for content in contents:
+            assert content in package_content
+
+    def test_can_package_with_dashes_in_name(self, runner, app_skeleton):
+        self.assert_can_package_dependency(
+            runner,
+            app_skeleton,
+            'googleapis-common-protos==1.5.2',
+            contents=[
+                'google/api/__init__.py',
+            ],
+        )
+
+    def test_can_package_simplejson(self, runner, app_skeleton):
+        self.assert_can_package_dependency(
+            runner,
+            app_skeleton,
+            'simplejson==3.17.0',
+            contents=[
+                'simplejson/__init__.py',
+            ],
+        )
 
     def test_does_not_package_bad_requirements_file(
             self, runner, app_skeleton):

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -187,6 +187,17 @@ class TestPipRunner(object):
         assert call.env_vars is None
         assert call.shim is None
 
+    def test_download_sdist(self, pip_factory):
+        pip, runner = pip_factory()
+        packages = ['foo', 'bar', 'baz']
+        runner.download_sdists(packages, 'directory')
+        expected_prefix = ['download', '--no-binary=:all:', '--no-deps',
+                           '--dest', 'directory']
+        for i, package in enumerate(packages):
+            assert pip.calls[i].args == expected_prefix + [package]
+            assert pip.calls[i].env_vars is None
+            assert pip.calls[i].shim is None
+
     def test_download_wheels(self, pip_factory):
         # Make sure that `pip download` is called with the correct arguments
         # for getting lambda compatible wheels.


### PR DESCRIPTION
The packager has an initial download step to cast a wide net trying to
download "an" artifact for each package. This is to build a full
dependency closure of everything we want to install. Because we want to
get something for every package we place no restrictions on what type of
artifact we want. Pip naturally prefers system-specific wheels when
available. After this download step we check for for any missing
compatible wheels, and try to use pip to download wheels that are
linux compatible. This catches the case where we weren't running our
package command from a linux machine, and there were platform-specific
wheel files available.

There are several cases for packages missing a compatible wheel file at
this point:

1) There were no wheel files available for download at all. In this
   case our initial download call would have fetched an sdist.
2) There were no linux compatible wheel files available, and no wheel
   files compatible with your local system. In this case the initial
   download will have downloaded the sdist instead of a wheel. The
   secondary download to try and force a compatible wheel will have also
   failed. Leaving us with just the initial sdist.
3) There were no linux compatible wheel files available, and there was a
   compatible one for your local system. In this case the initial
   download will have fetched the wheel that is compatible with your
   local system. And the second call to try and force a linux compatible
   download will have failed. Leaving you with just the incompatible
   wheel locally.

The next step after this is to try and build the sdist into a wheel
ourselves. Previous to this commit we were assuming we had an sdist
locally to build because case 1 and 2 are much more common. In case 3
the package would fail to build since the list of sdists to build is
empty. Resulting in a missing dependency error.

This commit fixes case 3 by doing a pip sdist-only download on any
package missing both a compatible wheel file and an sdist. Now when we
move on to the build step the sdist will be present.

Fixes #1304 
