### PR TITLE
Fix local execution of tests and linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ pylint:
 	###### PYLINT ######
 	pylint --rcfile .pylintrc chalice
 	# Run our custom linter on test code.
-	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
+	PYTHONPATH=. pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
 
 test:
 	py.test -v $(TESTS)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,5 +26,6 @@ hypothesis==4.43.1
 # pip does not catch the <0.7 requirement in pytest so we need to add it to
 # the top level requirements.
 pluggy==0.12
+watchdog==0.9.0
 
 mypy==0.740; python_version >= '3.6'


### PR DESCRIPTION
*Issue: #1328*

*Description of changes:*

Add missing package `watch` and adjust PYTHONPATH before running linter as to find the custom linter plugin in use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
