### PR TITLE
Disable anchor link checker

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -223,3 +223,7 @@ htmlhelp_basename = 'Chalicedoc'
 primary_domain = 'py'
 
 linkcheck_retries = 5
+# The AWS Doc site now uses javascript to dynamically render the content,
+# so the anchors aren't going to exist in the static html content.  This
+# will fail the anchor checker so we have to disable this.
+linkcheck_anchors = False


### PR DESCRIPTION
This is failing our builds now.  This is due to
the AWS Doc site using javascript to render the content
now so even though the anchor links are correct, you
won't be able to see them in the static HTML.