### PR TITLE
Docs: update Flask links to point palletsprojects.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1248,7 +1248,7 @@ The biggest difference between this framework and others is that the Python
 Serverless Microframework for AWS is singularly focused on using a familiar,
 decorator-based API to write python applications that run on Amazon API Gateway
 and AWS Lambda.  You can think of it as
-`Flask <http://flask.pocoo.org/>`__/`Bottle <http://bottlepy.org/docs/dev/index.html>`__
+`Flask <https://palletsprojects.com/p/flask/>`__/`Bottle <http://bottlepy.org/docs/dev/index.html>`__
 for serverless APIs.  Its goal is to make writing and deploying these types of
 applications as simple as possible specifically for Python developers.
 

--- a/docs/source/topics/blueprints.rst
+++ b/docs/source/topics/blueprints.rst
@@ -27,7 +27,7 @@ object.
 .. note::
 
   The Chalice blueprints are conceptually similar to `Blueprints
-  <http://flask.pocoo.org/docs/latest/blueprints/>`__ in Flask.  Flask
+  <https://flask.palletsprojects.com/blueprints/>`__ in Flask.  Flask
   blueprints allow you to define a set of URL routes separately from the main
   ``Flask`` object.  This concept is extended to all resources in Chalice.  A
   Chalice blueprint can have Lambda functions, event handlers, built-in

--- a/docs/source/topics/routing.rst
+++ b/docs/source/topics/routing.rst
@@ -3,7 +3,7 @@ Routing
 
 The :meth:`Chalice.route` method is used to construct which routes
 you want to create for your API.  The concept is the same
-mechanism used by `Flask <http://flask.pocoo.org/>`__ and
+mechanism used by `Flask <https://palletsprojects.com/p/flask/>`__ and
 `bottle <http://bottlepy.org/docs/dev/index.html>`__.
 You decorate a function with ``@app.route(...)``, and whenever
 a user requests that URL, the function you've decorated is called.


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*
Pallets moved to new website:
pocco.org -> palletsprojects.com
We can get rid of an extra redirect here, which I discovered in Travis CI logs:
```
(line    4) redirect  http://flask.pocoo.org/ - with Found to https://palletsprojects.com/p/flask/
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
