### PR TITLE
Allow CORS to continue working when content is gzipped

### DIFF
--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -234,7 +234,8 @@ class SwaggerGenerator(object):
                     "application/json": "{\"statusCode\": 200}"
                 },
                 "passthroughBehavior": "when_no_match",
-                "type": "mock"
+                "type": "mock",
+                "contentHandling": "CONVERT_TO_TEXT"
             }
         }
         swagger_for_path['options'] = options_request

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -258,6 +258,7 @@ class TestPreflightCORS(object):
                 },
                 'passthroughBehavior': 'when_no_match',
                 'type': 'mock',
+                'contentHandling': 'CONVERT_TO_TEXT'
             },
         }
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -320,6 +320,7 @@ class TestPreflightCORS(object):
                 },
                 'passthroughBehavior': 'when_no_match',
                 'type': 'mock',
+                'contentHandling': 'CONVERT_TO_TEXT'
             },
         }
 


### PR DESCRIPTION
*Issue #, if available:* #1336 

*Description of changes:* Set contentHandling for preflight (OPTIONS) requests to CONVERT_TO_TEXT to be inline with regular (Lambda-proxied methods) as well as allow CORS when content is gzipped.

As described in #1336, when CORS is used together with the recipe to gzip content from API, preflight requests (OPTIONS method) stop working (details in issue). This fix allows API Gateway to correctly convert Mock 200 response back to the browser.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
