### PR TITLE
Update pip with new import string

### DIFF
--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -12,17 +12,23 @@ def pip_import_string():
     import pip
     pip_major_version = int(pip.__version__.split('.')[0])
     pip_minor_version = int(pip.__version__.split('.')[1])
+    pip_major_minor = (pip_major_version, pip_minor_version)
     # Pip moved its internals to an _internal module in version 10.
     # In order to be compatible with version 9 which has it at at the
     # top level we need to figure out the correct import path here.
-    if pip_major_version == 9:
+    if (9, 0) <= pip_major_minor < (10, 0):
         return 'from pip import main'
-    # Pip changed their import structure again in 19.3
-    # https://github.com/pypa/pip/commit/09fd200
-    elif pip_major_version >= 19 and pip_minor_version >= 3:
-        return 'from pip._internal.main import main'
-    else:
+    elif (10, 0) <= pip_major_minor < (19, 3):
+        # Pip changed their import structure again in 19.3
+        # https://github.com/pypa/pip/commit/09fd200
         return 'from pip._internal import main'
+    elif (19, 3) <= pip_major_minor < (20, 0):
+        return 'from pip._internal.main import main'
+    elif (20, 0) <= pip_major_minor < (21, 0):
+        # More changes! https://github.com/pypa/pip/issues/7498
+        return 'from pip._internal.cli.main import main'
+    raise RuntimeError("Unknown import string for pip version: %s"
+                       % str(pip_major_minor))
 
 
 if os.name == 'nt':


### PR DESCRIPTION
Changed again in the latest pip version.

The existing version logic was getting hard to follow so I simplified to just have the in-order progression of pip's changes to the import string.

Moving forward, I think we should just change this to `python -m pip`, but I don't want to make that big of a change for now.  I'll come back to this in a bit.