### PR TITLE
Add support for lambda invoke role arn in custom auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Next Release (TBD)
   (`#1304 <https://github.com/aws/chalice/pull/1304>`__)
 * Add support for Python 3.8
   (`#1315 <https://github.com/aws/chalice/pull/1315>`__)
+* Add support for invocation role in custom authorizer
+  (`#1303 <https://github.com/aws/chalice/pull/1303>`__)
 
 
 1.12.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -276,7 +276,7 @@ class CustomAuthorizer(Authorizer):
     _AUTH_TYPE = 'custom'
 
     def __init__(self, name, authorizer_uri, ttl_seconds=300,
-                 header='Authorization', invoke_role_arn=''):
+                 header='Authorization', invoke_role_arn=None):
         self.name = name
         self._header = header
         self._authorizer_uri = authorizer_uri
@@ -284,7 +284,7 @@ class CustomAuthorizer(Authorizer):
         self._invoke_role_arn = invoke_role_arn
 
     def to_swagger(self):
-        return {
+        swagger = {
             'in': 'header',
             'type': 'apiKey',
             'name': self._header,
@@ -293,9 +293,12 @@ class CustomAuthorizer(Authorizer):
                 'type': 'token',
                 'authorizerUri': self._authorizer_uri,
                 'authorizerResultTtlInSeconds': self._ttl_seconds,
-                'authorizerCredentials': self._invoke_role_arn,
             }
         }
+        if self._invoke_role_arn is not None:
+            swagger['x-amazon-apigateway-authorizer'][
+                'authorizerCredentials'] = self._invoke_role_arn
+        return swagger
 
 
 class CORSConfig(object):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -276,11 +276,12 @@ class CustomAuthorizer(Authorizer):
     _AUTH_TYPE = 'custom'
 
     def __init__(self, name, authorizer_uri, ttl_seconds=300,
-                 header='Authorization'):
+                 header='Authorization', invoke_role_arn=''):
         self.name = name
         self._header = header
         self._authorizer_uri = authorizer_uri
         self._ttl_seconds = ttl_seconds
+        self._invoke_role_arn = invoke_role_arn
 
     def to_swagger(self):
         return {
@@ -292,6 +293,7 @@ class CustomAuthorizer(Authorizer):
                 'type': 'token',
                 'authorizerUri': self._authorizer_uri,
                 'authorizerResultTtlInSeconds': self._ttl_seconds,
+                'authorizerCredentials': self._invoke_role_arn,
             }
         }
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -379,6 +379,29 @@ def test_can_add_api_key(sample_app, swagger_gen):
 
 def test_can_use_authorizer_object(sample_app, swagger_gen):
     authorizer = CustomAuthorizer(
+        'MyAuth', authorizer_uri='auth-uri', header='Authorization'
+    )
+
+    @sample_app.route('/auth', authorizer=authorizer)
+    def auth():
+        return {'foo': 'bar'}
+
+    doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/auth']['get']
+    assert single_method.get('security') == [{'MyAuth': []}]
+    security_definitions = doc['securityDefinitions']
+    assert 'MyAuth' in security_definitions
+    my_auth = security_definitions['MyAuth']
+    # authorizerCredentials should not be in this dict because it's None.
+    assert my_auth['x-amazon-apigateway-authorizer'] == {
+        'authorizerUri': 'auth-uri',
+        'type': 'token',
+        'authorizerResultTtlInSeconds': 300,
+    }
+
+
+def test_can_use_authorizer_object_with_role_arn(sample_app, swagger_gen):
+    authorizer = CustomAuthorizer(
         'MyAuth', authorizer_uri='auth-uri', header='Authorization',
         invoke_role_arn='role-arn')
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -379,7 +379,8 @@ def test_can_add_api_key(sample_app, swagger_gen):
 
 def test_can_use_authorizer_object(sample_app, swagger_gen):
     authorizer = CustomAuthorizer(
-        'MyAuth', authorizer_uri='auth-uri', header='Authorization')
+        'MyAuth', authorizer_uri='auth-uri', header='Authorization',
+        invoke_role_arn='role-arn')
 
     @sample_app.route('/auth', authorizer=authorizer)
     def auth():
@@ -398,7 +399,8 @@ def test_can_use_authorizer_object(sample_app, swagger_gen):
         'x-amazon-apigateway-authorizer': {
             'authorizerUri': 'auth-uri',
             'type': 'token',
-            'authorizerResultTtlInSeconds': 300
+            'authorizerResultTtlInSeconds': 300,
+            'authorizerCredentials': 'role-arn'
         }
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1056,7 +1056,8 @@ def test_typecheck_list_type():
 
 def test_can_serialize_custom_authorizer():
     auth = app.CustomAuthorizer(
-        'Name', 'myuri', ttl_seconds=10, header='NotAuth'
+        'Name', 'myuri', ttl_seconds=10, header='NotAuth',
+        invoke_role_arn='role-arn'
     )
     assert auth.to_swagger() == {
         'in': 'header',
@@ -1067,6 +1068,7 @@ def test_can_serialize_custom_authorizer():
             'type': 'token',
             'authorizerUri': 'myuri',
             'authorizerResultTtlInSeconds': 10,
+            'authorizerCredentials': 'role-arn',
         }
     }
 


### PR DESCRIPTION
This pulls in https://github.com/aws/chalice/pull/1303 and rebases it against develop.  I also made some minor changes to preserve the existing behavior in terms of the swagger doc we generate.