### PR TITLE
Dont hardcode boto3 version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -979,7 +979,7 @@ First, install boto3::
 
 Next, add ``boto3`` to your requirements.txt file::
 
-    $ echo 'boto3==1.3.1' >> requirements.txt
+    $ pip freeze | grep boto3 >> requirements.txt
 
 The requirements.txt file should be in the same directory that contains
 your ``app.py`` file.  Next, let's update our view code to use boto3:


### PR DESCRIPTION
Use pip freeze instead of referencing a hardcoded version of boto3

*Issue #, if available:*

*Description of changes:*
Small change to the readme around how to append the boto3 dependency to the requirements.txt file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
