### PR TITLE
Run tests without cond deps installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
 language: python
 sudo: false
+env:
+  global:
+    - INSTALL_STRING=".[event-file-poller]" TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
 matrix:
   include:
   - python: "3.8"
     dist: xenial
     sudo: true
-    env: TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
+    env: INSTALL_STRING="."
+  - python: "3.8"
+    dist: xenial
+    sudo: true
   - python: "3.7"
     dist: xenial
     sudo: true
-    env: TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
   - python: "3.6"
-    env: TEST_TYPE=prcheck HYPOTHESIS_PROFILE=ci
   - python: "2.7"
-    env: TEST_TYPE=prcheck-py2 HYPOTHESIS_PROFILE=ci
+    env: TEST_TYPE=prcheck-py2
 install:
   - pip install -r requirements-dev.txt -r requirements-docs.txt
-  - pip install -e .
-  - pip install -e ".[event-file-poller]"
+  - pip install -e "$INSTALL_STRING"
 script:
   - env
   - make $TEST_TYPE

--- a/chalice/cli/filewatch/eventbased.py
+++ b/chalice/cli/filewatch/eventbased.py
@@ -1,9 +1,8 @@
 import threading  # noqa
 
 from typing import Callable, Optional  # noqa
-import watchdog.observers
-from watchdog.events import FileSystemEventHandler
-from watchdog.events import FileSystemEvent  # noqa
+import watchdog.observers  # pylint: disable=import-error
+from watchdog import events  # pylint: disable=import-error
 
 from chalice.cli.filewatch import FileWatcher, WorkerProcess
 
@@ -27,7 +26,7 @@ class WatchdogFileWatcher(FileWatcher):
         observer.start()
 
 
-class WatchdogRestarter(FileSystemEventHandler):
+class WatchdogRestarter(events.FileSystemEventHandler):
 
     def __init__(self, restart_event):
         # type: (threading.Event) -> None
@@ -35,7 +34,7 @@ class WatchdogRestarter(FileSystemEventHandler):
         self.restart_event = restart_event
 
     def on_any_event(self, event):
-        # type: (FileSystemEvent) -> None
+        # type: (events.FileSystemEvent) -> None
         # If we modify a file we'll get a FileModifiedEvent
         # as well as a DirectoryModifiedEvent.
         # We only care about reloading is a file is modified.


### PR DESCRIPTION
This will catch the issue we ran into where watchdog
was always being imported (#1355).

Rather than run this for every python version and double
our test matrix, I just updated this to run on the latest
python version.  The types of problems this will catch aren't
tied to a single python version so we only need to run this
test once.