### PR TITLE
changes to previous LocalChalice approach to fixing chalice local mul…

### DIFF
--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -20,7 +20,6 @@ from chalice.local import NotAuthorizedError
 from chalice.local import ForbiddenError
 from chalice.local import InvalidAuthorizerError
 from chalice.local import LocalDevServer
-from chalice.local import LocalChalice
 
 
 AWS_REQUEST_ID_PATTERN = re.compile(
@@ -668,21 +667,6 @@ def test_can_provide_host_to_local_server(sample_app):
     assert dev_server.host == '0.0.0.0'
 
 
-def test_wraps_sample_app_with_local_chalice(sample_app):
-    dev_server = local.create_local_server(
-        sample_app, None, "127.0.0.1", 23456
-    )
-    assert isinstance(dev_server.app_object, LocalChalice)
-    assert dev_server.app_object._chalice is sample_app
-    assert dev_server.app_object.app_name is sample_app.app_name
-    dev_server.app_object.current_request = "foo"
-    assert dev_server.app_object.current_request == "foo"
-    assert (
-        dev_server.app_object.current_request
-        is not sample_app.current_request
-    )
-
-
 class TestLambdaContext(object):
     def test_can_get_remaining_time_once(self, lambda_context_args):
         time_source = FakeTimeSource([0, 5])
@@ -1083,10 +1067,3 @@ class TestLocalDevServer(object):
         )
 
         assert provided_args[0] == ('0.0.0.0', 8000)
-
-    def test_does_use_daemon_threads(self, sample_app):
-        server = LocalDevServer(
-            sample_app, Config(), '0.0.0.0', 8000
-        )
-
-        assert server.server.daemon_threads


### PR DESCRIPTION
…tithreading problems

*Issue #759

*Description of changes:*

- wrapping Chalice with LocalChalice didn't actually change how Chalice instances interacted with current_request internally (i.e. within __call__)
- this approach is much more hacky, but is required to force Chalice instances to interact with current_request in a thread-safe manner
- added a more useful unit test that actually ensures thread isolation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
