### PR TITLE
prepend `path.module` to zip path in generating terraform file

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -979,7 +979,8 @@ class TerraformCodeLocationPostProcessor(TemplatePostProcessor):
                 self._osutils.copy(r['filename'], asset_path)
                 copied = True
             r['filename'] = "${path.module}/deployment.zip"
-            r['source_code_hash'] = '${filebase64sha256("${path.module}/deployment.zip")}'
+            r['source_code_hash'] = \
+                '${filebase64sha256("${path.module}/deployment.zip")}'
 
 
 class TemplateMergePostProcessor(TemplatePostProcessor):

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -978,8 +978,8 @@ class TerraformCodeLocationPostProcessor(TemplatePostProcessor):
                 asset_path = os.path.join(outdir, 'deployment.zip')
                 self._osutils.copy(r['filename'], asset_path)
                 copied = True
-            r['filename'] = "./deployment.zip"
-            r['source_code_hash'] = '${filebase64sha256("./deployment.zip")}'
+            r['filename'] = "${path.module}/deployment.zip"
+            r['source_code_hash'] = '${filebase64sha256("${path.module}/deployment.zip")}'
 
 
 class TemplateMergePostProcessor(TemplatePostProcessor):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -81,9 +81,9 @@ def test_terraform_post_processor_moves_files_once():
         'old-dir.zip', os.path.join('outdir', 'deployment.zip'))
     assert mock_osutils.copy.call_count == 1
     assert template['resource']['aws_lambda_function'][
-        'foo']['filename'] == ('./deployment.zip')
+        'foo']['filename'] == ('${path.module}/deployment.zip')
     assert template['resource']['aws_lambda_function'][
-        'bar']['filename'] == ('./deployment.zip')
+        'bar']['filename'] == ('${path.module}/deployment.zip')
 
 
 def test_template_generator_default():


### PR DESCRIPTION
#1300

Added `${path.module}` to generated terraform script. This will make it usable as a terraform module


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
