### PR TITLE
Make current_request thread safe in local mode

### DIFF
--- a/.changes/next-release/36408038949-bugfix-local-5121.json
+++ b/.changes/next-release/36408038949-bugfix-local-5121.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "local",
+  "description": "Make ``current_request`` thread safe in local mode (#759)"
+}

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -21,7 +21,6 @@ from chalice.local import NotAuthorizedError
 from chalice.local import ForbiddenError
 from chalice.local import InvalidAuthorizerError
 from chalice.local import LocalDevServer
-from chalice.local import LocalChalice
 
 
 AWS_REQUEST_ID_PATTERN = re.compile(
@@ -689,21 +688,6 @@ def test_can_provide_host_to_local_server(sample_app):
     dev_server = local.create_local_server(sample_app, None, host='0.0.0.0',
                                            port=23456)
     assert dev_server.host == '0.0.0.0'
-
-
-def test_wraps_sample_app_with_local_chalice(sample_app):
-    dev_server = local.create_local_server(
-        sample_app, None, "127.0.0.1", 23456
-    )
-    assert isinstance(dev_server.app_object, LocalChalice)
-    assert dev_server.app_object._chalice is sample_app
-    assert dev_server.app_object.app_name is sample_app.app_name
-    dev_server.app_object.current_request = "foo"
-    assert dev_server.app_object.current_request == "foo"
-    assert (
-        dev_server.app_object.current_request
-        is not sample_app.current_request
-    )
 
 
 class TestLambdaContext(object):


### PR DESCRIPTION
This builds on https://github.com/aws/chalice/pull/1375
by ensuring we swap out the current request on the instance
of the running app.

I've also added a functional test to check for thread safety.

Long term, we should move to the forkingmixin, but it's too
drastic of a change to swap out for a bug fix so it will need
more vetting before we can switch over.

Fixes #759.
