### PR TITLE
Validate queue name in on_sqs_message registration

### DIFF
--- a/.changes/next-release/37309442039-enhancement-SQS-77311.json
+++ b/.changes/next-release/37309442039-enhancement-SQS-77311.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "SQS",
+  "description": "Validate queue name is used and not queue URL or ARN (#1388)"
+}

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -319,3 +319,15 @@ def test_valid_minimum_compression_size(sample_app):
     config = Config.create(chalice_app=sample_app,
                            minimum_compression_size=1)
     assert validate_configuration(config) is None
+
+
+def test_validate_sqs_queue_name(sample_app):
+
+    @sample_app.on_sqs_message(
+        queue='https://sqs.us-west-2.amazonaws.com/12345/myqueue')
+    def handler(event):
+        pass
+
+    config = Config.create(chalice_app=sample_app)
+    with pytest.raises(ValueError):
+        validate_configuration(config)


### PR DESCRIPTION
You'll now see:

```
 The 'queue' parameter for the '@app.on_sqs_message()' handler must be the name
  of the queue, not the queue URL or the queue ARN.  Invalid value:
 https://sqs.us-west-2.amazonaws.com/12345/mytestqueue
```

Fixes #1388 
