### PR TITLE
Add note about the context values being stringified

### DIFF
--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -158,6 +158,8 @@ URLs as well as the principal id of the user.  You can optionally
 return a dictionary of key value pairs (as the ``context`` kwarg).
 This dictionary will be passed through on subsequent requests.
 In our example above we're not using the context dictionary.
+API Gateway will convert all the values in the ``context``
+dictionary to string values.
 
 Now let's deploy our app.  As usual, we just need to run
 ``chalice deploy`` and chalice will automatically deploy all the


### PR DESCRIPTION
See: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html

Closes #1386