### PR TITLE
Fix regression when packaging pandas

### DIFF
--- a/.changes/next-release/26083360944-bugfix-packaging-16408.json
+++ b/.changes/next-release/26083360944-bugfix-packaging-16408.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "packaging",
+  "description": "Fix pandas packaging regression (#1398)"
+}

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import stat
 import uuid
 from zipfile import ZipFile
@@ -91,6 +92,18 @@ class TestPackage(object):
             'SQLAlchemy==1.3.13',
             contents=[
                 'sqlalchemy/__init__.py',
+            ],
+        )
+
+    @pytest.mark.skipif(sys.version_info[0] == 2,
+                        reason='pandas==1.0.3 is only suported on py3.')
+    def test_can_package_pandas(self, runner, app_skeleton):
+        self.assert_can_package_dependency(
+            runner,
+            app_skeleton,
+            'pandas==1.0.3',
+            contents=[
+                'pandas/_libs/__init__.py',
             ],
         )
 


### PR DESCRIPTION
Fixes #1398

This is a regression introduced in #1316.
As part of the original change, we added a condition
where we would download an sdist in the case where we only
had an incompatible-on-lambda .whl file.  This change altered
the logic slightly to download sdists before recategorizing
the second pass of .whl files.

That alone is still not enough to fix this issue.  After
the second pass where we download manylinux1 wheels, we now
no longer preserve the property that `all_deps = sdist + compat +
incompat`.  Specifically, it may be possible that we have two
wheels for one package (e.g a macOS wheel and now a manylinux1
wheel).  So we also need to update our list of incompatible
wheels to be "incompatible wheels that we still need to deal with."

And finally, this is all just a workaround to hide the actual
issue, which is that you can't get the name/version via
setuptools/egg_info because trying to do so results in:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/var/folders/rb/4c1d0xbd18g_wxjcjlvb0whn1cjh5m/T/tmp35v4q3md/pandas-1.0.3/setup.py", line 757, in <module>
    ext_modules=maybe_cythonize(extensions, compiler_directives=directives),
  File "/var/folders/rb/4c1d0xbd18g_wxjcjlvb0whn1cjh5m/T/tmp35v4q3md/pandas-1.0.3/setup.py", line 515, in maybe_cythonize
    raise RuntimeError("Cannot cythonize without Cython installed.")
RuntimeError: Cannot cythonize without Cython installed.
```

We fortunately don't have to deal with this issue for pandas because
we have a manylinux1 wheel available so we can skip the sdist
path entirely.  However, that part of the code doesn't check
returncodes so it fails with an opaque error.  We should probably
have a fallback (even if it's not 100% reliable) in this case.

I might take a crack at refactoring this packaging code, but for
now the immediate priority is fixing this regression, which is
what this change does.

cc @stealthycoin 