### PR TITLE
Mark blueprints as an accepted API

### DIFF
--- a/.changes/next-release/25801099573-feature-blueprints-84327.json
+++ b/.changes/next-release/25801099573-feature-blueprints-84327.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "blueprints",
+  "description": "Mark blueprints as an accepted API (#1250)"
+}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -989,7 +989,6 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
         self.log.setLevel(level)
 
     def register_blueprint(self, blueprint, name_prefix=None, url_prefix=None):
-        self._features_used.add('BLUEPRINTS')
         blueprint.register(self, options={'name_prefix': name_prefix,
                                           'url_prefix': url_prefix})
 

--- a/docs/source/topics/blueprints.rst
+++ b/docs/source/topics/blueprints.rst
@@ -2,21 +2,6 @@ Blueprints
 ==========
 
 
-.. warning::
-
-  Blueprints are considered an experimental API.  You'll need to opt-in
-  to this feature using the ``BLUEPRINTS`` feature flag:
-
-  .. code-block:: python
-
-    app = Chalice('myapp')
-    app.experimental_feature_flags.update([
-        'BLUEPRINTS'
-    ])
-
-  See :doc:`experimental` for more information.
-
-
 Chalice blueprints are used to organize your application into logical
 components.  Using a blueprint, you define your resources and decorators in
 modules outside of your ``app.py``.  You then register a blueprint in your main
@@ -73,9 +58,6 @@ imported when running in Lambda.  We'll now import this module in our
     from chalicelib.blueprints import extra_routes
 
     app = Chalice(app_name='blueprint-demo')
-    app.experimental_feature_flags.update([
-        'BLUEPRINTS'
-    ])
     app.register_blueprint(extra_routes)
 
 
@@ -215,9 +197,6 @@ In our ``app.py`` we'll register these blueprints:
     from chalicelib.api import myapi
 
     app = Chalice(app_name='blueprint-demo')
-    app.experimental_feature_flags.update([
-        'BLUEPRINTS'
-    ])
     app.register_blueprint(myevents)
     app.register_blueprint(myapi)
 

--- a/docs/source/topics/experimental.rst
+++ b/docs/source/topics/experimental.rst
@@ -46,7 +46,7 @@ tells you which feature flags you need to add::
     If you still like to use these experimental features, you can opt-in by adding this to your app.py file:
 
     app.experimental_feature_flags.update([
-        'BLUEPRINTS'
+        'FEATURE_FLAG_NAME'
     ])
 
 
@@ -76,17 +76,20 @@ The status of an experimental API can be:
   * - Feature
     - Feature Flag Name
     - Version Added
+    - Version Finalized
     - Status
     - GitHub Issue(s)
   * - :doc:`blueprints`
     - ``BLUEPRINTS``
     - 1.7.0
-    - Trial
+    - 1.15.0
+    - Accepted
     - `#1023 <https://github.com/aws/chalice/pull/1023>`__,
       `#651 <https://github.com/aws/chalice/pull/651>`__
   * - :doc:`websockets`
     - ``WEBSOCKETS``
     - 1.10.0
+    - n/a
     - Trial
     - `#1041 <https://github.com/aws/chalice/pull/1041>`__,
       `#1017 <https://github.com/aws/chalice/issues/1017>`__

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2103,19 +2103,6 @@ def test_every_decorator_added_to_blueprint():
         assert method_name in blueprint_api
 
 
-def test_blueprint_gated_behind_feature_flag():
-    # Blueprints won't validate unless you enable their feature flag.
-    myapp = app.Chalice('myapp')
-    bp = app.Blueprint('app.chalicelib.blueprints.foo')
-
-    @bp.route('/')
-    def index():
-        pass
-
-    myapp.register_blueprint(bp)
-    assert_requires_opt_in(myapp, flag='BLUEPRINTS')
-
-
 @pytest.mark.parametrize('input_dict', [
     {},
     {'key': []}


### PR DESCRIPTION
See #1250.  There has been no major feedback about the
feature that required changing the API.  It's stable and
hasn't changed from when it was first introduced.  We can
call this an accepted feature and guarantee backwards
compatibility.
