### PR TITLE
Fix pyyaml line in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'attrs>=19.3.0,<20.0.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',
-    'pyyaml>=5.3.1,<6.0.0'
+    'pyyaml>=5.3.1,<6.0.0',
     'wheel',
     'setuptools'
 ]


### PR DESCRIPTION
Originally caught in the PR for non aws partition support,
but I'd like to get this change in sooner rather than later.

Note that this doesn't cause issues because chalice will interpret
this as '<6.0.0wheel', and also wheel is already pulled in by another
package.
