### PR TITLE
Add script for generating docs for gh-pages

### DIFF
--- a/scripts/gh-page-docs
+++ b/scripts/gh-page-docs
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Run this from the rootdir of the repository:
+#
+# ./scripts/gh-page-docs
+#
+# This script will check the docs for errors, render them
+# to html, then copy them over to a local (separate) checkout
+# of this repo's gh-pages branch.
+# Do not run this with a virtualenv activated.  This is intended
+# to be run in CI systems where you start with system python.
+set -e
+
+CHECKOUT_DIR="/tmp/chalice-gh-doc-build"
+VENV_DIR="/tmp/chalice-gh-doc-build-venv37"
+
+
+echo "Setting up environment"
+python3 -m venv $VENV_DIR
+source "${VENV_DIR}/bin/activate"
+echo
+echo
+which python3
+python3 -c "import sys; print(sys.executable)"
+which pip3
+echo
+echo
+python3 -m pip install -e .
+python3 -m pip install -r requirements-dev.txt
+python3 -m pip install -r requirements-docs.txt
+
+
+# Don't allow docs to be deployed if there's any errors.
+echo "Linting docs and checking for errors"
+make doccheck
+
+echo "Building docs"
+cd docs
+make clean && make html
+
+echo
+echo "Copy docs to local checkout"
+rm -rf "${CHECKOUT_DIR}"
+git clone git://github.com/aws/chalice --branch gh-pages \
+	--single-branch ${CHECKOUT_DIR}
+cp -r build/html/* ${CHECKOUT_DIR}/
+
+echo "Commiting docs."
+cd ${CHECKOUT_DIR}
+git add -A .
+git commit -am "Updating generated documentation"
+git remote add upstream git@github.com:aws/chalice.git
+echo "Docs are available at ${CHECKOUT_DIR}"
+# This step is usually handled by the CI system that has access
+# to the creds needed to push back to github.
+echo "Run 'git push upstream gh-pages' to deploy the docs to github pages"


### PR DESCRIPTION
This is a script that will generate the html docs for chalice and place them in a local checkout of the `gh-pages` branch of chalice in `/tmp/chalice-gh-doc-build`.  You can then run `git push upstream gh-pages` to push them to gh-pages.  