### PR TITLE
Add support for OAuth scopes on routes

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -479,7 +479,7 @@ class RouteEntry(object):
 
     def __init__(self, view_function, view_name, path, method,
                  api_key_required=None, content_types=None,
-                 cors=False, authorizer=None):
+                 cors=False, authorizer=None, scopes=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
@@ -500,6 +500,7 @@ class RouteEntry(object):
             cors = None
         self.cors = cors
         self.authorizer = authorizer
+        self.scopes = scopes
 
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
@@ -896,6 +897,7 @@ class _HandlerRegistration(object):
             'content_types': actual_kwargs.pop('content_types',
                                                ['application/json']),
             'cors': actual_kwargs.pop('cors', self.api.cors),
+            'scopes': actual_kwargs.pop('scopes', None),
         }
         if route_kwargs['cors'] is None:
             route_kwargs['cors'] = self.api.cors

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -8,6 +8,7 @@ import json
 import traceback
 import decimal
 import base64
+import copy
 from collections import defaultdict
 
 
@@ -221,9 +222,13 @@ class CaseInsensitiveMapping(Mapping):
 
 class Authorizer(object):
     name = ''
+    scopes = []
 
     def to_swagger(self):
         raise NotImplementedError("to_swagger")
+
+    def with_scopes(self, scopes):
+        raise NotImplementedError("with_scopes")
 
 
 class IAMAuthorizer(Authorizer):
@@ -232,6 +237,7 @@ class IAMAuthorizer(Authorizer):
 
     def __init__(self):
         self.name = 'sigv4'
+        self.scopes = []
 
     def to_swagger(self):
         return {
@@ -241,12 +247,16 @@ class IAMAuthorizer(Authorizer):
             'x-amazon-apigateway-authtype': 'awsSigv4',
         }
 
+    def with_scopes(self, scopes):
+        raise NotImplementedError("with_scopes")
+
 
 class CognitoUserPoolAuthorizer(Authorizer):
 
     _AUTH_TYPE = 'cognito_user_pools'
 
-    def __init__(self, name, provider_arns, header='Authorization'):
+    def __init__(self, name, provider_arns, header='Authorization',
+                 scopes=None):
         self.name = name
         self._header = header
         if not isinstance(provider_arns, list):
@@ -257,6 +267,7 @@ class CognitoUserPoolAuthorizer(Authorizer):
                 "provider_arns should be a list of ARNs, received: %s"
                 % provider_arns)
         self._provider_arns = provider_arns
+        self.scopes = scopes or []
 
     def to_swagger(self):
         return {
@@ -270,18 +281,24 @@ class CognitoUserPoolAuthorizer(Authorizer):
             }
         }
 
+    def with_scopes(self, scopes):
+        authorizer_with_scopes = copy.deepcopy(self)
+        authorizer_with_scopes.scopes = scopes
+        return authorizer_with_scopes
+
 
 class CustomAuthorizer(Authorizer):
 
     _AUTH_TYPE = 'custom'
 
     def __init__(self, name, authorizer_uri, ttl_seconds=300,
-                 header='Authorization', invoke_role_arn=None):
+                 header='Authorization', invoke_role_arn=None, scopes=None):
         self.name = name
         self._header = header
         self._authorizer_uri = authorizer_uri
         self._ttl_seconds = ttl_seconds
         self._invoke_role_arn = invoke_role_arn
+        self.scopes = scopes or []
 
     def to_swagger(self):
         swagger = {
@@ -299,6 +316,11 @@ class CustomAuthorizer(Authorizer):
             swagger['x-amazon-apigateway-authorizer'][
                 'authorizerCredentials'] = self._invoke_role_arn
         return swagger
+
+    def with_scopes(self, scopes):
+        authorizer_with_scopes = copy.deepcopy(self)
+        authorizer_with_scopes.scopes = scopes
+        return authorizer_with_scopes
 
 
 class CORSConfig(object):
@@ -479,7 +501,7 @@ class RouteEntry(object):
 
     def __init__(self, view_function, view_name, path, method,
                  api_key_required=None, content_types=None,
-                 cors=False, authorizer=None, scopes=None):
+                 cors=False, authorizer=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
@@ -500,7 +522,6 @@ class RouteEntry(object):
             cors = None
         self.cors = cors
         self.authorizer = authorizer
-        self.scopes = scopes
 
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
@@ -897,7 +918,6 @@ class _HandlerRegistration(object):
             'content_types': actual_kwargs.pop('content_types',
                                                ['application/json']),
             'cors': actual_kwargs.pop('cors', self.api.cors),
-            'scopes': actual_kwargs.pop('scopes', None),
         }
         if route_kwargs['cors'] is None:
             route_kwargs['cors'] = self.api.cors
@@ -1187,9 +1207,10 @@ class BuiltinAuthConfig(object):
 # we would need more research to know for sure.  For now, this is a
 # special cased runtime class that knows about its config.
 class ChaliceAuthorizer(object):
-    def __init__(self, name, func):
+    def __init__(self, name, func, scopes=None):
         self.name = name
         self.func = func
+        self.scopes = scopes or []
         # This is filled in during the @app.authorizer()
         # processing.
         self.config = None
@@ -1205,6 +1226,11 @@ class ChaliceAuthorizer(object):
         return AuthRequest(event['type'],
                            event['authorizationToken'],
                            event['methodArn'])
+
+    def with_scopes(self, scopes):
+        authorizer_with_scopes = copy.deepcopy(self)
+        authorizer_with_scopes.scopes = scopes
+        return authorizer_with_scopes
 
 
 class AuthRequest(object):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -25,7 +25,9 @@ _BUILTIN_AUTH_FUNC = Callable[
 
 class Authorizer:
     name = ... # type: str
+    scopes = ... # type: List[str]
     def to_swagger(self) -> Dict[str, Any]: ...
+    def with_scopes(self, scopes: List[str]) -> Authorizer: ...
 
 
 class CognitoUserPoolAuthorizer(Authorizer): ...
@@ -96,7 +98,6 @@ class RouteEntry(object):
     content_types = ... # type: List[str]
     view_args = ... # type: List[str]
     cors = ... # type: CORSConfig
-    scopes = ... # type: List[str]
 
     def __init__(self,
                  view_function: Callable[..., Any],
@@ -105,7 +106,6 @@ class RouteEntry(object):
                  method: str,
                  api_key_required: Optional[bool]=None,
                  content_types: Optional[List[str]]=None,
-                 scopes: Optional[List[str]]=None,
                  authorizer: Optional[Union[Authorizer,
                                             ChaliceAuthorizer]]=None,
                  cors: Union[bool, CORSConfig]=False) -> None: ...
@@ -195,7 +195,9 @@ class Chalice(DecoratorAPI):
 class ChaliceAuthorizer(object):
     name = ... # type: str
     func = ... # type: _BUILTIN_AUTH_FUNC
+    scopes = ... # type: List[str]
     config = ... # type: BuiltinAuthConfig
+    def with_scopes(self, scopes: List[str]) -> ChaliceAuthorizer: ...
 
 
 class BuiltinAuthConfig(object):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -96,6 +96,7 @@ class RouteEntry(object):
     content_types = ... # type: List[str]
     view_args = ... # type: List[str]
     cors = ... # type: CORSConfig
+    scopes = ... # type: List[str]
 
     def __init__(self,
                  view_function: Callable[..., Any],
@@ -104,6 +105,7 @@ class RouteEntry(object):
                  method: str,
                  api_key_required: Optional[bool]=None,
                  content_types: Optional[List[str]]=None,
+                 scopes: Optional[List[str]]=None,
                  authorizer: Optional[Union[Authorizer,
                                             ChaliceAuthorizer]]=None,
                  cors: Union[bool, CORSConfig]=False) -> None: ...

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -150,8 +150,11 @@ class SwaggerGenerator(object):
             # file.
             current.setdefault('security', []).append({'api_key': []})
         if view.authorizer:
+            scopes = []  # type: List[str]
+            if view.scopes:
+                scopes = view.scopes
             current.setdefault('security', []).append(
-                {view.authorizer.name: []})
+                {view.authorizer.name: scopes})
         if view.view_args:
             self._add_view_args(current, view.view_args)
         return current

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -150,11 +150,8 @@ class SwaggerGenerator(object):
             # file.
             current.setdefault('security', []).append({'api_key': []})
         if view.authorizer:
-            scopes = []  # type: List[str]
-            if view.scopes:
-                scopes = view.scopes
             current.setdefault('security', []).append(
-                {view.authorizer.name: scopes})
+                {view.authorizer.name: view.authorizer.scopes})
         if view.view_args:
             self._add_view_args(current, view.view_args)
         return current

--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -223,6 +223,35 @@ For more information on custom authorizers, see the
 page in the API Gateway user guide.
 
 
+Scopes
+-------------------------
+
+OAuth 2.0 and OpenID Connect (OIDC) scopes can be used to implement access
+controls in your Chalice app. In Chalice, all scopes are configured per-route
+and specified using the ``scopes`` kwarg to an ``@app.route()`` call.
+
+To integrate Scopes with a Cognito Authorizer in Chalice, you'll need to have
+an existing `Cognito user pools`_ and `Cognito resource server`_ configured.
+Scopes for Cognito Authorizers need to include the full identifier
+which is ``resourceServerIdentifier/scopeName``.
+
+.. code-block:: python
+
+    from chalice import CognitoUserPoolAuthorizer
+
+    authorizer = CognitoUserPoolAuthorizer(
+        'MyPool', provider_arns=['arn:aws:cognito:...:userpool/name'])
+
+    @app.route('/user-pools', methods=['GET'], authorizer=authorizer, scopes=["https://mychaliceapp.example.com/todos.read"])
+    def authenticated():
+        return {"success": True}
+
+Scopes can also be used with custom authorizers. The custom authorizer will
+need to inspect the access token to determine if access should be granted
+based on the scopes configured for the route.
+
+
 .. _IAM permissions: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html
 .. _Cognito User Pools: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html
+.. _Cognito Resource Server: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-define-resource-servers.html
 .. _API Gateway documentation: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html

--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -227,13 +227,29 @@ Scopes
 -------------------------
 
 OAuth 2.0 and OpenID Connect (OIDC) scopes can be used to implement access
-controls in your Chalice app. In Chalice, all scopes are configured per-route
-and specified using the ``scopes`` kwarg to an ``@app.route()`` call.
+controls in your Chalice app. Scopes are supported when using the Cognito
+Authorizer, Custom Authorizers, and Built-In Authorizers.
 
 To integrate Scopes with a Cognito Authorizer in Chalice, you'll need to have
 an existing `Cognito user pools`_ and `Cognito resource server`_ configured.
 Scopes for Cognito Authorizers need to include the full identifier
 which is ``resourceServerIdentifier/scopeName``.
+
+Scopes can be configured per-authorizer using the ``scopes`` attribute.
+
+.. code-block:: python
+
+    from chalice import CognitoUserPoolAuthorizer
+
+    authorizer = CognitoUserPoolAuthorizer(
+        'MyPool', provider_arns=['arn:aws:cognito:...:userpool/name'],
+        scopes=["https://mychaliceapp.example.com/todos.read"])
+
+    @app.route('/user-pools', methods=['GET'], authorizer=authorizer)
+    def authenticated():
+        return {"success": True}
+
+Scopes can be configured per-route for an Authorizer using ``with_scopes``.
 
 .. code-block:: python
 
@@ -242,13 +258,16 @@ which is ``resourceServerIdentifier/scopeName``.
     authorizer = CognitoUserPoolAuthorizer(
         'MyPool', provider_arns=['arn:aws:cognito:...:userpool/name'])
 
-    @app.route('/user-pools', methods=['GET'], authorizer=authorizer, scopes=["https://mychaliceapp.example.com/todos.read"])
+    @app.route(
+        '/user-pools',
+        methods=['GET'],
+        authorizer=authorizer.with_scopes(["https://mychaliceapp.example.com/todos.read"]))
     def authenticated():
         return {"success": True}
 
-Scopes can also be used with custom authorizers. The custom authorizer will
-need to inspect the access token to determine if access should be granted
-based on the scopes configured for the route.
+Scopes can also be used with custom authorizers and built-in authorizers.
+These authorizers will need to inspect the access token to determine if access
+should be granted based on the scopes configured for the authorizer and route.
 
 
 .. _IAM permissions: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_controlling.html

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -430,6 +430,36 @@ def test_can_use_authorizer_object_with_role_arn(sample_app, swagger_gen):
     }
 
 
+def test_can_use_authorizer_object_scopes(sample_app, swagger_gen):
+    authorizer = CustomAuthorizer(
+        'MyAuth', authorizer_uri='auth-uri', header='Authorization',
+        invoke_role_arn='role-arn', scopes=["write:test", "read:test"])
+
+    @sample_app.route('/auth', authorizer=authorizer)
+    def auth():
+        return {'foo': 'bar'}
+
+    doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/auth']['get']
+    assert single_method.get('security') == [{
+        'MyAuth': ["write:test", "read:test"]
+    }]
+    security_definitions = doc['securityDefinitions']
+    assert 'MyAuth' in security_definitions
+    assert security_definitions['MyAuth'] == {
+        'type': 'apiKey',
+        'name': 'Authorization',
+        'in': 'header',
+        'x-amazon-apigateway-authtype': 'custom',
+        'x-amazon-apigateway-authorizer': {
+            'authorizerUri': 'auth-uri',
+            'type': 'token',
+            'authorizerResultTtlInSeconds': 300,
+            'authorizerCredentials': 'role-arn'
+        }
+    }
+
+
 def test_can_use_authorizer_object_with_scopes(sample_app, swagger_gen):
     authorizer = CustomAuthorizer(
         'MyAuth', authorizer_uri='auth-uri', header='Authorization',
@@ -437,8 +467,7 @@ def test_can_use_authorizer_object_with_scopes(sample_app, swagger_gen):
 
     @sample_app.route(
         '/auth',
-        authorizer=authorizer,
-        scopes=["write:test", "read:test"]
+        authorizer=authorizer.with_scopes(["write:test", "read:test"])
     )
     def auth():
         return {'foo': 'bar'}
@@ -486,8 +515,7 @@ def test_can_use_api_key_and_authorizers_with_scopes(sample_app, swagger_gen):
 
     @sample_app.route(
         '/auth',
-        authorizer=authorizer,
-        scopes=["write:test", "read:test"],
+        authorizer=authorizer.with_scopes(["write:test", "read:test"]),
         api_key_required=True
     )
     def auth():
@@ -553,8 +581,7 @@ def test_can_use_cognito_auth_object_with_scopes(sample_app, swagger_gen):
 
     @sample_app.route(
         '/api-key-required',
-        authorizer=authorizer,
-        scopes=["write:test", "read:test"]
+        authorizer=authorizer.with_scopes(["write:test", "read:test"])
     )
     def foo():
         return {}
@@ -621,6 +648,57 @@ def test_builtin_auth(sample_app):
         pass
 
     doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/auth']['get']
+    assert single_method.get('security') == [{'myauth': []}]
+    assert 'securityDefinitions' in doc
+    assert doc['securityDefinitions']['myauth'] == {
+        'in': 'header',
+        'name': 'Authorization',
+        'type': 'apiKey',
+        'x-amazon-apigateway-authtype': 'custom',
+        'x-amazon-apigateway-authorizer': {
+            'type': 'token',
+            'authorizerCredentials': 'arn:role',
+            'authorizerResultTtlInSeconds': 10,
+            'authorizerUri': ('arn:aws:apigateway:us-west-2:lambda:path'
+                              '/2015-03-31/functions/auth_arn/invocations'),
+        }
+    }
+
+
+def test_builtin_auth_with_scopes(sample_app):
+    swagger_gen = SwaggerGenerator(
+        region='us-west-2',
+        deployed_resources={
+            'api_handler_arn': 'lambda_arn',
+            'api_handler_name': 'api-dev',
+            'lambda_functions': {
+                'api-dev-myauth': {
+                    'arn': 'auth_arn',
+                    'type': 'authorizer',
+                }
+            }
+        }
+    )
+
+    @sample_app.authorizer(name='myauth',
+                           ttl_seconds=10,
+                           execution_role='arn:role')
+    def auth(auth_request):
+        pass
+
+    @sample_app.route(
+        '/auth',
+        authorizer=auth.with_scopes(["write:test", "read:test"])
+    )
+    def foo():
+        pass
+
+    doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/auth']['get']
+    assert single_method.get('security') == [{
+        'myauth': ["write:test", "read:test"]
+    }]
     assert 'securityDefinitions' in doc
     assert doc['securityDefinitions']['myauth'] == {
         'in': 'header',
@@ -663,6 +741,8 @@ def test_will_default_to_function_name_for_auth(sample_app):
         pass
 
     doc = swagger_gen.generate_swagger(sample_app)
+    single_method = doc['paths']['/auth']['get']
+    assert single_method.get('security') == [{'auth': []}]
     assert 'securityDefinitions' in doc
     assert doc['securityDefinitions']['auth'] == {
         'in': 'header',


### PR DESCRIPTION
This change adds support for a new `scopes` kwarg on routes which is used to add OAuth 2.0 and OpenID Connect style scopes for access control to methods in API Gateway.

Resolves #1326 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
