### PR TITLE
Get `current_app` via mounted Blueprint

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1573,6 +1573,15 @@ class Blueprint(DecoratorAPI):
         return self._current_app.current_request
 
     @property
+    def current_app(self):
+        if self._current_app is None:
+            raise RuntimeError(
+                "Can only access Blueprint.current_app if it's registered "
+                "to an app."
+            )
+        return self._current_app
+
+    @property
     def lambda_context(self):
         if self._current_app is None:
             raise RuntimeError(

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2073,12 +2073,12 @@ def test_can_call_current_app_on_blueprint_when_mounted(create_event):
 
     @bp.route('/appname')
     def appname():
-        return {"name": bp.current_app.app_name}
+        return {'name': bp.current_app.app_name}
 
     myapp.register_blueprint(bp)
     event = create_event('/appname', 'GET', {})
     response = json_response_body(myapp(event, context=None))
-    assert response == {"name": "myapp"}
+    assert response == {'name': 'myapp'}
 
 def test_can_call_lambda_context_on_blueprint_when_mounted(create_event):
     myapp = app.Chalice('myapp')

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2067,6 +2067,18 @@ def test_can_call_current_request_on_blueprint_when_mounted(create_event):
     assert isinstance(response, dict)
     assert response['method'] == 'GET'
 
+def test_can_call_current_app_on_blueprint_when_mounted(create_event):
+    myapp = app.Chalice('myapp')
+    bp = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @bp.route('/appname')
+    def appname():
+        return {"name": bp.current_app.app_name}
+
+    myapp.register_blueprint(bp)
+    event = create_event('/appname', 'GET', {})
+    response = json_response_body(myapp(event, context=None))
+    assert response == {"name": "myapp"}
 
 def test_can_call_lambda_context_on_blueprint_when_mounted(create_event):
     myapp = app.Chalice('myapp')

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2067,6 +2067,7 @@ def test_can_call_current_request_on_blueprint_when_mounted(create_event):
     assert isinstance(response, dict)
     assert response['method'] == 'GET'
 
+
 def test_can_call_current_app_on_blueprint_when_mounted(create_event):
     myapp = app.Chalice('myapp')
     bp = app.Blueprint('app.chalicelib.blueprints.foo')
@@ -2079,6 +2080,7 @@ def test_can_call_current_app_on_blueprint_when_mounted(create_event):
     event = create_event('/appname', 'GET', {})
     response = json_response_body(myapp(event, context=None))
     assert response == {'name': 'myapp'}
+
 
 def test_can_call_lambda_context_on_blueprint_when_mounted(create_event):
     myapp = app.Chalice('myapp')


### PR DESCRIPTION
*Issue #, if available:* #1094

*Description of changes:*

- Added in property to Blueprint class that returns the current app that the Blueprint is mounted on

- Added in test for new `current_app` property


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
