### PR TITLE
Issue#1470

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -77,6 +77,7 @@ class LocalARNBuilder(object):
         # with a '//'.
         if path != '/':
             path = path[1:]
+        path = path.split('?')[0]
         return self.ARN_FORMAT.format(
             region=self.LOCAL_REGION,
             account_id=self.LOCAL_ACCOUNT_ID,

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -999,9 +999,11 @@ class TestArnBuilder(object):
         assert arn == built_arn
 
     def test_build_arn_with_query_params(self, arn_builder):
-        arn = 'arn:aws:execute-api:mars-west-1:123456789012:ymy8tbxw7b/api/*/resource'
+        arn = ('arn:aws:execute-api:mars-west-1:123456789012:ymy8tbxw7b/api/'
+               '*/resource')
         built_arn = arn_builder.build_arn('*', '/resource?foo=bar')
         assert arn == built_arn
+
 
 @pytest.mark.parametrize('arn,pattern', [
     ('mars-west-2:123456789012:ymy8tbxw7b/api/GET/foo',

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -998,6 +998,10 @@ class TestArnBuilder(object):
         built_arn = arn_builder.build_arn('*', '/resource')
         assert arn == built_arn
 
+    def test_build_arn_with_query_params(self, arn_builder):
+        arn = 'arn:aws:execute-api:mars-west-1:123456789012:ymy8tbxw7b/api/*/resource'
+        built_arn = arn_builder.build_arn('*', '/resource?foo=bar')
+        assert arn == built_arn
 
 @pytest.mark.parametrize('arn,pattern', [
     ('mars-west-2:123456789012:ymy8tbxw7b/api/GET/foo',


### PR DESCRIPTION
*Issue #, if available:* Issue #1470 

*Description of changes:*
When using AuthResponse in authorizer, request with correct credentials but with query parameters in the url will throw 403 `{"Message": "User is not authorized to access this resource"}` error. 
When deployed the request will be with status 200 OK, so there is inconsistencies between local and deployed.

* Added a line that strips the query parameters form the path in LocalARNBuilder build_arn method
* Added a test for this 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
