### PR TITLE
First working version of request_authorizers

### DIFF
--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -3,7 +3,7 @@ from chalice.app import (
     ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
     NotFoundError, ConflictError, TooManyRequestsError, Response, CORSConfig,
     CustomAuthorizer, CognitoUserPoolAuthorizer, IAMAuthorizer,
-    UnprocessableEntityError, WebsocketDisconnectedError,
+    UnprocessableEntityError, WebsocketDisconnectedError, RequestAuthorizerIdentitySources,
     AuthResponse, AuthRoute, Cron, Rate, __version__ as chalice_version
 )
 # We're reassigning version here to keep mypy happy.

--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -660,7 +660,7 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
 
 class AppViewTransformer(ast.NodeTransformer):
     _CHALICE_DECORATORS = [
-        'route', 'authorizer', 'lambda_function',
+        'route', 'authorizer', 'request_authorizer', 'lambda_function',
         'schedule', 'on_s3_event', 'on_sns_message',
         'on_sqs_message', 'on_ws_connect', 'on_ws_message',
         'on_ws_disconnect',

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -626,6 +626,17 @@ class DecoratorAPI(object):
             }
         )
 
+    def request_authorizer(self, identity_sources, ttl_seconds=None, execution_role=None, name=None):
+        return self._create_registration_function(
+            handler_type='request_authorizer',
+            name=name,
+            registration_kwargs={
+                'ttl_seconds': ttl_seconds,
+                'execution_role': execution_role,
+                'identity_sources': identity_sources
+            }
+        )
+
     def on_s3_event(self, bucket, events=None,
                     prefix=None, suffix=None, name=None):
         return self._create_registration_function(
@@ -744,6 +755,8 @@ class DecoratorAPI(object):
             # Authorizer is special cased and doesn't quite fit the
             # EventSourceHandler pattern.
             return ChaliceAuthorizer(handler_name, user_handler)
+        if handler_type == 'request_authorizer':
+            return ChaliceRequestPayloadAuthorizer(handler_name, user_handler)
         return user_handler
 
     def _register_handler(self, handler_type, name,
@@ -900,6 +913,28 @@ class _HandlerRegistration(object):
             handler_string=handler_string,
             ttl_seconds=ttl_seconds,
             execution_role=execution_role,
+        )
+        wrapped_handler.config = auth_config
+        self.builtin_auth_handlers.append(auth_config)
+
+    def _register_request_authorizer(self, name, handler_string, wrapped_handler,
+                             kwargs, **unused):
+        actual_kwargs = kwargs.copy()
+        ttl_seconds = actual_kwargs.pop('ttl_seconds', None)
+        execution_role = actual_kwargs.pop('execution_role', None)
+        identity_sources = actual_kwargs.pop('identity_sources')
+        if not isinstance(identity_sources, RequestAuthorizerIdentitySources):
+            raise TypeError('TypeError: identity_sources must be an RequestAuthorizerIdentitySources instance')
+        if actual_kwargs:
+            raise TypeError(
+                'TypeError: authorizer() got unexpected keyword '
+                'arguments: %s' % ', '.join(list(actual_kwargs)))
+        auth_config = BuiltinAuthConfig(
+            name=name,
+            handler_string=handler_string,
+            ttl_seconds=ttl_seconds,
+            execution_role=execution_role,
+            identity_sources=identity_sources
         )
         wrapped_handler.config = auth_config
         self.builtin_auth_handlers.append(auth_config)
@@ -1177,12 +1212,13 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
 
 class BuiltinAuthConfig(object):
     def __init__(self, name, handler_string, ttl_seconds=None,
-                 execution_role=None):
+                 execution_role=None, identity_sources=None):
         # We'd also support all the misc config options you can set.
         self.name = name
         self.handler_string = handler_string
         self.ttl_seconds = ttl_seconds
         self.execution_role = execution_role
+        self.identity_sources = identity_sources
 
 
 # ChaliceAuthorizer is unique in that the runtime component (the thing
@@ -1233,11 +1269,77 @@ class ChaliceAuthorizer(object):
         return authorizer_with_scopes
 
 
+class ChaliceRequestPayloadAuthorizer(ChaliceAuthorizer):
+    _AUTH_TYPE = 'request'
+
+    def _transform_event(self, event):
+        request = RequestAuthorizerRequest(
+            event['type'],
+            event['methodArn'],
+            event.get('headers', {}),
+            event.get('queryStringParameters', {}),
+            event.get('stageVariables', {}),
+            event.get('requestContext', {}),
+        )
+        return request
+
+    def stringify_identity_sources(self):
+        prefixes = {
+            'headers': 'method.request.header',
+            'querystring': 'method.request.querystring',
+            'stage_variable': 'stageVariables',
+            'request_context': 'context'
+        }
+        result = ""
+        for source in vars(self.config.identity_sources):
+            prefix = prefixes.get(source)
+            if not getattr(self.config.identity_sources, source):
+                continue
+            for key in getattr(self.config.identity_sources, source):
+                src = ".".join([prefix, key])
+                result = src if result == "" else ", ".join([result, src])
+        return result
+
+    def to_swagger(self):
+        swagger = {
+            'type': 'apiKey',
+            'name': "Unused",
+            'in': 'header',
+            'x-amazon-apigateway-authtype': self._AUTH_TYPE,
+            'x-amazon-apigateway-authorizer': {
+                'type': 'request',
+                'identitySource': self.stringify_identity_sources(),
+                'authorizerResultTtlInSeconds': 0
+            }
+        }
+        return swagger
+
+
+class RequestAuthorizerIdentitySources:
+    def __init__(self, headers=None, querystring=None, stage_variables=None, context=None):
+        if not any([headers, querystring, stage_variables, context]):
+            raise ValueError('Must provide at least one identity source')  # TODO BETTER MESSAGE
+        self.headers = headers
+        self.querystring = querystring
+        self.stage_variables = stage_variables
+        self.context = context
+
+
 class AuthRequest(object):
     def __init__(self, auth_type, token, method_arn):
         self.auth_type = auth_type
         self.token = token
         self.method_arn = method_arn
+
+
+class RequestAuthorizerRequest(object):
+    def __init__(self, auth_type, method_arn, headers, query_string_parameters, stage_variables, reqest_context):
+        self.auth_type = auth_type
+        self.method_arn = method_arn
+        self.headers = headers
+        self.query_string_parameters = query_string_parameters
+        self.stage_variables = stage_variables
+        self.request_context = reqest_context
 
 
 class AuthResponse(object):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1286,7 +1286,7 @@ class ChaliceRequestPayloadAuthorizer(ChaliceAuthorizer):
     def stringify_identity_sources(self):
         prefixes = {
             'headers': 'method.request.header',
-            'querystring': 'method.request.querystring',
+            'query_params': 'method.request.querystring',
             'stage_variable': 'stageVariables',
             'request_context': 'context'
         }
@@ -1316,11 +1316,11 @@ class ChaliceRequestPayloadAuthorizer(ChaliceAuthorizer):
 
 
 class RequestAuthorizerIdentitySources:
-    def __init__(self, headers=None, querystring=None, stage_variables=None, context=None):
-        if not any([headers, querystring, stage_variables, context]):
+    def __init__(self, headers=None, query_params=None, stage_variables=None, context=None):
+        if not any([headers, query_params, stage_variables, context]):
             raise ValueError('Must provide at least one identity source')  # TODO BETTER MESSAGE
         self.headers = headers
-        self.querystring = querystring
+        self.query_params = query_params
         self.stage_variables = stage_variables
         self.context = context
 
@@ -1337,7 +1337,7 @@ class RequestAuthorizerRequest(object):
         self.auth_type = auth_type
         self.method_arn = method_arn
         self.headers = headers
-        self.query_string_parameters = query_string_parameters
+        self.query_params = query_string_parameters
         self.stage_variables = stage_variables
         self.request_context = reqest_context
 

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -107,7 +107,8 @@ class RouteEntry(object):
                  api_key_required: Optional[bool]=None,
                  content_types: Optional[List[str]]=None,
                  authorizer: Optional[Union[Authorizer,
-                                            ChaliceAuthorizer]]=None,
+                                            ChaliceAuthorizer,
+                                            ChaliceRequestPayloadAuthorizer]]=None,
                  cors: Union[bool, CORSConfig]=False) -> None: ...
 
     def _parse_view_args(self) -> List[str]: ...
@@ -136,6 +137,12 @@ class DecoratorAPI(object):
                    ttl_seconds: Optional[int]=None,
                    execution_role: Optional[str]=None,
                    name: Optional[str]=None) -> Callable[..., Any]: ...
+
+    def request_authorizer(self,
+               identity_sources: RequestAuthorizerIdentitySources,
+               ttl_seconds: Optional[int]=None,
+               execution_role: Optional[str]=None,
+               name: Optional[str]=None) -> Callable[..., Any]: ...
 
     def on_s3_event(self,
                     bucket: str,
@@ -198,6 +205,15 @@ class ChaliceAuthorizer(object):
     scopes = ... # type: List[str]
     config = ... # type: BuiltinAuthConfig
     def with_scopes(self, scopes: List[str]) -> ChaliceAuthorizer: ...
+
+
+class ChaliceRequestPayloadAuthorizer(ChaliceAuthorizer):
+    name = ... # type: str
+    func = ... # type: _BUILTIN_AUTH_FUNC
+    scopes = ... # type: List[str]
+    config = ... # type: BuiltinAuthConfig
+    def with_scopes(self, scopes: List[str]) -> ChaliceRequestPayloadAuthorizer: ...
+    def stringify_identity_sources(self) -> str: ...
 
 
 class BuiltinAuthConfig(object):
@@ -284,3 +300,9 @@ class CloudWatchEventConfig(BaseEventSourceConfig):
 class Blueprint(DecoratorAPI):
     current_request = ... # type: Request
     lambda_context = ... # type: LambdaContext
+
+class RequestAuthorizerIdentitySources(object):
+    headers= ... # type: Optional[List[str]]=None
+    query_strings=... # type: Optional[List[str]]=None
+    stage_variables=... # type: Optional[List[str]]=None
+    context=... # type: Optional[List[str]]=None

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -400,7 +400,7 @@ class LocalGatewayAuthorizer(object):
     def _check_request_has_indentity_sources(self, authorizer, event, lambda_context):
         event_keys = {
             'headers': 'headers',
-            'querystring': 'queryStringParameters',
+            'query_params': 'queryStringParameters',
             'stage_variables': 'stageVariables',
             'request_context': 'requestContext'
         }

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -30,6 +30,7 @@ from typing import (
 from chalice.app import Chalice  # noqa
 from chalice.app import CORSConfig  # noqa
 from chalice.app import ChaliceAuthorizer  # noqa
+from chalice.app import ChaliceRequestPayloadAuthorizer
 from chalice.app import CognitoUserPoolAuthorizer  # noqa
 from chalice.app import RouteEntry  # noqa
 from chalice.app import Request  # noqa
@@ -185,7 +186,7 @@ class LambdaEventConverter(object):
                 },
                 'path': path.split('?')[0],
             },
-            'headers': {k.lower(): v for k, v in headers.items()},
+            'headers': dict(headers),
             'pathParameters': view_route.captured,
             'stageVariables': {},
         }
@@ -342,6 +343,28 @@ class LocalGatewayAuthorizer(object):
                                "principalId": cognito_username}
                 lambda_event = self._update_lambda_event(lambda_event,
                                                          auth_result)
+        if isinstance(authorizer, ChaliceRequestPayloadAuthorizer):
+            arn = self._arn_builder.build_arn(method, raw_path)
+            auth_event = self._prepare_request_authorizer_event(arn, lambda_event,
+                                                        lambda_context)
+            self._check_request_has_indentity_sources(authorizer, auth_event, lambda_context)
+            try:
+                auth_result = authorizer(auth_event, lambda_context)
+            except (KeyError, TypeError):
+                raise ForbiddenError(
+                    {'message': "FU"}
+                )
+            authed = self._check_can_invoke_view_function(arn, auth_result)
+            if authed:
+                lambda_event = self._update_lambda_event(lambda_event, auth_result)
+            else:
+                raise ForbiddenError(
+                    {'x-amzn-RequestId': lambda_context.aws_request_id,
+                     'x-amzn-ErrorType': 'AccessDeniedException'},
+                    (b'{"Message": '
+                     b'"User is not authorized to access this resource"}'))
+            return lambda_event, lambda_context
+
         if not isinstance(authorizer, ChaliceAuthorizer):
             # Currently the only supported local authorizer is the
             # BuiltinAuthConfig type. Anything else we will err on the side of
@@ -373,6 +396,24 @@ class LocalGatewayAuthorizer(object):
                 (b'{"Message": '
                  b'"User is not authorized to access this resource"}'))
         return lambda_event, lambda_context
+
+    def _check_request_has_indentity_sources(self, authorizer, event, lambda_context):
+        event_keys = {
+            'headers': 'headers',
+            'querystring': 'queryStringParameters',
+            'stage_variables': 'stageVariables',
+            'request_context': 'requestContext'
+        }
+        sources = authorizer.config.identity_sources
+        for source in vars(sources):
+            if getattr(sources, source):
+                for key in getattr(sources, source):
+                    if key not in event[event_keys.get(source)]:
+                        raise NotAuthorizedError(
+                            {'x-amzn-RequestId': lambda_context.aws_request_id,
+                             'x-amzn-ErrorType': 'UnauthorizedException'},
+                            b'{"message":"Unauthorized"}')
+
 
     def _check_can_invoke_view_function(self, arn, auth_result):
         # type: (str, ResponseType) -> bool
@@ -428,6 +469,22 @@ class LocalGatewayAuthorizer(object):
                  'x-amzn-ErrorType': 'UnauthorizedException'},
                 b'{"message":"Unauthorized"}')
         authorizer_event['methodArn'] = arn
+        return authorizer_event
+
+    def _prepare_request_authorizer_event(self, arn, lambda_event, lambda_context):
+        # type: (str, EventType, LambdaContext) -> EventType
+        """Translate event for an authorizer input."""
+        authorizer_event = lambda_event.copy()
+        authorizer_event['type'] = 'REQUEST'
+        authorizer_event['methodArn'] = arn
+        authorizer_event['resource'] = None
+        authorizer_event['path'] = None
+        authorizer_event['httpMethod'] = None
+        authorizer_event['headers'] = lambda_event['headers']
+        authorizer_event['queryStringParameters'] = lambda_event.get('multiValueQueryStringParameters', {})
+        authorizer_event['pathParameters'] = lambda_event['pathParameters']
+        authorizer_event['stageVariables'] = lambda_event['stageVariables']
+        authorizer_event['requestContext'] = lambda_event['requestContext']
         return authorizer_event
 
     def _decode_jwt_payload(self, jwt):


### PR DESCRIPTION
*Issue #, if available:* Issue #1467 

*Description of changes:*
* Added request_authroizer to DecoratorAPI
* Added new class through which the user would define Request payload identity source
   eg `identity_sources = RequestPayloadIdentitySources(headers=['Authorization', 'Testing'], query_params=['something']`
* Added new authorizer class `ChaliceRequestPayloadAuthorizer`
* Changed BuildinAutoConfig to accept identity_sources so the same config can be reused
* Added new RequestAuthRequest (rename could be welcomed) that holds the arugments necessary for authorization
* Added first tests

TODO: 
[ ] Some refactorings
[ ] Add more tests
[ ] Consider renaming some of the classes and arguments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
