### PR TITLE
Add support for automatic layers in Chalice

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -319,6 +319,42 @@ class TypedAWSClient(object):
             vpc_config['SecurityGroupIds'] = security_group_ids
         return vpc_config
 
+    def publish_layer(self, layer_name, zip_contents, runtime):
+        # type: (str, bytes, str) -> str
+        try:
+            return self._client('lambda').publish_layer_version(
+                LayerName=layer_name,
+                Content={'ZipFile': zip_contents},
+                CompatibleRuntimes=[runtime])['LayerVersionArn']
+        except _REMOTE_CALL_ERRORS as e:
+            context = LambdaErrorContext(
+                layer_name,
+                'publish_layer_version',
+                len(zip_contents)
+            )
+            raise self._get_lambda_code_deployment_error(e, context)
+
+    def delete_layer_version(self, layer_version_arn):
+        # type: (str) -> None
+        client = self._client('lambda')
+        _, layer_name, version_number = layer_version_arn.rsplit(":", 2)
+        try:
+            return client.delete_layer_version(
+                LayerName=layer_name,
+                VersionNumber=int(version_number))
+        except client.exceptions.ResourceNotFoundException:
+            pass
+
+    def get_layer_version(self, layer_version_arn):
+        # type: (str) -> Dict[str, Any]
+        client = self._client('lambda')
+        try:
+            return client.get_layer_version_by_arn(
+                Arn=layer_version_arn)
+        except client.exceptions.ResourceNotFoundException:
+            pass
+        return {}
+
     def create_function(self,
                         function_name,               # type: str
                         role_arn,                    # type: str

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -295,10 +295,10 @@ class Config(object):
         # type: () -> bool
         v = self._chain_lookup('automatic_layer',
                                varies_per_chalice_stage=True,
-                               varies_per_function=True)
+                               varies_per_function=False)
         if v is None:
-            return True
-        return bool(v)
+            return False
+        return v
 
     @property
     def iam_role_arn(self):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -291,6 +291,16 @@ class Config(object):
                                   varies_per_function=True)
 
     @property
+    def automatic_layer(self):
+        # type: () -> bool
+        v = self._chain_lookup('automatic_layer',
+                               varies_per_chalice_stage=True,
+                               varies_per_function=True)
+        if v is None:
+            return True
+        return bool(v)
+
+    @property
     def iam_role_arn(self):
         # type: () -> str
         return self._chain_lookup('iam_role_arn',

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -27,6 +27,16 @@ class ApplicationGraphBuilder(object):
         # type: (Config, str) -> models.Application
         resources = []  # type: List[models.Model]
         deployment = models.DeploymentPackage(models.Placeholder.BUILD_STAGE)
+        if config.automatic_layer:
+            resources.append(
+                models.LambdaLayer(
+                    resource_name='layer',
+                    layer_name='%s-%s-%s' % (
+                        config.app_name or 'chalice',
+                        config.chalice_stage, 'layer'),
+                    runtime=config.lambda_python_version,
+                    deployment_package=models.DeploymentPackage(
+                        models.Placeholder.BUILD_STAGE)))
         for function in config.chalice_app.pure_lambda_functions:
             resource = self._create_lambda_model(
                 config=config, deployment=deployment,

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -22,21 +22,12 @@ class ApplicationGraphBuilder(object):
     def __init__(self):
         # type: () -> None
         self._known_roles = {}  # type: Dict[str, models.IAMRole]
+        self._managed_layer = None  # type: Optional[models.LambdaLayer]
 
     def build(self, config, stage_name):
         # type: (Config, str) -> models.Application
         resources = []  # type: List[models.Model]
         deployment = models.DeploymentPackage(models.Placeholder.BUILD_STAGE)
-        if config.automatic_layer:
-            resources.append(
-                models.LambdaLayer(
-                    resource_name='layer',
-                    layer_name='%s-%s-%s' % (
-                        config.app_name or 'chalice',
-                        config.chalice_stage, 'layer'),
-                    runtime=config.lambda_python_version,
-                    deployment_package=models.DeploymentPackage(
-                        models.Placeholder.BUILD_STAGE)))
         for function in config.chalice_app.pure_lambda_functions:
             resource = self._create_lambda_model(
                 config=config, deployment=deployment,
@@ -359,6 +350,21 @@ class ApplicationGraphBuilder(object):
         )
         return resource
 
+    def _get_managed_lambda_layer(self, config):
+        # type: (Config) -> Optional[models.LambdaLayer]
+        if not config.automatic_layer:
+            return None
+        if self._managed_layer is None:
+            self._managed_layer = models.LambdaLayer(
+                resource_name='managed-layer',
+                layer_name='%s-%s-%s' % (
+                    config.app_name, config.chalice_stage, 'managed-layer'),
+                runtime=config.lambda_python_version,
+                deployment_package=models.DeploymentPackage(
+                    models.Placeholder.BUILD_STAGE)
+            )
+        return self._managed_layer
+
     def _get_role_reference(self, config, stage_name, function_name):
         # type: (Config, str, str) -> models.IAMRole
         role = self._create_role_reference(config, stage_name, function_name)
@@ -468,7 +474,8 @@ class ApplicationGraphBuilder(object):
             security_group_ids=security_group_ids,
             subnet_ids=subnet_ids,
             reserved_concurrency=config.reserved_concurrency,
-            layers=lambda_layers
+            layers=lambda_layers,
+            managed_layer=self._get_managed_lambda_layer(config),
         )
         self._inject_role_traits(function, role)
         return function

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -91,7 +91,7 @@ import botocore.exceptions
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError
 from botocore.session import Session  # noqa
-from typing import Optional, Dict, List, Any, Type  # noqa
+from typing import Optional, Dict, List, Any, Type, cast  # noqa
 
 from chalice.config import Config  # noqa
 from chalice.compat import is_broken_pipe_error
@@ -115,6 +115,10 @@ from chalice.deploy.packager import PipRunner
 from chalice.deploy.packager import SubprocessPip
 from chalice.deploy.packager import DependencyBuilder as PipDependencyBuilder
 from chalice.deploy.packager import LambdaDeploymentPackager
+from chalice.deploy.packager import AppOnlyDeploymentPackager
+from chalice.deploy.packager import LayerDeploymentPackager
+from chalice.deploy.packager import BaseLambdaDeploymentPackager  # noqa
+from chalice.deploy.packager import EmptyPackageError
 from chalice.deploy.planner import PlanStage
 from chalice.deploy.planner import RemoteState
 from chalice.deploy.planner import NoopPlanner
@@ -268,7 +272,7 @@ def _create_deployer(session,       # type: Session
         application_builder=ApplicationGraphBuilder(),
         deps_builder=DependencyBuilder(),
         build_stage=create_build_stage(
-            osutils, UI(), TemplatedSwaggerGenerator(),
+            osutils, UI(), TemplatedSwaggerGenerator(), config
         ),
         plan_stage=PlanStage(
             osutils=osutils, remote_state=RemoteState(
@@ -280,24 +284,40 @@ def _create_deployer(session,       # type: Session
     )
 
 
-def create_build_stage(osutils, ui, swagger_gen):
-    # type: (OSUtils, UI, SwaggerGenerator) -> BuildStage
+def create_build_stage(osutils, ui, swagger_gen, config):
+    # type: (OSUtils, UI, SwaggerGenerator, Config) -> BuildStage
     pip_runner = PipRunner(pip=SubprocessPip(osutils=osutils),
                            osutils=osutils)
     dependency_builder = PipDependencyBuilder(
         osutils=osutils,
         pip_runner=pip_runner
     )
+    deployment_packager = cast(BaseDeployStep, None)
+    if config.automatic_layer:
+        deployment_packager = ManagedLayerDeploymentPackager(
+            lambda_packager=AppOnlyDeploymentPackager(
+                osutils=osutils,
+                dependency_builder=dependency_builder,
+                ui=ui,
+            ),
+            layer_packager=LayerDeploymentPackager(
+                osutils=osutils,
+                dependency_builder=dependency_builder,
+                ui=ui,
+            )
+        )
+    else:
+        deployment_packager = DeploymentPackager(
+            packager=LambdaDeploymentPackager(
+                osutils=osutils,
+                dependency_builder=dependency_builder,
+                ui=ui,
+            )
+        )
     build_stage = BuildStage(
         steps=[
             InjectDefaults(),
-            DeploymentPackager(
-                packager=LambdaDeploymentPackager(
-                    osutils=osutils,
-                    dependency_builder=dependency_builder,
-                    ui=ui,
-                ),
-            ),
+            deployment_packager,
             PolicyGenerator(
                 policy_gen=AppPolicyGenerator(
                     osutils=osutils
@@ -362,6 +382,9 @@ class Deployer(object):
             config, chalice_stage_name)
         resources = self._deps_builder.build_dependencies(application)
         self._build_stage.execute(config, resources)
+        # Rebuild dependencies in case the build stage modified
+        # the app graph.
+        resources = self._deps_builder.build_dependencies(application)
         plan = self._plan_stage.execute(resources)
         self._sweeper.execute(plan, config)
         self._executor.execute(plan)
@@ -422,20 +445,57 @@ class DeploymentPackager(BaseDeployStep):
         # type: (LambdaDeploymentPackager) -> None
         self._packager = packager
 
-    def handle_lambdalayer(self, config, resource):
-        # type: (Config, models.LambdaLayer) -> None
-        if isinstance(resource.deployment_package.filename,
-                      models.Placeholder):
-            zip_filename = self._packager.create_layer_package(
-                config.project_dir, config.lambda_python_version)
-            resource.deployment_package.filename = zip_filename
-
     def handle_deploymentpackage(self, config, resource):
         # type: (Config, models.DeploymentPackage) -> None
         if isinstance(resource.filename, models.Placeholder):
             zip_filename = self._packager.create_deployment_package(
                 config.project_dir, config.lambda_python_version)
             resource.filename = zip_filename
+
+
+class ManagedLayerDeploymentPackager(BaseDeployStep):
+    # If we're creating a layer for non-app code there's two different
+    # packagers we need.  One for the Lambda functions (app code) and
+    # one for the Lambda layer (requirements.txt + vendor).
+    def __init__(self,
+                 lambda_packager,  # type: BaseLambdaDeploymentPackager
+                 layer_packager,   # type: BaseLambdaDeploymentPackager
+                 ):
+        # type: (...) -> None
+        self._lambda_packager = lambda_packager
+        self._layer_packager = layer_packager
+
+    def handle_lambdafunction(self, config, resource):
+        # type: (Config, models.LambdaFunction) -> None
+        if isinstance(resource.deployment_package.filename,
+                      models.Placeholder):
+            zip_filename = self._lambda_packager.create_deployment_package(
+                config.project_dir, config.lambda_python_version
+            )
+            resource.deployment_package.filename = zip_filename
+        if resource.managed_layer is not None and \
+                resource.managed_layer.is_empty:
+            # Lambda doesn't allow us to create an empty layer so if we've
+            # tried to create the deploment package and determined it's empty
+            # we should remove the managed layer from the model entirely so
+            # downstream consumers don't have to worry about it.
+            resource.managed_layer = None
+
+    def handle_lambdalayer(self, config, resource):
+        # type: (Config, models.LambdaLayer) -> None
+        if isinstance(resource.deployment_package.filename,
+                      models.Placeholder):
+            try:
+                zip_filename = self._layer_packager.create_deployment_package(
+                    config.project_dir, config.lambda_python_version
+                )
+                resource.deployment_package.filename = zip_filename
+            except EmptyPackageError:
+                # An empty package is not valid in Lambda.  There's
+                # no point in trying to represent it in the model
+                # because nothing downstream (planner, SAM/tf) can
+                # consume as a useful entity.
+                resource.is_empty = True
 
 
 class SwaggerBuilder(BaseDeployStep):

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -422,6 +422,14 @@ class DeploymentPackager(BaseDeployStep):
         # type: (LambdaDeploymentPackager) -> None
         self._packager = packager
 
+    def handle_lambdalayer(self, config, resource):
+        # type: (Config, models.LambdaLayer) -> None
+        if isinstance(resource.deployment_package.filename,
+                      models.Placeholder):
+            zip_filename = self._packager.create_layer_package(
+                config.project_dir, config.lambda_python_version)
+            resource.deployment_package.filename = zip_filename
+
     def handle_deploymentpackage(self, config, resource):
         # type: (Config, models.DeploymentPackage) -> None
         if isinstance(resource.filename, models.Placeholder):
@@ -624,6 +632,11 @@ class DeploymentReporter(object):
     def _report_lambda_function(self, resource, report):
         # type: (Dict[str, Any], List[str]) -> None
         report.append('  - Lambda ARN: %s' % resource['lambda_arn'])
+
+    def _report_lambda_layer(self, resource, report):
+        # type: (Dict[str, Any], List[str]) -> None
+        report.append('  - Lambda Layer ARN: %s' % (
+            resource['layer_version_arn']))
 
     def _default_report(self, resource, report):
         # type: (Dict[str, Any], List[str]) -> None

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -181,6 +181,11 @@ class LambdaLayer(ManagedModel):
     layer_name = attrib()             # type: str
     runtime = attrib()                # type: str
     deployment_package = attrib()     # type: DeploymentPackage
+    is_empty = attrib(default=False)  # type: bool
+
+    def dependencies(self):
+        # type: () -> List[Model]
+        return [self.deployment_package]
 
 
 @attrs
@@ -198,11 +203,18 @@ class LambdaFunction(ManagedModel):
     security_group_ids = attrib()     # type: List[str]
     subnet_ids = attrib()             # type: List[str]
     reserved_concurrency = attrib()   # type: int
+    # These are customer created layers.
     layers = attrib()                 # type: List[str]
+    managed_layer = attrib(
+        default=None)                 # type: Opt[LambdaLayer]
 
     def dependencies(self):
         # type: () -> List[Model]
-        return [self.role, self.deployment_package]
+        resources = []  # type: List[Model]
+        if self.managed_layer is not None:
+            resources.append(self.managed_layer)
+        resources.extend([self.role, self.deployment_package])
+        return resources
 
 
 @attrs

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -176,6 +176,14 @@ class ManagedIAMRole(IAMRole, ManagedModel):
 
 
 @attrs
+class LambdaLayer(ManagedModel):
+    resource_type = 'lambda_layer'
+    layer_name = attrib()             # type: str
+    runtime = attrib()                # type: str
+    deployment_package = attrib()     # type: DeploymentPackage
+
+
+@attrs
 class LambdaFunction(ManagedModel):
     resource_type = 'lambda_function'
     function_name = attrib()          # type: str

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -4,11 +4,13 @@ import inspect
 import re
 import subprocess
 import logging
+import functools
 from email.parser import FeedParser
 from email.message import Message  # noqa
 from zipfile import ZipFile  # noqa
 
 from typing import Any, Set, List, Optional, Tuple, Iterable, Callable  # noqa
+from typing import Iterator  # noqa
 from typing import Dict, MutableMapping, AnyStr  # noqa
 from chalice.compat import pip_import_string
 from chalice.compat import pip_no_compile_c_env_vars
@@ -53,7 +55,11 @@ class PackageDownloadError(Exception):
     """Generic networking error during a package download."""
 
 
-class LambdaDeploymentPackager(object):
+class EmptyPackageError(Exception):
+    """A deployment package cannot be an empty zip file."""
+
+
+class BaseLambdaDeploymentPackager(object):
     _CHALICE_LIB_DIR = 'chalicelib'
     _VENDOR_DIR = 'vendor'
 
@@ -70,63 +76,17 @@ class LambdaDeploymentPackager(object):
         self._dependency_builder = dependency_builder
         self._ui = ui
 
+    def create_deployment_package(self, project_dir, python_version):
+        # type: (str, str) -> str
+        raise NotImplementedError("create_deployment_package")
+
     def _get_requirements_filename(self, project_dir):
         # type: (str) -> str
         # Gets the path to a requirements.txt file out of a project dir path
         return self._osutils.joinpath(project_dir, 'requirements.txt')
 
-    def create_layer_package(self, project_dir, python_version):
-        # type: (str, str) -> str
-        msg = "Creating layer package."
-        self._ui.write("%s\n" % msg)
-        logger.debug(msg)
-        # Now we need to create a zip file and add in the site-packages
-        # dir first, followed by the app_dir contents next.
-        package_filename = self.deployment_package_filename(
-            project_dir, python_version, 'layer-')
-        requirements_filepath = self._get_requirements_filename(project_dir)
-        with self._osutils.tempdir() as site_packages_dir:
-            try:
-                abi = self._RUNTIME_TO_ABI[python_version]
-                self._dependency_builder.build_site_packages(
-                    abi, requirements_filepath, site_packages_dir)
-            except MissingDependencyError as e:
-                missing_packages = '\n'.join([p.identifier for p
-                                              in e.missing])
-                self._ui.write(
-                    MISSING_DEPENDENCIES_TEMPLATE % missing_packages)
-            dirname = self._osutils.dirname(
-                self._osutils.abspath(package_filename))
-            if not self._osutils.directory_exists(dirname):
-                self._osutils.makedirs(dirname)
-            with self._osutils.open_zip(package_filename, 'w',
-                                        self._osutils.ZIP_DEFLATED) as z:
-                self._add_py_deps(z, site_packages_dir)
-                self._add_vendor_files(z, self._osutils.joinpath(
-                    project_dir, self._VENDOR_DIR))
-        return package_filename
-
-    def create_deployment_package(self, project_dir, python_version,
-                                  package_filename=None):
-        # type: (str, str, Optional[str]) -> str
-        msg = "Creating deployment package."
-        self._ui.write("%s\n" % msg)
-        logger.debug(msg)
-        # Now we need to create a zip file and add in the site-packages
-        # dir first, followed by the app_dir contents next.
-        package_filename = self.deployment_package_filename(
-            project_dir, python_version)
-        dirname = self._osutils.dirname(
-            self._osutils.abspath(package_filename))
-        if not self._osutils.directory_exists(dirname):
-            self._osutils.makedirs(dirname)
-        with self._osutils.open_zip(package_filename, 'w',
-                                    self._osutils.ZIP_DEFLATED) as z:
-            self._add_app_files(z, project_dir)
-        return package_filename
-
-    def _add_vendor_files(self, zipped, dirname):
-        # type: (ZipFile, str) -> None
+    def _add_vendor_files(self, zipped, dirname, prefix=''):
+        # type: (ZipFile, str, str) -> None
         if not self._osutils.directory_exists(dirname):
             return
         prefix_len = len(dirname) + 1
@@ -134,12 +94,13 @@ class LambdaDeploymentPackager(object):
                                                      followlinks=True):
             for filename in filenames:
                 full_path = self._osutils.joinpath(root, filename)
-                zip_path = 'python/%s' % full_path[prefix_len:]
+                zip_path = full_path[prefix_len:]
+                if prefix:
+                    zip_path = self._osutils.joinpath(prefix, zip_path)
                 zipped.write(full_path, zip_path)
 
-    def deployment_package_filename(
-            self, project_dir, python_version, prefix=""):
-        # type: (str, str, str) -> str
+    def deployment_package_filename(self, project_dir, python_version):
+        # type: (str, str) -> str
         # Computes the name of the deployment package zipfile
         # based on a hash of the requirements file.
         # This is done so that we only "pip install -r requirements.txt"
@@ -148,17 +109,24 @@ class LambdaDeploymentPackager(object):
         # to the end of the filename since the the dependencies may not change
         # but if the python version changes then the dependencies need to be
         # re-downloaded since they will not be compatible.
+        return self._deployment_package_filename(project_dir, python_version)
+
+    def _deployment_package_filename(self, project_dir, python_version,
+                                     prefix=''):
+        # type: (str, str, str) -> str
         requirements_filename = self._get_requirements_filename(project_dir)
         hash_contents = self._hash_project_dir(
-            requirements_filename, self._osutils.joinpath(project_dir,
-                                                          self._VENDOR_DIR))
+            requirements_filename,
+            self._osutils.joinpath(project_dir, self._VENDOR_DIR),
+            project_dir
+        )
         filename = '%s%s-%s.zip' % (prefix, hash_contents, python_version)
         deployment_package_filename = self._osutils.joinpath(
             project_dir, '.chalice', 'deployments', filename)
         return deployment_package_filename
 
-    def _add_py_deps(self, zip_fileobj, deps_dir):
-        # type: (ZipFile, str) -> None
+    def _add_py_deps(self, zip_fileobj, deps_dir, prefix=''):
+        # type: (ZipFile, str, str) -> None
         prefix_len = len(deps_dir) + 1
         for root, dirnames, filenames in self._osutils.walk(deps_dir):
             if root == deps_dir and 'chalice' in dirnames:
@@ -167,33 +135,45 @@ class LambdaDeploymentPackager(object):
                 dirnames.remove('chalice')
             for filename in filenames:
                 full_path = self._osutils.joinpath(root, filename)
-                zip_path = 'python/%s' % full_path[prefix_len:]
+                zip_path = full_path[prefix_len:]
+                if prefix:
+                    zip_path = self._osutils.joinpath(prefix, zip_path)
                 zip_fileobj.write(full_path, zip_path)
 
     def _add_app_files(self, zip_fileobj, project_dir):
         # type: (ZipFile, str) -> None
+        for full_path, zip_path in self._iter_app_filenames(project_dir):
+            zip_fileobj.write(full_path, zip_path)
+
+    def _iter_app_filenames(self, project_dir):
+        # type: (str) -> Iterator[Tuple[str, str]]
         chalice_router = inspect.getfile(app)
         if chalice_router.endswith('.pyc'):
             chalice_router = chalice_router[:-1]
-        zip_fileobj.write(chalice_router, 'chalice/app.py')
+        yield (chalice_router, 'chalice/app.py')
 
         chalice_init = inspect.getfile(chalice)
         if chalice_init.endswith('.pyc'):
             chalice_init = chalice_init[:-1]
-        zip_fileobj.write(chalice_init, 'chalice/__init__.py')
+        yield (chalice_init, 'chalice/__init__.py')
+        yield (self._osutils.joinpath(project_dir, 'app.py'), 'app.py')
+        for filename in self._iter_chalice_lib_if_needed(project_dir):
+            yield filename
 
-        zip_fileobj.write(self._osutils.joinpath(project_dir, 'app.py'),
-                          'app.py')
-        self._add_chalice_lib_if_needed(project_dir, zip_fileobj)
-
-    def _hash_project_dir(self, requirements_filename, vendor_dir):
-        # type: (str, str) -> str
+    def _hash_project_dir(self, requirements_filename, vendor_dir,
+                          project_dir):
+        # type: (str, str, str) -> str
         if not self._osutils.file_exists(requirements_filename):
             contents = b''
         else:
             contents = self._osutils.get_file_contents(
                 requirements_filename, binary=True)
         h = hashlib.md5(contents)
+        for filename, _ in self._iter_app_filenames(project_dir):
+            with self._osutils.open(filename, 'rb') as f:
+                reader = functools.partial(f.read, 1024 * 1024)
+                for chunk in iter(reader, b''):
+                    h.update(chunk)
         if self._osutils.directory_exists(vendor_dir):
             self._hash_vendor_dir(vendor_dir, h)
         return h.hexdigest()
@@ -214,8 +194,8 @@ class LambdaDeploymentPackager(object):
                     # infer the types.  So the compromise here is to
                     # just write it the idiomatic way and have pylint
                     # ignore this warning.
-                    # pylint: disable=cell-var-from-loop
-                    for chunk in iter(lambda: f.read(1024 * 1024), b''):
+                    reader = functools.partial(f.read, 1024 * 1024)
+                    for chunk in iter(reader, b''):
                         md5.update(chunk)
 
     def inject_latest_app(self, deployment_package_filename, project_dir):
@@ -260,8 +240,8 @@ class LambdaDeploymentPackager(object):
         return filename == 'app.py' or filename.startswith(
             ('chalicelib/', 'chalice/'))
 
-    def _add_chalice_lib_if_needed(self, project_dir, zip_fileobj):
-        # type: (str, ZipFile) -> None
+    def _iter_chalice_lib_if_needed(self, project_dir):
+        # type: (str) -> Iterator[Tuple[str, str]]
         libdir = self._osutils.joinpath(project_dir, self._CHALICE_LIB_DIR)
         if self._osutils.directory_exists(libdir):
             for rootdir, _, filenames in self._osutils.walk(libdir):
@@ -270,7 +250,169 @@ class LambdaDeploymentPackager(object):
                     zip_path = self._osutils.joinpath(
                         self._CHALICE_LIB_DIR,
                         fullpath[len(libdir) + 1:])
-                    zip_fileobj.write(fullpath, zip_path)
+                    yield (fullpath, zip_path)
+
+    def _create_output_dir_if_needed(self, package_filename):
+        # type: (str) -> None
+        dirname = self._osutils.dirname(
+            self._osutils.abspath(package_filename))
+        if not self._osutils.directory_exists(dirname):
+            self._osutils.makedirs(dirname)
+
+    def _build_python_dependencies(self, python_version, requirements_filepath,
+                                   site_packages_dir):
+        # type: (str, str, str) -> None
+        try:
+            abi = self._RUNTIME_TO_ABI[python_version]
+            self._dependency_builder.build_site_packages(
+                abi, requirements_filepath, site_packages_dir)
+        except MissingDependencyError as e:
+            missing_packages = '\n'.join([p.identifier for p in e.missing])
+            self._ui.write(MISSING_DEPENDENCIES_TEMPLATE % missing_packages)
+
+
+class LambdaDeploymentPackager(BaseLambdaDeploymentPackager):
+    def create_deployment_package(self, project_dir, python_version):
+        # type: (str, str) -> str
+        msg = "Creating deployment package."
+        self._ui.write("%s\n" % msg)
+        logger.debug(msg)
+        package_filename = self.deployment_package_filename(
+            project_dir, python_version)
+        if self._osutils.file_exists(package_filename):
+            self._ui.write("Reusing existing deployment package.\n")
+            return package_filename
+        self._create_output_dir_if_needed(package_filename)
+        with self._osutils.tempdir() as tmpdir:
+            requirements_filepath = self._get_requirements_filename(
+                project_dir)
+            self._build_python_dependencies(python_version,
+                                            requirements_filepath,
+                                            site_packages_dir=tmpdir)
+            with self._osutils.open_zip(package_filename, 'w',
+                                        self._osutils.ZIP_DEFLATED) as z:
+                self._add_py_deps(z, deps_dir=tmpdir)
+                self._add_app_files(z, project_dir)
+                self._add_vendor_files(z, self._osutils.joinpath(
+                    project_dir, self._VENDOR_DIR))
+        return package_filename
+
+
+class AppOnlyDeploymentPackager(BaseLambdaDeploymentPackager):
+    def create_deployment_package(self, project_dir, python_version):
+        # type: (str, str) -> str
+        msg = "Creating app deployment package."
+        self._ui.write("%s\n" % msg)
+        logger.debug(msg)
+        package_filename = self.deployment_package_filename(project_dir,
+                                                            python_version)
+        if self._osutils.file_exists(package_filename):
+            self._ui.write("  Reusing existing app deployment package.\n")
+            return package_filename
+        self._create_output_dir_if_needed(package_filename)
+        with self._osutils.open_zip(package_filename, 'w',
+                                    self._osutils.ZIP_DEFLATED) as z:
+            self._add_app_files(z, project_dir)
+        return package_filename
+
+    def deployment_package_filename(self, project_dir, python_version):
+        # type: (str, str) -> str
+        return self._deployment_package_filename(project_dir, python_version,
+                                                 prefix='appcode-')
+
+    def _deployment_package_filename(self, project_dir, python_version,
+                                     prefix=''):
+        # type: (str, str, str) -> str
+        h = hashlib.md5(b'')
+        for filename, _ in self._iter_app_filenames(project_dir):
+            with self._osutils.open(filename, 'rb') as f:
+                reader = functools.partial(f.read, 1024 * 1024)
+                for chunk in iter(reader, b''):
+                    h.update(chunk)
+        digest = h.hexdigest()
+        filename = '%s%s-%s.zip' % (prefix, digest, python_version)
+        deployment_package_filename = self._osutils.joinpath(
+            project_dir, '.chalice', 'deployments', filename)
+        return deployment_package_filename
+
+
+class LayerDeploymentPackager(BaseLambdaDeploymentPackager):
+
+    # A Lambda layer will unzip into the /opt directory instead of
+    # the current working directory of the function.  This means
+    # in order for our python dependencies to work we need.
+    _PREFIX = 'python/lib/%s/site-packages'
+
+    def create_deployment_package(self, project_dir, python_version):
+        # type: (str, str) -> str
+        msg = "Creating shared layer deployment package."
+        self._ui.write("%s\n" % msg)
+        logger.debug(msg)
+        package_filename = self.deployment_package_filename(
+            project_dir, python_version)
+        self._create_output_dir_if_needed(package_filename)
+        if self._osutils.file_exists(package_filename):
+            self._ui.write(
+                "  Reusing existing shared layer deployment package.\n")
+            return package_filename
+        with self._osutils.tempdir() as tmpdir:
+            requirements_filepath = self._get_requirements_filename(
+                project_dir)
+            self._build_python_dependencies(python_version,
+                                            requirements_filepath,
+                                            site_packages_dir=tmpdir)
+            with self._osutils.open_zip(package_filename, 'w',
+                                        self._osutils.ZIP_DEFLATED) as z:
+                prefix = self._PREFIX % python_version
+                self._add_py_deps(z, deps_dir=tmpdir, prefix=prefix)
+                self._add_vendor_files(z, self._osutils.joinpath(
+                    project_dir, self._VENDOR_DIR), prefix=prefix)
+        self._check_valid_package(package_filename)
+        return package_filename
+
+    def _check_valid_package(self, package_filename):
+        # type: (str) -> None
+        # Lambda does not allow empty deployment packages, so if there are no
+        # requirements.txt deps or anything in vendor/, we need to let the
+        # call know that we couldn't generate a useful deployment package
+        # for them.  The caller will then need make the appropriate adjustments
+        # i.e remove that LambdaLayer model from the app.
+        with self._osutils.open_zip(package_filename,
+                                    'r', self._osutils.ZIP_DEFLATED) as z:
+            total_size = sum([f.file_size for f in z.infolist()])
+            # We have to check the total archive size, Lambda will still error
+            # out if you have a zip file with all empty files.  It's not enough
+            # to check if the zipfile is empty.
+            if not total_size > 0:
+                # We want to make sure we remove any deployment packages we
+                # know are invalid, we don't want them being used as cache
+                # hits in subsequent create_deployment_package() requests.
+                self._osutils.remove_file(package_filename)
+                raise EmptyPackageError(package_filename)
+
+    def deployment_package_filename(self, project_dir, python_version):
+        # type: (str, str) -> str
+        return self._deployment_package_filename(project_dir, python_version,
+                                                 prefix='managed-layer-')
+
+    def _deployment_package_filename(self, project_dir, python_version,
+                                     prefix=''):
+        # type: (str, str, str) -> str
+        requirements_filename = self._get_requirements_filename(project_dir)
+        if not self._osutils.file_exists(requirements_filename):
+            contents = b''
+        else:
+            contents = self._osutils.get_file_contents(
+                requirements_filename, binary=True)
+        h = hashlib.md5(contents)
+        vendor_dir = self._osutils.joinpath(project_dir, self._VENDOR_DIR)
+        if self._osutils.directory_exists(vendor_dir):
+            self._hash_vendor_dir(vendor_dir, h)
+        hash_contents = h.hexdigest()
+        filename = '%s%s-%s.zip' % (prefix, hash_contents, python_version)
+        deployment_package_filename = self._osutils.joinpath(
+            project_dir, '.chalice', 'deployments', filename)
+        return deployment_package_filename
 
 
 class DependencyBuilder(object):

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -98,6 +98,16 @@ class RemoteState(object):
             function_arn=deployed_values['lambda_arn'],
         )
 
+    def _resource_exists_lambdalayer(self, resource):
+        # type: (models.LambdaLayer) -> bool
+        try:
+            deployed_values = self._deployed_resources.resource_values(
+                resource.resource_name)
+        except ValueError:
+            return False
+        return bool(self._client.get_layer_version(
+            deployed_values['layer_version_arn']))
+
     def _resource_exists_lambdafunction(self, resource):
         # type: (models.LambdaFunction) -> bool
         return self._client.lambda_function_exists(resource.function_name)
@@ -346,6 +356,41 @@ class PlanStage(object):
                 value=resource.domain_name
             )
         ])
+
+    def _plan_lambdalayer(self, resource):
+        # type: (models.LambdaLayer) -> Sequence[InstructionMsg]
+
+        api_calls = []  # type: List[InstructionMsg]
+        filename = cast(str, resource.deployment_package.filename)
+
+        # Automatically clean up old layer versions.
+        # https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+        msg = 'Creating'
+        if self._remote_state.resource_exists(resource):
+            state = self._remote_state.resource_deployed_values(resource)
+            api_calls.append(
+                models.APICall(
+                    method_name='delete_layer_version',
+                    params={'layer_version_arn': state['layer_version_arn']}
+                )
+            )
+            msg = 'Updating'
+
+        api_calls.extend([(
+            models.APICall(
+                method_name='publish_layer',
+                params={'layer_name': resource.layer_name,
+                        'zip_contents': self._osutils.get_file_contents(
+                            filename, binary=True),
+                        'runtime': resource.runtime},
+                output_var='layer_version_arn'
+            ), "%s lambda layer: %s\n" % (msg, resource.layer_name)),
+            models.RecordResourceVariable(
+                resource_type='lambda_layer',
+                resource_name=resource.resource_name,
+                name='layer_version_arn',
+                variable_name='layer_version_arn',
+        )])
         return api_calls
 
     def _plan_lambdafunction(self, resource):
@@ -363,7 +408,9 @@ class PlanStage(object):
         if resource.reserved_concurrency is None:
             concurrency_api_call = models.APICall(
                 method_name='delete_function_concurrency',
-                params={'function_name': resource.function_name},
+                params={
+                    'function_name': resource.function_name,
+                },
                 output_var='reserved_concurrency_result'
             )
         else:
@@ -380,6 +427,10 @@ class PlanStage(object):
                 % resource.function_name
             )
 
+        layers = [Variable('layer_version_arn')]  # type: List[Any]
+        if resource.layers:
+            layers.extend(resource.layers)
+
         api_calls = []  # type: List[InstructionMsg]
         if not self._remote_state.resource_exists(resource):
             params = {
@@ -395,8 +446,9 @@ class PlanStage(object):
                 'memory_size': resource.memory_size,
                 'security_group_ids': resource.security_group_ids,
                 'subnet_ids': resource.subnet_ids,
-                'layers': resource.layers
+                'layers': layers
             }
+
             api_calls.extend([
                 (models.APICall(
                     method_name='create_function',
@@ -425,7 +477,7 @@ class PlanStage(object):
                 'memory_size': resource.memory_size,
                 'security_group_ids': resource.security_group_ids,
                 'subnet_ids': resource.subnet_ids,
-                'layers': resource.layers
+                'layers': layers
             }
             api_calls.extend([
                 (models.APICall(

--- a/chalice/deploy/sweeper.py
+++ b/chalice/deploy/sweeper.py
@@ -8,6 +8,7 @@ from typing import ( # noqa
     Sequence,
     cast,
 )
+from typing import List, Dict, Tuple  # noqa
 
 from chalice.config import Config, DeployedResources  # noqa
 from chalice.deploy import models
@@ -205,6 +206,16 @@ class ResourceSweeper(object):
             ),
             'message': msg
         }
+
+    def _delete_lambda_layer(self, resource_values):
+        # type: (Dict[str, str]) -> Tuple[List[models.APICall], Dict[int, str]]
+        apicall = models.APICall(
+            method_name='delete_layer_version',
+            params={'layer_version_arn': resource_values[
+                'layer_version_arn']})
+        return [apicall], {
+            id(apicall): "Deleting layer version: %s\n" % resource_values[
+                'layer_version_arn']}
 
     def _delete_iam_role(self, resource_values):
         # type: (Dict[str, Any]) -> ResourceValueType

--- a/chalice/deploy/sweeper.py
+++ b/chalice/deploy/sweeper.py
@@ -8,7 +8,6 @@ from typing import ( # noqa
     Sequence,
     cast,
 )
-from typing import List, Dict, Tuple  # noqa
 
 from chalice.config import Config, DeployedResources  # noqa
 from chalice.deploy import models
@@ -208,14 +207,18 @@ class ResourceSweeper(object):
         }
 
     def _delete_lambda_layer(self, resource_values):
-        # type: (Dict[str, str]) -> Tuple[List[models.APICall], Dict[int, str]]
+        # type: (Dict[str, str]) -> ResourceValueType
         apicall = models.APICall(
             method_name='delete_layer_version',
             params={'layer_version_arn': resource_values[
                 'layer_version_arn']})
-        return [apicall], {
-            id(apicall): "Deleting layer version: %s\n" % resource_values[
-                'layer_version_arn']}
+        return {
+            'instructions': (apicall,),
+            'message': (
+                "Deleting layer version: %s\n"
+                % resource_values['layer_version_arn']
+            )
+        }
 
     def _delete_iam_role(self, resource_values):
         # type: (Dict[str, Any]) -> ResourceValueType

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -172,6 +172,7 @@ class SAMTemplateGenerator(TemplateGenerator):
         # type: (Config, PackageOptions) -> None
         super(SAMTemplateGenerator, self).__init__(config, options)
         self._seen_names = set([])  # type: Set[str]
+        self._chalice_layer = ""
 
     def generate(self, resources):
         # type: (List[models.Model]) -> Dict[str, Any]
@@ -180,6 +181,20 @@ class SAMTemplateGenerator(TemplateGenerator):
         for resource in resources:
             self.dispatch(resource, template)
         return template
+
+    def _generate_lambdalayer(self, resource, template):
+        # type: (models.LambdaLayer, Dict[str, Any]) -> None
+        layer = to_cfn_resource_name(
+            resource.resource_name)
+        template['Resources'][layer] = {
+            "Type": "AWS::Serverless::LayerVersion",
+            "Properties": {
+                "CompatibleRuntimes": [resource.runtime],
+                "ContentUri": resource.deployment_package.filename,
+                "LayerName": resource.layer_name
+            }
+        }
+        self._chalice_layer = resource.layer_name
 
     def _generate_scheduledevent(self, resource, template):
         # type: (models.ScheduledEvent, Dict[str, Any]) -> None
@@ -252,10 +267,15 @@ class SAMTemplateGenerator(TemplateGenerator):
             }
             lambdafunction_definition['Properties'].update(
                 reserved_concurrency_config)
-        if resource.layers:
+
+        layers = resource.layers or []  # type: List[Any]
+        if self._chalice_layer:
+            layers.insert(0, {'Ref': self._chalice_layer})
+
+        if layers:
             layers_config = {
-                'Layers': resource.layers
-            }  # type: Dict[str, List[str]]
+                'Layers': layers
+            }  # type: Dict[str, Any]
             lambdafunction_definition['Properties'].update(layers_config)
 
         resources[cfn_name] = lambdafunction_definition
@@ -1133,13 +1153,17 @@ class SAMCodeLocationPostProcessor(TemplatePostProcessor):
         # somehow, which isn't currently possible.
         copied = False
         for resource in template['Resources'].values():
-            if resource['Type'] != 'AWS::Serverless::Function':
-                continue
-            original_location = resource['Properties']['CodeUri']
-            new_location = os.path.join(outdir, 'deployment.zip')
-            if not copied:
+            if resource['Type'] == 'AWS::Serverless::Function':
+                original_location = resource['Properties']['CodeUri']
+                new_location = os.path.join(outdir, 'deployment.zip')
+                if not copied:
+                    self._osutils.copy(original_location, new_location)
+                    copied = True
+                resource['Properties']['CodeUri'] = './deployment.zip'
+            elif resource['Type'] == 'AWS::Serverless::LayerVersion':
+                original_location = resource['Properties']['ContentUri']
+                new_location = os.path.join(outdir, 'layer-deployment.zip')
                 self._osutils.copy(original_location, new_location)
-                copied = True
             resource['Properties']['CodeUri'] = './deployment.zip'
 
 

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -135,6 +135,15 @@ seconds.
 A list of Lambda Layers arns. This value can be provided per stage as well as
 per Lambda function. See `AWS Lambda Layers Configuration`_.
 
+
+``automatic_layers``
+~~~~~~~~~~~~~~~~~~~~
+
+Indicates whether chalice will automatically construct a single
+stage layer for all Lambda functions with requirements.txt libraries and
+vendored libraries.  Boolean value defaults to ``false`` if not specified.
+
+
 .. _custom-domain-config-options:
 
 ``api_gateway_custom_domain``

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -274,7 +274,7 @@ def test_can_package_with_single_file(runner):
         assert os.path.isfile('package.zip')
         with zipfile.ZipFile('package.zip', 'r') as f:
             assert sorted(f.namelist()) == [
-                'deployment.zip', 'layer-deployment.zip', 'sam.json']
+                'deployment.zip', 'sam.json']
 
 
 def test_package_terraform_err_with_single_file_or_merge(runner):

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -273,7 +273,8 @@ def test_can_package_with_single_file(runner):
         assert result.exit_code == 0, result.output
         assert os.path.isfile('package.zip')
         with zipfile.ZipFile('package.zip', 'r') as f:
-            assert sorted(f.namelist()) == ['deployment.zip', 'sam.json']
+            assert sorted(f.namelist()) == [
+                'deployment.zip', 'layer-deployment.zip', 'sam.json']
 
 
 def test_package_terraform_err_with_single_file_or_merge(runner):

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -122,7 +122,7 @@ def test_no_error_message_printed_on_empty_reqs_file(tmpdir,
     appdir = _create_app_structure(tmpdir)
     appdir.join('app.py').write('# Foo')
     appdir.join('requirements.txt').write('\n')
-    chalice_deployer.create_deployment_package(
+    chalice_deployer.create_layer_package(
         str(appdir), 'python2.7')
     out, err = capfd.readouterr()
     assert err.strip() == ''
@@ -201,10 +201,10 @@ def test_vendor_dir_included(tmpdir, chalice_deployer):
     vendor = appdir.mkdir('vendor')
     extra_package = vendor.mkdir('mypackage')
     extra_package.join('__init__.py').write('# Test package')
-    name = chalice_deployer.create_deployment_package(
+    name = chalice_deployer.create_layer_package(
         str(appdir), 'python2.7')
     with zipfile.ZipFile(name) as f:
-        _assert_in_zip('mypackage/__init__.py', b'# Test package', f)
+        _assert_in_zip('python/mypackage/__init__.py', b'# Test package', f)
 
 
 @slow
@@ -213,14 +213,14 @@ def test_subsequent_deploy_replaces_vendor_dir(tmpdir, chalice_deployer):
     vendor = appdir.mkdir('vendor')
     extra_package = vendor.mkdir('mypackage')
     extra_package.join('__init__.py').write('# v1')
-    name = chalice_deployer.create_deployment_package(
+    name = chalice_deployer.create_layer_package(
         str(appdir), 'python2.7')
     # Now we update a package in vendor/ with a new version.
     extra_package.join('__init__.py').write('# v2')
-    name = chalice_deployer.create_deployment_package(
+    name = chalice_deployer.create_layer_package(
         str(appdir), 'python2.7')
     with zipfile.ZipFile(name) as f:
-        _assert_in_zip('mypackage/__init__.py', b'# v2', f)
+        _assert_in_zip('python/mypackage/__init__.py', b'# v2', f)
 
 
 @slow
@@ -302,6 +302,33 @@ def test_chalice_runtime_injected_on_change(tmpdir, chalice_deployer):
         assert 'chalice/app.py' in z.namelist()
 
 
+@slow
+def test_layer_dep_bundling(tmpdir):
+    appdir = _create_app_structure(tmpdir)
+    builder = mock.Mock(spec=DependencyBuilder)
+    fake_package = mock.Mock(spec=Package)
+    fake_package.identifier = 'foo==1.2'
+
+    def build_site_packages(abi, requirements_filepath, site_packages_dir):
+        pkgdir = os.path.join(site_packages_dir, 'foo')
+        os.mkdir(pkgdir)
+        with open(os.path.join(pkgdir, '__init__.py'), 'w') as fh:
+            fh.write('# test lib')
+
+    builder.build_site_packages.side_effect = build_site_packages
+    ui = mock.Mock(spec=chalice.utils.UI)
+    osutils = chalice.utils.OSUtils()
+    packager = LambdaDeploymentPackager(
+        osutils=osutils,
+        dependency_builder=builder,
+        ui=ui,
+    )
+
+    name = packager.create_layer_package(str(appdir), 'python2.7')
+    with zipfile.ZipFile(name) as f:
+        _assert_in_zip('python/foo/__init__.py', b'# test lib', f)
+
+
 def test_does_handle_missing_dependency_error(tmpdir):
     appdir = _create_app_structure(tmpdir)
     builder = mock.Mock(spec=DependencyBuilder)
@@ -316,7 +343,7 @@ def test_does_handle_missing_dependency_error(tmpdir):
         dependency_builder=builder,
         ui=ui,
     )
-    packager.create_deployment_package(str(appdir), 'python2.7')
+    packager.create_layer_package(str(appdir), 'python2.7')
 
     output = ''.join([call[0][0] for call in ui.write.call_args_list])
     assert 'Could not install dependencies:\nfoo==1.2' in output

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -495,6 +495,67 @@ class TestPlanCreateUpdateDomainName(BasePlannerTests):
 
 
 class TestPlanLambdaFunction(BasePlannerTests):
+
+    def test_can_create_layer(self):
+        layer = models.LambdaLayer(
+            resource_name='layer',
+            layer_name='bar',
+            runtime='python2.7',
+            deployment_package=models.DeploymentPackage(
+                filename='foo')
+        )
+        plan = self.determine_plan(layer)
+        expected = [models.APICall(
+            method_name='publish_layer',
+            params={
+                'layer_name': 'bar',
+                'zip_contents': mock.ANY,
+                'runtime': 'python2.7'})
+        ]
+        self.assert_apicall_equals(plan[0], expected[0])
+        assert list(self.last_plan.messages.values()) == [
+            'Creating lambda layer: bar\n',
+        ]
+
+    def test_can_update_layer(self):
+        layer = models.LambdaLayer(
+            resource_name='layer',
+            layer_name='bar',
+            runtime='python2.7',
+            deployment_package=models.DeploymentPackage(
+                filename='foo')
+        )
+        copy_of_layer = attr.evolve(layer)
+        self.remote_state.declare_resource_exists(
+            copy_of_layer,
+            layer_version_arn='arn:bar:4'
+        )
+
+        plan = self.determine_plan(layer)
+        expected = [
+            models.APICall(
+                method_name='delete_layer_version',
+                params={'layer_version_arn': 'arn:bar:4'}),
+            models.APICall(
+                method_name='publish_layer',
+                params={
+                    'layer_name': 'bar',
+                    'zip_contents': mock.ANY,
+                    'runtime': 'python2.7'}),
+            models.RecordResourceVariable(
+                resource_type='lambda_layer',
+                resource_name='layer',
+                name='layer_version_arn',
+                variable_name='layer_version_arn')
+        ]
+        assert len(plan) == 3
+        assert plan[0] == expected[0]
+        assert plan[2] == expected[2]
+        self.assert_apicall_equals(plan[1], expected[1])
+        assert list(self.last_plan.messages.values()) == [
+            'Updating lambda layer: bar\n',
+        ]
+
     def test_can_create_function(self):
         function = create_function_resource('function_name')
         self.remote_state.declare_no_resources_exists()
@@ -513,7 +574,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'memory_size': 128,
                 'security_group_ids': [],
                 'subnet_ids': [],
-                'layers': None
+                'layers': [Variable('layer_version_arn')]
             },
         ),
             models.APICall(
@@ -552,7 +613,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'memory_size': 128,
                 'security_group_ids': [],
                 'subnet_ids': [],
-                'layers': layers
+                'layers': [Variable('layer_version_arn')] + layers
             },
         ),
             models.APICall(
@@ -590,7 +651,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
             'timeout': 60,
             'security_group_ids': [],
             'subnet_ids': [],
-            'layers': None
+            'layers': [Variable('layer_version_arn')]
         }
         expected_params = dict(memory_size=256, **existing_params)
         expected = [models.APICall(
@@ -633,7 +694,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'memory_size': 128,
                 'security_group_ids': [],
                 'subnet_ids': [],
-                'layers': None
+                'layers': [Variable('layer_version_arn')]
             },
         ),
             models.APICall(
@@ -1888,6 +1949,37 @@ class TestRemoteState(object):
         assert not self.remote_state.resource_exists(role)
         self.client.get_role_arn_for_name.assert_called_with('app-dev')
 
+    def test_lambda_layer_not_exists(self):
+        layer = models.LambdaLayer(
+            resource_name='layer',
+            layer_name='bar',
+            runtime='python2.7',
+            deployment_package=models.DeploymentPackage(
+                filename='foo')
+        )
+        assert not self.remote_state.resource_exists(layer)
+
+    def test_lambda_layer_exists(self):
+        layer = models.LambdaLayer(
+            resource_name='layer',
+            layer_name='bar',
+            runtime='python2.7',
+            deployment_package=models.DeploymentPackage(
+                filename='foo')
+        )
+        deployed_resources = {
+            'resources': [{
+                'name': 'layer',
+                'resource_type': 'lambda_layer',
+                'layer_version_arn': 'arn:layer:4'
+            }]
+        }
+        self.client.get_layer_version.return_value = {
+            'LayerVersionArn': 'arn:layer:4'}
+        remote_state = RemoteState(
+            self.client, DeployedResources(deployed_resources))
+        assert remote_state.resource_exists(layer)
+
     def test_lambda_function_exists(self):
         function = create_function_resource('function-name')
         self.client.lambda_function_exists.return_value = True
@@ -2316,6 +2408,20 @@ class TestUnreferencedResourcePlanner(BasePlannerTests):
             {'name': 'myrole2'},
             {'name': 'myrole'},
         ]
+
+    def test_can_delete_lambda_layer(self):
+        plan = []
+        deployed = {
+            'resources': [{
+                'name': 'layer',
+                'resource_type': 'lambda_layer',
+                'layer_version_arn': 'arn'}]}
+        config = FakeConfig(deployed)
+        self.execute(plan, config)
+        assert plan == [
+            models.APICall(
+                method_name='delete_layer_version',
+                params={'layer_version_arn': 'arn'})]
 
     def test_can_delete_scheduled_event(self):
         plan = []

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -20,7 +20,7 @@ def create_function_resource(name, function_name=None,
                              runtime='python2.7', handler='app.app',
                              tags=None, timeout=60,
                              memory_size=128, deployment_package=None,
-                             role=None, layers=None):
+                             role=None, layers=None, managed_layer=None):
     if function_name is None:
         function_name = 'appname-dev-%s' % name
     if environment_variables is None:
@@ -46,7 +46,19 @@ def create_function_resource(name, function_name=None,
         subnet_ids=[],
         layers=layers,
         reserved_concurrency=None,
+        managed_layer=managed_layer,
     )
+
+
+def create_managed_layer():
+    layer = models.LambdaLayer(
+        resource_name='layer',
+        layer_name='bar',
+        runtime='python2.7',
+        deployment_package=models.DeploymentPackage(
+            filename='foo')
+    )
+    return layer
 
 
 def create_api_mapping():
@@ -155,6 +167,13 @@ class BasePlannerTests(object):
         planner = PlanStage(self.remote_state, self.osutils)
         self.last_plan = planner.execute([resource])
         return self.last_plan.instructions
+
+    def filter_api_calls(self, plan):
+        api_calls = []
+        for instruction in plan:
+            if isinstance(instruction, models.APICall):
+                api_calls.append(instruction)
+        return api_calls
 
 
 class TestPlanManagedRole(BasePlannerTests):
@@ -574,7 +593,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'memory_size': 128,
                 'security_group_ids': [],
                 'subnet_ids': [],
-                'layers': [Variable('layer_version_arn')]
+                'layers': [],
             },
         ),
             models.APICall(
@@ -596,10 +615,22 @@ class TestPlanLambdaFunction(BasePlannerTests):
 
     def test_create_function_with_layers(self):
         layers = ['arn:aws:lambda:us-east-1:111:layer:test_layer:1']
-        function = create_function_resource('function_name', layers=layers)
+        function = create_function_resource(
+            'function_name', layers=layers,
+            managed_layer=create_managed_layer()
+        )
         self.remote_state.declare_no_resources_exists()
-        plan = self.determine_plan(function)
+        plan = self.filter_api_calls(
+            self.determine_plan(function.managed_layer))
+        plan.extend(self.filter_api_calls(self.determine_plan(function)))
         expected = [models.APICall(
+            method_name='publish_layer',
+            params={
+                'layer_name': 'bar',
+                'zip_contents': mock.ANY,
+                'runtime': 'python2.7'}
+        ),
+            models.APICall(
             method_name='create_function',
             params={
                 'function_name': 'appname-dev-function_name',
@@ -627,11 +658,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
         # create_function
         self.assert_apicall_equals(plan[0], expected[0])
         # delete_function_concurrency
-        self.assert_apicall_equals(plan[2], expected[1])
-
-        assert list(self.last_plan.messages.values()) == [
-            'Creating lambda function: appname-dev-function_name\n',
-        ]
+        self.assert_apicall_equals(plan[1], expected[1])
 
     def test_can_update_lambda_function_code(self):
         function = create_function_resource('function_name')
@@ -651,7 +678,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
             'timeout': 60,
             'security_group_ids': [],
             'subnet_ids': [],
-            'layers': [Variable('layer_version_arn')]
+            'layers': [],
         }
         expected_params = dict(memory_size=256, **existing_params)
         expected = [models.APICall(
@@ -675,6 +702,27 @@ class TestPlanLambdaFunction(BasePlannerTests):
             'Updating lambda function: appname-dev-function_name\n',
         ]
 
+    def test_can_update_lambda_function_with_managed_layer(self):
+        function = create_function_resource(
+            'function_name',
+            managed_layer=create_managed_layer(),
+        )
+        copy_of_function = attr.evolve(function)
+        self.remote_state.declare_resource_exists(copy_of_function)
+        copy_of_layer = attr.evolve(function.managed_layer)
+        self.remote_state.declare_resource_exists(
+            copy_of_layer,
+            layer_version_arn='arn:bar:4'
+        )
+        plan = self.determine_plan(function.managed_layer)
+        plan.extend(self.determine_plan(function))
+        self.assert_apicall_equals(plan[0], models.APICall(
+            method_name='delete_layer_version',
+            params={'layer_version_arn': 'arn:bar:4'},
+        ))
+        assert plan[3].method_name == 'update_function'
+        assert plan[3].params['layers'] == [Variable('layer_version_arn')]
+
     def test_can_create_function_with_reserved_concurrency(self):
         function = create_function_resource('function_name')
         function.reserved_concurrency = 5
@@ -694,7 +742,7 @@ class TestPlanLambdaFunction(BasePlannerTests):
                 'memory_size': 128,
                 'security_group_ids': [],
                 'subnet_ids': [],
-                'layers': [Variable('layer_version_arn')]
+                'layers': [],
             },
         ),
             models.APICall(

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -308,6 +308,14 @@ class TemplateTestBase(object):
             reserved_concurrency=None,
         )
 
+    def managed_layer(self):
+        return models.LambdaLayer(
+            resource_name='layer',
+            layer_name='bar',
+            runtime='python2.7',
+            deployment_package=models.DeploymentPackage(filename='layer.zip')
+        )
+
 
 class TestPackageOptions(object):
 
@@ -414,6 +422,24 @@ class TestTerraformTemplate(TemplateTestBase):
         template = self.template_gen.generate([function])
         tf_resource = self.get_function(template)
         assert tf_resource['layers'] == layers
+
+    def test_adds_managed_layer_when_provided(self):
+        function = self.lambda_function()
+        function.layers = ['arn://layer1', 'arn://layer2']
+        function.managed_layer = self.managed_layer()
+        template = self.template_gen.generate(
+            [function.managed_layer, function])
+        tf_resource = self.get_function(template)
+        assert tf_resource['layers'] == [
+            '${aws_lambda_layer_version.layer.arn}',
+            'arn://layer1',
+            'arn://layer2',
+        ]
+        assert template['resource']['aws_lambda_layer_version']['layer'] == {
+            'layer_name': 'bar',
+            'compatible_runtimes': ['python2.7'],
+            'filename': 'layer.zip',
+        }
 
     def test_adds_reserved_concurrency_when_provided(self, sample_app):
         function = self.lambda_function()
@@ -767,6 +793,7 @@ class TestSAMTemplate(TemplateTestBase):
     def test_sam_generates_sam_template_basic(self, sample_app):
         config = Config.create(chalice_app=sample_app,
                                project_dir='.',
+                               automatic_layer=True,
                                api_gateway_stage='api')
         template = self.generate_template(config)
         # Verify the basic structure is in place.  The specific parts
@@ -781,8 +808,28 @@ class TestSAMTemplate(TemplateTestBase):
             # This casing on the ApiHandlerRole name is unfortunate, but the 3
             # other resources in this list are hardcoded from the old deployer.
             'ApiHandlerRole',
-            'Layer',
+            'ManagedLayer',
             'RestAPI'
+        ]
+
+    def test_can_generate_lambda_layer_if_configured(self, sample_app):
+        config = Config.create(chalice_app=sample_app,
+                               app_name='testapp',
+                               project_dir='.',
+                               automatic_layer=True,
+                               api_gateway_stage='api')
+        template = self.generate_template(config)
+        managed_layer = template['Resources']['ManagedLayer']
+        assert managed_layer == {
+            'Type': 'AWS::Serverless::LayerVersion',
+            'Properties': {
+                'CompatibleRuntimes': [config.lambda_python_version],
+                'LayerName': 'testapp-dev-managed-layer',
+                'ContentUri': models.Placeholder.BUILD_STAGE,
+            }
+        }
+        assert template['Resources']['APIHandler']['Properties']['Layers'] == [
+            {'Ref': 'ManagedLayer'}
         ]
 
     def test_supports_precreated_role(self):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -776,11 +776,13 @@ class TestSAMTemplate(TemplateTestBase):
         assert 'Outputs' in template
         assert 'Resources' in template
         assert list(sorted(template['Resources'])) == [
-            'APIHandler', 'APIHandlerInvokePermission',
+            'APIHandler',
+            'APIHandlerInvokePermission',
             # This casing on the ApiHandlerRole name is unfortunate, but the 3
             # other resources in this list are hardcoded from the old deployer.
             'ApiHandlerRole',
-            'RestAPI',
+            'Layer',
+            'RestAPI'
         ]
 
     def test_supports_precreated_role(self):


### PR DESCRIPTION
This PR implements the automatic layer proposal in https://github.com/aws/chalice/issues/1485.
It pulls in https://github.com/aws/chalice/pull/1179 and adds several changes and bug fixes in order to adhere to the linked proposal.

Most of this is the standard stuff for adding new resource, with a small modification to how we handle empty layers.
Lambda does not let you create empty layers (or a layer where all your files are 0 size).  This represents a problem because we construct the appgraph based on your config file, but we won't know until build time if the layer we're suppose to create is empty or not.  Once we determine the layer is empty we then have a few ways of dealing with this.  I tried out different approaches and tried to come up with a reasonable compromise that isn't a huge hack but also doesn't require a large refactoring.

* Added an attribute `is_empty` to the `LambdaLayer`, which lets us mark when we've determined that the zipfile is empty.  This also allows us to skip processing this file again for each Lambda function (since they all share the same managed layer).
* In the build stage, if the LambdaLayer is empty, then we remove the edge from `LambdaFunction -> LambdaLayer`.  Once we do that for all our Lambda functions that effectively removes it from the appgraph.
* (the slightly hacky part) We need rebuild our dependencies by traversing the appgraph again after the build stage.  We previously made the assumption that once we flatten our graph that we'll never modify the edges in the graph and won't remove nodes.  Now that this is no longer the case (we're removing a LambdaLayer), we need to traverse the graph again.  The better longer term fix is to not have the "dependency builder" as part of the deploy process and instead have the build stage, planner etc all take an application graph.  They'll then be responsible for traversing the graph as necessary.  However this would change the interface for the main parts of the deployer and be a much larger change.