### PR TITLE
Fix: Blueprint decorator authorizer throws TypeError

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -772,7 +772,7 @@ class _HandlerRegistration(object):
             if name_prefix is not None:
                 name = name_prefix + name
             url_prefix = options.get('url_prefix')
-            if url_prefix is not None:
+            if url_prefix is not None and handler_type == 'route':
                 # Move url_prefix into kwargs so only the
                 # route() handler gets a url_prefix kwarg.
                 kwargs['url_prefix'] = url_prefix
@@ -893,7 +893,6 @@ class _HandlerRegistration(object):
         actual_kwargs = kwargs.copy()
         ttl_seconds = actual_kwargs.pop('ttl_seconds', None)
         execution_role = actual_kwargs.pop('execution_role', None)
-        actual_kwargs.pop('url_prefix', None)
         if actual_kwargs:
             raise TypeError(
                 'TypeError: authorizer() got unexpected keyword '

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -893,6 +893,7 @@ class _HandlerRegistration(object):
         actual_kwargs = kwargs.copy()
         ttl_seconds = actual_kwargs.pop('ttl_seconds', None)
         execution_role = actual_kwargs.pop('execution_role', None)
+        actual_kwargs.pop('url_prefix', None)
         if actual_kwargs:
             raise TypeError(
                 'TypeError: authorizer() got unexpected keyword '

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2082,6 +2082,26 @@ def test_can_call_lambda_context_on_blueprint_when_mounted(create_event):
     assert response == {'context': 'foo'}
 
 
+def test_can_add_authorizer_with_url_prefix_and_routes():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('app.chalicelib.blueprints.foo')
+
+    @foo.authorizer()
+    def myauth(event):
+        pass
+
+    @foo.route('/foo', authorizer=myauth)
+    def routefoo():
+        pass
+
+    myapp.register_blueprint(foo, url_prefix='/bar')
+    assert len(myapp.builtin_auth_handlers) == 1
+    authorizer = myapp.builtin_auth_handlers[0]
+    assert isinstance(authorizer, app.BuiltinAuthConfig)
+    assert authorizer.name == 'myauth'
+    assert authorizer.handler_string == 'app.chalicelib.blueprints.foo.myauth'
+
+
 def test_runtime_error_if_current_request_access_on_non_registered_blueprint():
     bp = app.Blueprint('app.chalicelib.blueprints.foo')
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
When registering builtin authorizer on blueprint decorator:
```
from chalice.app import AuthResponse, Blueprint


blueprint = Blueprint(__name__)

@blueprint.authorizer()
def demo_auth(auth_request):
    token = auth_request.token
    if token == 'allow':
        return AuthResponse(routes=['*'], principal_id='user')
    else:
        return AuthResponse(routes=[], principal_id='user')
```
`TypeError: TypeError: authorizer() got unexpected keyword arguments: url_prefix` is raised

I guess this is due to url_prefix get stored in kwargs here:
```
    def _do_register_handler(self, handler_type, name, user_handler,
                             wrapped_handler, kwargs, options=None):
        url_prefix = None
        name_prefix = None
        module_name = 'app'
        if options is not None:
            name_prefix = options.get('name_prefix')
            if name_prefix is not None:
                name = name_prefix + name
            url_prefix = options.get('url_prefix')
            if url_prefix is not None:
                # Move url_prefix into kwargs so only the
                # route() handler gets a url_prefix kwarg.
                kwargs['url_prefix'] = url_prefix
            # module_name is always provided if options is not None.
            module_name = options['module_name']
        handler_string = '%s.%s' % (module_name, user_handler.__name__)
        getattr(self, '_register_%s' % handler_type)(
            name=name,
            user_handler=user_handler,
            handler_string=handler_string,
            wrapped_handler=wrapped_handler,
            kwargs=kwargs,
        )
```

I feel that this is important because you cannot register authorizer on blueprint and you cannot register it on `app` decorator too because circular import would happen

*Description of changes:*
Since the authorizers don't depend on kwarg I popped it out of the `actual_kwargs` in `_register_authorizer` method. 

Both local and deployed version are working

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
