### PR TITLE
Add stage variables Issue#1480

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1038,12 +1038,14 @@ class TypedAWSClient(object):
         except client.exceptions.NotFoundException:
             raise ResourceDoesNotExistError(rest_api_id)
 
-    def deploy_rest_api(self, rest_api_id, api_gateway_stage):
-        # type: (str, str) -> None
+    def deploy_rest_api(self, rest_api_id, api_gateway_stage, stage_variables=None):
+        # type: (str, str, Optional[dict]) -> None
         client = self._client('apigateway')
+        stage_variables = stage_variables if stage_variables else {}
         client.create_deployment(
             restApiId=rest_api_id,
             stageName=api_gateway_stage,
+            variables=stage_variables
         )
 
     def add_permission_for_apigateway(self, function_name,

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1038,15 +1038,23 @@ class TypedAWSClient(object):
         except client.exceptions.NotFoundException:
             raise ResourceDoesNotExistError(rest_api_id)
 
-    def deploy_rest_api(self, rest_api_id, api_gateway_stage, stage_variables=None):
-        # type: (str, str, Optional[dict]) -> None
+    def deploy_rest_api(self,
+                        rest_api_id,
+                        api_gateway_stage,
+                        stage_variables=None):
+        # type: (str, str, Optional[Dict[str, str]]) -> None
         client = self._client('apigateway')
-        stage_variables = stage_variables if stage_variables else {}
-        client.create_deployment(
-            restApiId=rest_api_id,
-            stageName=api_gateway_stage,
-            variables=stage_variables
-        )
+        if stage_variables:
+            client.create_deployment(
+                restApiId=rest_api_id,
+                stageName=api_gateway_stage,
+                variables=stage_variables
+            )
+        else:
+            client.create_deployment(
+                restApiId=rest_api_id,
+                stageName=api_gateway_stage
+            )
 
     def add_permission_for_apigateway(self, function_name,
                                       region_name, account_id,

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -325,6 +325,11 @@ class Config(object):
         return self._chain_merge('environment_variables')
 
     @property
+    def stage_variables(self):
+        # type: () -> Dict[str, str]
+        return self._chain_merge('stage_variables')
+
+    @property
     def tags(self):
         # type: () -> Dict[str, str]
         tags = self._chain_merge('tags')

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -231,6 +231,23 @@ class Config(object):
                 final.update(value)
         return final
 
+    def _chain_merge_skip_lambda(self, name):
+        # type: (str) -> Dict[str, Any]
+        # Merge without lambda function specific key
+        search_dicts = [
+            self._default_params,
+            self._config_from_disk,
+            self._config_from_disk.get('stages', {}).get(
+                self.chalice_stage, {}),
+            self._user_provided_params
+        ]
+        final = {}
+        for cfg_dict in search_dicts:
+            value = cfg_dict.get(name, {})
+            if isinstance(value, dict):
+                final.update(value)
+        return final
+
     @property
     def config_file_version(self):
         # type: () -> str
@@ -327,7 +344,7 @@ class Config(object):
     @property
     def stage_variables(self):
         # type: () -> Dict[str, str]
-        return self._chain_merge('stage_variables')
+        return self._chain_merge_skip_lambda('stage_variables')
 
     @property
     def tags(self):

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -163,7 +163,8 @@ class ApplicationGraphBuilder(object):
                 config.api_gateway_endpoint_type,
                 config.api_gateway_stage,
             )
-        stage_variables = config.stage_variables
+
+        stage_variables = config.stage_variables or None
 
         return models.RestAPI(
             resource_name='rest_api',
@@ -192,15 +193,6 @@ class ApplicationGraphBuilder(object):
             }
         }]
         return {"Version": "2012-10-17", "Statement": statements}
-
-    def _get_stage_variables(self, config, stage_name):
-        # type: (Config, str) -> dict
-        stage_variables = config.config_from_disk.get('stage_variables', {})
-        stage_variables_for_stage = config.config_from_disk[
-            'stages'][stage_name].get('stage_variables', {})
-        stage_variables.update(stage_variables_for_stage)
-        return stage_variables
-
 
     def _create_websocket_api_model(
             self,

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -163,10 +163,7 @@ class ApplicationGraphBuilder(object):
                 config.api_gateway_endpoint_type,
                 config.api_gateway_stage,
             )
-        stage_variables = self._get_stage_variables(
-            config,
-            stage_name
-        )
+        stage_variables = config.stage_variables
 
         return models.RestAPI(
             resource_name='rest_api',

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -163,6 +163,10 @@ class ApplicationGraphBuilder(object):
                 config.api_gateway_endpoint_type,
                 config.api_gateway_stage,
             )
+        stage_variables = self._get_stage_variables(
+            config,
+            stage_name
+        )
 
         return models.RestAPI(
             resource_name='rest_api',
@@ -173,7 +177,8 @@ class ApplicationGraphBuilder(object):
             lambda_function=lambda_function,
             authorizers=authorizers,
             policy=policy,
-            domain_name=custom_domain_name
+            domain_name=custom_domain_name,
+            stage_variables=stage_variables
         )
 
     def _get_default_private_api_policy(self, config):
@@ -190,6 +195,15 @@ class ApplicationGraphBuilder(object):
             }
         }]
         return {"Version": "2012-10-17", "Statement": statements}
+
+    def _get_stage_variables(self, config, stage_name):
+        # type: (Config, str) -> dict
+        stage_variables = config.config_from_disk.get('stage_variables', {})
+        stage_variables_for_stage = config.config_from_disk[
+            'stages'][stage_name].get('stage_variables', {})
+        stage_variables.update(stage_variables_for_stage)
+        return stage_variables
+
 
     def _create_websocket_api_model(
             self,

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -257,6 +257,7 @@ class RestAPI(ManagedModel):
     policy = attrib(default=None)                # type: Opt[IAMPolicy]
     authorizers = attrib(default=Factory(list))  # type: List[LambdaFunction]
     domain_name = attrib(default=None)    # type: Opt[DomainName]
+    stage_variables = attrib(default=None)  # type: Opt[Dict[str, Any]]
 
     def dependencies(self):
         # type: () -> List[Model]

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1108,6 +1108,16 @@ class PlanStage(object):
             'value': resource.minimum_compression}
         ]  # type: List[Dict]
 
+        deploy_rest_api_params = {
+            'rest_api_id': Variable('rest_api_id'),
+            'api_gateway_stage': resource.api_gateway_stage
+        }
+
+        if resource.stage_variables:
+            deploy_rest_api_params.update(
+                {'stage_variables': resource.stage_variables}
+            )
+
         shared_plan_epilogue = [
             models.APICall(
                 method_name='update_rest_api',
@@ -1125,9 +1135,7 @@ class PlanStage(object):
             ),
             models.APICall(
                 method_name='deploy_rest_api',
-                params={'rest_api_id': Variable('rest_api_id'),
-                        'api_gateway_stage': resource.api_gateway_stage,
-                        'stage_variables': resource.stage_variables}
+                params=deploy_rest_api_params
             ),
             models.StoreValue(
                 name='rest_api_url',

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1126,7 +1126,8 @@ class PlanStage(object):
             models.APICall(
                 method_name='deploy_rest_api',
                 params={'rest_api_id': Variable('rest_api_id'),
-                        'api_gateway_stage': resource.api_gateway_stage},
+                        'api_gateway_stage': resource.api_gateway_stage,
+                        'stage_variables': resource.stage_variables}
             ),
             models.StoreValue(
                 name='rest_api_url',

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -93,6 +93,15 @@ level key, the stage specific environment variables will be merged into the top
 level keys.  See the examples section below for a concrete example.
 
 
+``stage_variables``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A mapping of key value pairs. Stage variables will be added to API Gateway stage
+variables and thus be exposed in the incoming requests. Stage variables can be added
+to configuration file both on root the level and the stage level. Mechanism of variable
+resolving on specific stages is the same as for environment variables.
+
+
 ``iam_policy_file``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -96,10 +96,12 @@ level keys.  See the examples section below for a concrete example.
 ``stage_variables``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A mapping of key value pairs. Stage variables will be added to API Gateway stage
-variables and thus be exposed in the incoming requests. Stage variables can be added
-to configuration file both on root the level and the stage level. Mechanism of variable
-resolving on specific stages is the same as for environment variables.
+A mapping of key value pairs. Stage variables will be added to API Gateway
+stage variables and thus be exposed in the incoming requests. Stage variables
+can be added to configuration file both on root the level and the stage level.
+Mechanism of variable resolving on specific stages is the same as for
+environment variables, excluding the possibility of stage_variables be
+specified on lambda function level.
 
 
 ``iam_policy_file``

--- a/tests/unit/deploy/test_appgraph.py
+++ b/tests/unit/deploy/test_appgraph.py
@@ -425,7 +425,6 @@ class TestApplicationGraphBuilder(object):
         assert rest_api.lambda_function.function_name == 'sample-app-dev'
         assert rest_api.stage_variables == {"test": "test"}
 
-
     def test_can_build_rest_api_with_authorizer(self, sample_app_with_auth):
         config = self.create_config(sample_app_with_auth,
                                     app_name='rest-api-app',

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -363,6 +363,7 @@ def test_env_vars_chain_merge():
         'shared_stage_key': 'from-stage',
     }
 
+
 def test_stage_vars_chain_merge():
     config_from_disk = {
         'stage_variables': {
@@ -388,7 +389,6 @@ def test_stage_vars_chain_merge():
         'shared_stage': 'from-stage',
         'shared_stage_key': 'from-stage',
     }
-
 
 
 def test_can_load_python_version():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -363,6 +363,33 @@ def test_env_vars_chain_merge():
         'shared_stage_key': 'from-stage',
     }
 
+def test_stage_vars_chain_merge():
+    config_from_disk = {
+        'stage_variables': {
+            'top_level': 'foo',
+            'shared_stage_key': 'from-top',
+            'shared_stage': 'from-top',
+        },
+        'stages': {
+            'prod': {
+                'stage_variables': {
+                    'stage_var': 'bar',
+                    'shared_stage_key': 'from-stage',
+                    'shared_stage': 'from-stage',
+                },
+            }
+        }
+    }
+    c = Config('prod', config_from_disk=config_from_disk)
+    resolved = c.stage_variables
+    assert resolved == {
+        'top_level': 'foo',
+        'stage_var': 'bar',
+        'shared_stage': 'from-stage',
+        'shared_stage_key': 'from-stage',
+    }
+
+
 
 def test_can_load_python_version():
     c = Config('dev')

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -599,6 +599,35 @@ def test_can_create_lambda_event():
         'stageVariables': {},
     }
 
+def test_can_create_lambda_event_with_stage_vars():
+    converter = local.LambdaEventConverter(
+        local.RouteMatcher(['/foo/bar', '/foo/{capture}']),
+        None,
+        {
+            "stage_variable": "test"
+        })
+    event = converter.create_lambda_event(
+        method='GET',
+        path='/foo/other',
+        headers={'content-type': 'application/json'}
+    )
+    assert event == {
+        'requestContext': {
+            'httpMethod': 'GET',
+            'resourcePath': '/foo/{capture}',
+            'path': '/foo/other',
+            'identity': {
+                'sourceIp': local.LambdaEventConverter.LOCAL_SOURCE_IP
+            },
+        },
+        'headers': {'content-type': 'application/json'},
+        'pathParameters': {'capture': 'other'},
+        'multiValueQueryStringParameters': None,
+        'body': None,
+        'stageVariables': {"stage_variable": "test"},
+    }
+
+
 
 def test_parse_query_string():
     converter = local.LambdaEventConverter(

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -599,6 +599,7 @@ def test_can_create_lambda_event():
         'stageVariables': {},
     }
 
+
 def test_can_create_lambda_event_with_stage_vars():
     converter = local.LambdaEventConverter(
         local.RouteMatcher(['/foo/bar', '/foo/{capture}']),
@@ -626,7 +627,6 @@ def test_can_create_lambda_event_with_stage_vars():
         'body': None,
         'stageVariables': {"stage_variable": "test"},
     }
-
 
 
 def test_parse_query_string():


### PR DESCRIPTION
*Issue #180,*

Adding the stage variables. 
When specified in the config.json they are added to both deploy process and LocalAPIGateWay so they can be exposed in current request

*Description of changes:*
Added `stage_variable` parameter handling in the Config object. New _chain_merge that skips lamda function specific keys was introduced, though I could have modified the existing one (would like to hear opinions on this)
Added new stage_variables parameter to deploy_rest_api AWS client
Added stage_variables handling to LocalAPIGateway
Added tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
