### PR TITLE
Improve support for pep517 builds

### DIFF
--- a/.changes/next-release/32219544702-bugfix-Packaging-88305.json
+++ b/.changes/next-release/32219544702-bugfix-Packaging-88305.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Packaging",
+  "description": "Add fallback to retrieve name/version from sdist (#1486)"
+}

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -846,7 +846,7 @@ class SDistMetadataFetcher(object):
                 egg_info_dir, info_contents[0], 'PKG-INFO')
         else:
             # This might be a pep 517 package in which case this PKG-INFO file
-            # should be available right in the top level irectory of the sdist
+            # should be available right in the top level directory of the sdist
             # in the case where the egg_info command fails.
             logger.debug("Using fallback location for PKG-INFO file in "
                          "package directory: %s", package_dir)

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -323,6 +323,10 @@ class OSUtils(object):
         # type: () -> int
         return subprocess.PIPE
 
+    def basename(self, path):
+        # type: (str) -> str
+        return os.path.basename(path)
+
 
 def getting_started_prompt(prompter):
     # type: (Any) -> bool

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -1236,7 +1236,6 @@ class TestSdistMetadataFetcher(object):
         pkg_info_file = (
             'Name: foo\n'
             'Version: 1.0\n'
-
         )
         with osutils.tempdir() as tempdir:
             filepath = self._write_fake_sdist(bad_setup_py, tempdir,


### PR DESCRIPTION
What was happening:

* A pep517 build can declare build dependencies.  Pip will then
  know to install these dependencies before trying to build a wheel
  file.
* When creating a build environment, it's only guaranteed to last
  for the duration of the build process.  It's not accessible once
  a pip command finishes running.
* When we try to retrieve the version of a package we run a "modified"
  form of "python setup.py egg_info".
* The problem with this is that we're not using the build environment
  that has all the build dependencies installed (it's already gone),
  so if setup.py imports a module (e.g. cython) because it expects
  it to be there because it declared it as a build dependency
  the egg_info command will fail.
* We don't check the RC or have a fallback case if we can't generate
  egg info.
* We fail with an indecipherable IndexError.

We now have a fallback where if we can't import/run the setup.py file,
we assume the PKG-INFO file should be in the top level directory of the
sdist so we check if it's there, and if so we use that file.

Fixes #1486.