### PR TITLE
PEP 561 / py.typed support

### DIFF
--- a/chalice/py.typed
+++ b/chalice/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. This package provides inline type annotations.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'event-file-poller': ['watchdog==0.9.0'],
     },
     license="Apache License 2.0",
-    package_data={'chalice': ['*.json']},
+    package_data={'chalice': ['*.json', 'py.typed']},
     include_package_data=True,
     zip_safe=False,
     keywords='chalice',


### PR DESCRIPTION
*Issue #, if available:*
#1499 

*Description of changes:*
Add a `py.typed` marker, per PEP 561, that allows consumers of Chalice to use its PEP 484 (mypy) typing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Testing
I made a venv, did `pip install .` and then tried consuming Chalice types with a 2-line chalice-consuming script using mypy. It failed with the pypi release and succeeded with this release.