### PR TITLE
Revamp deployment pipeline from 'generate-pipeline' command

### DIFF
--- a/.changes/next-release/55533665057-feature-Pipeline-7081.json
+++ b/.changes/next-release/55533665057-feature-Pipeline-7081.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Pipeline",
+  "description": "Add a new v2 template for the deployment pipeline CloudFormation template (#1506)"
+}

--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -1,32 +1,112 @@
 import copy
+import re
 
-from typing import List, Dict, Any, Optional  # noqa
+from typing import List, Dict, Any, Optional, Callable  # noqa
+import yaml
 
 from chalice.config import Config  # noqa
 from chalice import constants
 from chalice import __version__ as chalice_version
 
 
+def create_buildspec_v2(pipeline_params):
+    # type: (PipelineParameters) -> Dict[str, Any]
+    install_commands = [
+        "pip install 'chalice%s'" % pipeline_params.chalice_version_range,
+        "pip install -r requirements.txt",
+    ]
+    build_commands = [
+        "chalice package /tmp/packaged",
+        ("aws cloudformation package --template-file /tmp/packaged/sam.json "
+         "--s3-bucket ${APP_S3_BUCKET} "
+         "--output-template-file transformed.yaml")
+    ]
+    buildspec = {
+        "version": "0.2",
+        "phases": {
+            "install": {
+                "commands": install_commands,
+                "runtime-versions": {
+                    "python": pipeline_params.py_major_minor,
+                }
+            },
+            "build": {
+                "commands": build_commands,
+            }
+        },
+        "artifacts": {
+            "type": "zip",
+            "files": [
+                "transformed.yaml"
+            ]
+        }
+
+    }
+    return buildspec
+
+
+def create_buildspec_legacy(pipeline_params):
+    # type: (PipelineParameters) -> Dict[str, Any]
+    install_commands = [
+        'sudo pip install --upgrade awscli',
+        'aws --version',
+        "sudo pip install 'chalice%s'" % pipeline_params.chalice_version_range,
+        'sudo pip install -r requirements.txt',
+        'chalice package /tmp/packaged',
+        ('aws cloudformation package '
+            '--template-file /tmp/packaged/sam.json'
+            ' --s3-bucket ${APP_S3_BUCKET}'
+            '--output-template-file transformed.yaml'),
+    ]
+    buildspec = {
+        'version': '0.1',
+        'phases': {
+            'install': {
+                'commands': install_commands,
+            }
+        },
+        'artifacts': {
+            'type': 'zip',
+            'files': ['transformed.yaml']
+        }
+    }
+    return buildspec
+
+
 class InvalidCodeBuildPythonVersion(Exception):
-    def __init__(self, version):
-        # type: (str) -> None
-        super(InvalidCodeBuildPythonVersion, self).__init__(
-            'CodeBuild does not yet support python version %s.' % version
-        )
+    def __init__(self, version, msg=None):
+        # type: (str, Optional[str]) -> None
+        if msg is None:
+            msg = 'CodeBuild does not yet support python version %s.' % version
+        super(InvalidCodeBuildPythonVersion, self).__init__(msg)
 
 
 class PipelineParameters(object):
+
+    _PYTHON_VERSION = re.compile('python(.+)')
+
     def __init__(self, app_name, lambda_python_version,
                  codebuild_image=None, code_source='codecommit',
-                 chalice_version_range=None):
-        # type: (str, str, Optional[str], str, Optional[str]) -> None
+                 chalice_version_range=None, pipeline_version='v1'):
+        # type: (str, str, Optional[str], str, Optional[str], str) -> None
         self.app_name = app_name
+        # lambda_python_version is what matches lambda, e.g. 'python3.7'.
         self.lambda_python_version = lambda_python_version
+        # py_major_minor is just the version string, e.g. '3.7'
+        self.py_major_minor = self._extract_version(lambda_python_version)
         self.codebuild_image = codebuild_image
         self.code_source = code_source
         if chalice_version_range is None:
             chalice_version_range = self._lock_to_minor_version()
         self.chalice_version_range = chalice_version_range
+        self.pipeline_version = pipeline_version
+
+    def _extract_version(self, lambda_python_version):
+        # type: (str) -> str
+        matched = self._PYTHON_VERSION.match(lambda_python_version)
+        if matched is None:
+            raise InvalidCodeBuildPythonVersion(lambda_python_version)
+        return matched.group(1)
 
     def _lock_to_minor_version(self):
         # type: () -> str
@@ -36,7 +116,62 @@ class PipelineParameters(object):
         return '>=%s,<%s' % (min_version, max_version)
 
 
-class CreatePipelineTemplate(object):
+class BasePipelineTemplate(object):
+    def create_template(self, pipeline_params):
+        # type: (PipelineParameters) -> Dict[str, Any]
+        raise NotImplementedError("create_template")
+
+
+class CreatePipelineTemplateV2(BasePipelineTemplate):
+    _BASE_TEMPLATE = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Parameters": {
+            "ApplicationName": {
+                "Default": "ChaliceApp",
+                "Type": "String",
+                "Description": "Enter the name of your application"
+            },
+            "CodeBuildImage": {
+                "Default": "aws/codebuild/amazonlinux2-x86_64-standard:3.0",
+                "Type": "String",
+                "Description": "Name of codebuild image to use."
+            }
+        },
+        "Resources": {},
+        "Outputs": {},
+    }
+
+    def create_template(self, pipeline_params):
+        # type: (PipelineParameters) -> Dict[str, Any]
+        self._validate_python_version(pipeline_params.py_major_minor)
+        t = copy.deepcopy(self._BASE_TEMPLATE)  # type: Dict[str, Any]
+        params = t['Parameters']
+        params['ApplicationName']['Default'] = pipeline_params.app_name
+        resources = []  # type: List[BaseResource]
+        if pipeline_params.code_source == 'github':
+            resources.append(GithubSource())
+        else:
+            resources.append(CodeCommitSourceRepository())
+        resources.extend([CodeBuild(create_buildspec_v2), CodePipeline()])
+        for resource in resources:
+            resource.add_to_template(t, pipeline_params)
+        return t
+
+    def _validate_python_version(self, python_version):
+        # type: (str) -> None
+        major, minor = [
+            int(v) for v in python_version.split('.')
+        ]
+        if (major, minor) < (3, 7):
+            raise InvalidCodeBuildPythonVersion(
+                python_version,
+                'This CodeBuild image does not support python version: %s' % (
+                    python_version
+                )
+            )
+
+
+class CreatePipelineTemplateLegacy(BasePipelineTemplate):
 
     _CODEBUILD_IMAGE = {
         'python2.7': 'python:2.7.12',
@@ -75,7 +210,7 @@ class CreatePipelineTemplate(object):
             resources.append(GithubSource())
         else:
             resources.append(CodeCommitSourceRepository())
-        resources.extend([CodeBuild(), CodePipeline()])
+        resources.extend([CodeBuild(create_buildspec_legacy), CodePipeline()])
         for resource in resources:
             resource.add_to_template(t, pipeline_params)
         return t
@@ -135,14 +270,37 @@ class GithubSource(BaseResource):
             'Type': 'String',
             'Description': 'The name of the github repository.',
         }
-        p['GithubPersonalToken'] = {
-            'Type': 'String',
-            'Description': 'Personal access token for the github repo.',
-            'NoEcho': True,
-        }
+        if pipeline_params.pipeline_version == 'v1':
+            p['GithubPersonalToken'] = {
+                'Type': 'String',
+                'Description': 'Personal access token for the github repo.',
+                'NoEcho': True,
+            }
+        else:
+            p['GithubRepoSecretId'] = {
+                'Type': 'String',
+                'Default': 'GithubRepoAccess',
+                'Description': (
+                    'The name/ID of the SecretsManager secret that '
+                    'contains the personal access token for the github repo.'
+                )
+            }
+            p['GithubRepoSecretJSONKey'] = {
+                'Type': 'String',
+                'Default': 'OAuthToken',
+                'Description': (
+                    'The name of the JSON key in the SecretsManager secret '
+                    'that contains the personal access token for the '
+                    'github repo.'
+                )
+            }
 
 
 class CodeBuild(BaseResource):
+    def __init__(self, buildspec_generator=create_buildspec_legacy):
+        # type: (Callable[[PipelineParameters], Dict[str, Any]]) -> None
+        self._buildspec_generator = buildspec_generator
+
     def add_to_template(self, template, pipeline_params):
         # type: (Dict[str, Any], PipelineParameters) -> None
         resources = template.setdefault('Resources', {})
@@ -185,32 +343,12 @@ class CodeBuild(BaseResource):
                 },
                 "Source": {
                     "Type": "CODEPIPELINE",
-                    "BuildSpec": self._get_default_buildspec(pipeline_params),
+                    "BuildSpec": yaml.dump(
+                        self._buildspec_generator(pipeline_params),
+                    ),
                 }
             }
         }
-
-    def _get_default_buildspec(self, pipeline_params):
-        # type: (PipelineParameters) -> str
-        return (
-            "version: 0.1\n"
-            "phases:\n"
-            "  install:\n"
-            "    commands:\n"
-            "      - sudo pip install --upgrade awscli\n"
-            "      - aws --version\n"
-            "      - sudo pip install 'chalice%s'\n"
-            "      - sudo pip install -r requirements.txt\n"
-            "      - chalice package /tmp/packaged\n"
-            "      - aws cloudformation package"
-            " --template-file /tmp/packaged/sam.json"
-            " --s3-bucket ${APP_S3_BUCKET}"
-            " --output-template-file transformed.yaml\n"
-            "artifacts:\n"
-            "  type: zip\n"
-            "  files:\n"
-            "    - transformed.yaml\n"
-        ) % pipeline_params.chalice_version_range
 
     def _add_s3_bucket(self, resources, outputs):
         # type: (Dict[str, Any], Dict[str, Any]) -> None
@@ -382,27 +520,39 @@ class CodePipeline(BaseResource):
         # type: (PipelineParameters) -> Dict[str, Any]
         if pipeline_params.code_source == 'codecommit':
             return self._code_commit_source()
-        return self._github_source()
+        return self._github_source(pipeline_params.pipeline_version)
 
-    def _github_source(self):
-        # type: () -> Dict[str, Any]
+    def _github_source(self, pipeline_version):
+        # type: (str) -> Dict[str, Any]
+        oauth_token = {'Ref': 'GithubPersonalToken'}  # type: Dict[str, Any]
+        if pipeline_version == 'v2':
+            oauth_token = {
+                "Fn::Join": [
+                    "", ["{{resolve:secretsmanager:",
+                         {"Ref": "GithubRepoSecretId"},
+                         ":SecretString:",
+                         {"Ref": "GithubRepoSecretJSONKey"},
+                         "}}"]
+                ]
+            }
         return {
             'Name': 'Source',
             'Actions': [{
+                "Name": "Source",
                 "ActionTypeId": {
                     "Category": "Source",
                     "Owner": "ThirdParty",
-                    "Version": 1,
+                    "Version": "1",
                     "Provider": "GitHub"
                 },
                 'RunOrder': 1,
-                'OutputArtifacts': {
+                'OutputArtifacts': [{
                     'Name': 'SourceRepo',
-                },
+                }],
                 'Configuration': {
                     'Owner': {'Ref': 'GithubOwner'},
                     'Repo': {'Ref': 'GithubRepoName'},
-                    'OAuthToken': {'Ref': 'GithubPersonalToken'},
+                    'OAuthToken': oauth_token,
                     'Branch': 'master',
                     'PollForSourceChanges': True,
                 }
@@ -424,7 +574,7 @@ class CodePipeline(BaseResource):
                     "ActionTypeId": {
                         "Category": "Build",
                         "Owner": "AWS",
-                        "Version": 1,
+                        "Version": "1",
                         "Provider": "CodeBuild"
                     },
                     "OutputArtifacts": [
@@ -451,7 +601,7 @@ class CodePipeline(BaseResource):
                     "ActionTypeId": {
                         "Category": "Deploy",
                         "Owner": "AWS",
-                        "Version": 1,
+                        "Version": "1",
                         "Provider": "CloudFormation"
                     },
                     "InputArtifacts": [
@@ -481,7 +631,7 @@ class CodePipeline(BaseResource):
                     "ActionTypeId": {
                         "Category": "Deploy",
                         "Owner": "AWS",
-                        "Version": 1,
+                        "Version": "1",
                         "Provider": "CloudFormation"
                     },
                     "Configuration": {

--- a/docs/source/topics/cd.rst
+++ b/docs/source/topics/cd.rst
@@ -1,3 +1,4 @@
+===========================
 Continuous Deployment (CD)
 ===========================
 
@@ -14,13 +15,41 @@ greatly simplifies managing what resources belong to your Chalice app as they
 are all stored in the Continuous Deployment pipeline.
 
 Chalice can generate a CloudFormation template that will create a starter CD
-pipeline. It contains a CodeCommit repo, a CodeBuild stage for
-packaging your chalice app, and a CodePipeline stage to deploy your
+pipeline. By default it contains an AWS CodeCommit repo, an AWS CodeBuild stage
+for packaging your chalice app, and an AWS CodePipeline stage to deploy your
 application using CloudFormation.
+
+You can also configure a source repository hosted on GitHub instead of
+a CodeCommit repository.
+
+Pipeline Template Versions
+==========================
+
+This starter pipeline template can be generated using the ``generate-pipeline``
+command.  There are two versions of this pipeline.  The older ``v1`` template
+is the default (for backwards compatibility reasons), but the newer template
+version, ``v2``, is recommended.  The version can be specified using the
+``--pipeline-version`` option.  These are the differences between ``v1`` and
+``v2`` templates:
+
+* The ``v1`` templates use version ``0.1`` of the CodeBuild buildspec, whereas
+  ``v2`` uses ``0.2`` of the CodeBuild buildspec.  Buildspec ``0.2`` is the
+  recommended version to use with CodeBuild.  See their
+  `documentation <https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html>`__
+  for more information.
+* The ``v2`` template uses `AWS Secrets Manager <https://aws.amazon.com/secrets-manager/>`__
+  to configure access to a GitHub repository.
+* The ``v2`` buildspec uses `runtime-versions <https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.phases.install.runtime-versions>`__
+  to configure which version of Python to use instead of a Python
+  version specific CodeBuild image.  For ``v2`` templates the
+  ``aws/codebuild/amazonlinux2-x86_64-standard`` image.
+
+**The v2 pipeline template requires Python 3.7 or higher.** If you're using
+Python versions less than 3.7 you must use the ``v1`` pipeline template.
 
 
 Usage example
--------------
+=============
 
 Setting up the deployment pipeline is a two step process. First use the
 ``chalice generate-pipeline`` command to generate a base CloudFormation
@@ -29,12 +58,17 @@ the ``aws cloudformation deploy`` command. Below is an example.
 
 ::
 
-   $ chalice generate-pipeline pipeline.json
+   $ chalice generate-pipeline --pipeline-version v2 pipeline.json
    $ aws cloudformation deploy --stack-name mystack
          --template-file pipeline.json --capabilities CAPABILITY_IAM
    Waiting for changeset to be created..
    Waiting for stack create/update to complete
    Successfully created/updated stack - mystack
+
+.. note::
+   To configure your Chalice app to use a GitHub repository instead of
+   CodeCommit see the :ref:`cicd-github-repo` section below.
+
 
 Once the CloudFormation template has finished creating the stack, you will have
 several new AWS resources that make up a bare bones CD pipeline.
@@ -76,6 +110,12 @@ populate it with the Chalice application code. Permissions will also need to be
 set up, you can find the documentation on how to do that
 `here <https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html>`_
 .
+
+You can retrieve the CodeCommit clone URL by searching for the
+``SourceRepoURL`` in the CloudFormation stack output::
+
+    $ aws cloudformation describe-stacks --stack-name mysack \
+       --query "Stacks[0].Outputs[?OutputKey=='SourceRepoURL'] | [0].OutputValue"
 
 
 CodePipeline
@@ -144,3 +184,75 @@ Ideally the CodeBuild stage would be used to run unit and functional tests
 before deploying to beta. After the beta stage is up, integration tests can be
 run against that endpoint, and if they all pass the beta stage could be
 promoted to a production stage using the CodePipleine manual approval feature.
+
+.. _cicd-github-repo:
+
+Configuring a GitHub Repository
+===============================
+
+You can configure a GitHub repository instead of a CodeCommit repo when
+setting up your deployment pipeline by specifying the ``--source github``
+option.  When generating a CloudFormation template for a GitHub repository,
+there are several parameters that are added to your template that allow
+you to configure how to connect your GitHub repository with your CodePipeline.
+
+You must store your OAuth token that enables access to a GitHub repository
+in AWS Secrets Manager.  You then specify the secret name/id and the JSON
+key name as CloudFormation parameters.  This values default to a secret
+name of ``GithubRepoAccess`` and a JSON key name of ``OAuthToken``.
+
+Below is an example of how to configure a GitHub repository as the
+source for your deployment pipeline.
+
+First create a `GitHub token <https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token>`__
+that can be used in this template.  Next create a secret in AWS Secrets
+Manager.  You can either follow the documentation
+`here <https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_create-basic-secret.html>`__
+or use the AWS CLI or any AWS SDK.  For this example, we'll use the AWS CLI
+to create our secret.  Create a file named ``/tmp/secrets.json`` with these
+contents::
+
+    {"OAuthToken": "abcdefghhijklmnop"}
+
+Be sure to replace the value of ``OAuthToken`` with the value of your GitHub
+token you created.  Next we can create the secret using this command::
+
+    $ aws secretsmanager create-secret --name GithubRepoAccess \
+      --description "Token for Github Repo Access" \
+      --secret-string file:///tmp/secrets.json
+
+Now we can generate our deployment pipeline::
+
+    $ aws generate-pipeline --pipeline-version v2 \
+      --source github --buildspec-file buildspec.yml pipeline.json
+
+This will create two files, a ``pipeline.json`` file containing our
+deployment pipeline and a ``buildspec.yml`` file.  This buildspec file
+lets us update what commands should be run as part of our build process
+without having to redeploy our CloudFormation template.
+
+We now add and commit our changes to our repository.
+
+::
+
+    $ git add buildspec.yml pipeline.json
+    $ git commit -m "Add deployment pipeline template"
+    $ git push
+
+Now we're ready to deploy our CloudFormation template using the AWS CLI.  Be
+sure to replace the ``GithubOwner`` and ``GithubRepoName`` with your own
+values for your GitHub repository.  You'll also need to specify the
+``GithubRepoSecretId`` and ``GithubRepoSecretJSONKey`` if you used values
+other than the default vaues of ``GithubRepoAccess`` and ``OAuthToken`` when
+creating your secret in Secrets Manager.
+
+::
+
+    $ aws cloudformation deploy --template-file pipeline.json \
+      --stack-name MyChaliceApp --parameter-overrides \
+      GithubOwner=repo-owner-name \
+      GithubRepoName=repo-name \
+      --capabilities CAPABILITY_IAM
+
+We've now created a dpeloyment pipeline that will automatically deploy our
+Chalice app whenever we push to our GitHub repository.


### PR DESCRIPTION
The deployment pipeline generated from the ``generate-pipeline``
command hasn't been touched in several years.  In looking over
the code there's been notable changes in the underlying services
we use for the deployment pipeline:

* There's a new 0.2 version of the CodeBuild buildspec that has
  notable improvements from the 0.1 version buildspec.
* The way that CodeBuild manages language images has changed.
  Rather than having separate codebuild images for each runtime,
  you can now specify the runtime you need in your codebuild spec
  file (leading to issues such as #1412).  As a result you couldn't
  generate a deployment pipeline that worked with Python 3.8.
* CloudFormation added support for ssm/ssm-secure/secretsmanager.
  While we can't use ssm-secure for the GitHub OAuth token,
  secretsmanager is supported so we can more securely store our
  token instead of requiring it as a template parameter.

The output of `generate-pipeline` is in a grey area in terms of what to
support for backwards compatibility.  If the expectation is you can use
the output `generate-pipeline` to successfully set up a deployment
pipeline, then these changes are backwards compatible.  However,
the template parameters are changed as well as the CodeBuild image used
which could negatively impact customers.  As a result, I've decided
to make this an opt-in change (for now).  There's a new
`--pipeline-version` parameter where specifying `v2` will get you
the new features listed above.  The default value is `v1` which
will generate the same template as previous versions.
The other benefit of making this opt-in is we can restrict which
Python versions we support.  The new CodeBuild images only support
Python 3.7 and 3.8 so we can only support these new versions without
requiring fallbacks for earlier python version (you can just use
`v1` if you want to use older python versions).

Note that there was a bugfix needed when configuring a GitHub
repository as a source.  This was fixed in the `v1` template
as well as the `v2` template.