### PR TITLE
Fix type hint for generate_sqs_event function

### DIFF
--- a/chalice/test.py
+++ b/chalice/test.py
@@ -262,7 +262,7 @@ class TestEventsClient(BaseClient):
         return s3_event
 
     def generate_sqs_event(self, message_bodies, queue_name='queue-name'):
-        # type: (str, str) -> Dict[str, Any]
+        # type: (List[str], str) -> Dict[str, Any]
         records = [{
             'attributes': {
                 'ApproximateFirstReceiveTimestamp': '1530576251596',


### PR DESCRIPTION
*Description of changes:*

I fixed the type hint for generate_sqs_event function.

* The "message_bodies" argument of "generate_sqs_event" function is written to receive a list of string.
* However, the type hint is a "str", not a "List[str]". So IDE displays a warning sign.
* The reason why these miswritten type hints passed the "make typecheck" command is that the string type also has a "\_\_iter\__" method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
