### PR TITLE
Add support for Chalice middleware

### DIFF
--- a/.changes/next-release/28130110348-feature-Middleware-54618.json
+++ b/.changes/next-release/28130110348-feature-Middleware-54618.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Middleware",
+  "description": "Add support for middleware (#1509)"
+}

--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -4,7 +4,8 @@ from chalice.app import (
     NotFoundError, ConflictError, TooManyRequestsError, Response, CORSConfig,
     CustomAuthorizer, CognitoUserPoolAuthorizer, IAMAuthorizer,
     UnprocessableEntityError, WebsocketDisconnectedError,
-    AuthResponse, AuthRoute, Cron, Rate, __version__ as chalice_version
+    AuthResponse, AuthRoute, Cron, Rate, __version__ as chalice_version,
+    ConvertToMiddleware
 )
 # We're reassigning version here to keep mypy happy.
 __version__ = chalice_version

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -629,9 +629,9 @@ class WebsocketAPI(object):
 
 
 class DecoratorAPI(object):
-    def middleware(self, event_type):
+    def middleware(self, event_type='all'):
         def _middleware_wrapper(func):
-            self._register_middleware(func, event_type)
+            self.register_middleware(func, event_type)
             return func
         return _middleware_wrapper
 
@@ -794,8 +794,8 @@ class DecoratorAPI(object):
                           user_handler, wrapped_handler, kwargs, options=None):
         raise NotImplementedError("_register_handler")
 
-    def _register_middleware(self, func, event_type):
-        raise NotImplementedError("_register_middleware")
+    def register_middleware(self, func, event_type='all'):
+        raise NotImplementedError("register_middleware")
 
 
 class _HandlerRegistration(object):
@@ -810,7 +810,7 @@ class _HandlerRegistration(object):
         self.handler_map = {}
         self.middleware_handlers = []
 
-    def _register_middleware(self, func, event_type):
+    def register_middleware(self, func, event_type='all'):
         self.middleware_handlers.append((func, event_type))
 
     def _do_register_handler(self, handler_type, name, user_handler,
@@ -1767,10 +1767,10 @@ class Blueprint(DecoratorAPI):
                                      user_handler)
         return _defer_wrap_handler
 
-    def _register_middleware(self, func, event_type):
+    def register_middleware(self, func, event_type='all'):
         self._deferred_registrations.append(
             # pylint: disable=protected-access
-            lambda app, options: app._register_middleware(
+            lambda app, options: app.register_middleware(
                 func, event_type
             )
         )

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -21,6 +21,8 @@ class TooManyRequestsError(ChaliceViewError): ...
 ALL_ERRORS = ... # type: List[ChaliceViewError]
 _BUILTIN_AUTH_FUNC = Callable[
     [AuthRequest], Union[AuthResponse, Dict[str, Any]]]
+_GET_RESPONSE = Callable[[Any], Any]
+_MIDDLEWARE_FUNC = Callable[[Any, _GET_RESPONSE], Any]
 
 
 class Authorizer:
@@ -132,6 +134,12 @@ class WebsocketAPI(object):
 
 
 class DecoratorAPI(object):
+    def register_middleware(self,
+                            func: _MIDDLEWARE_FUNC,
+                            event_type: str='all') -> None: ...
+
+    def middleware(self, event_type: str='all') -> Callable[..., Any]: ...
+
     def authorizer(self,
                    ttl_seconds: Optional[int]=None,
                    execution_role: Optional[str]=None,
@@ -285,3 +293,8 @@ class CloudWatchEventConfig(BaseEventSourceConfig):
 class Blueprint(DecoratorAPI):
     current_request = ... # type: Request
     lambda_context = ... # type: LambdaContext
+
+
+class ConvertToMiddleware:
+    def __init__(self,
+                 lambda_wrapper: Callable[..., Any]) -> None: ...

--- a/docs/source/topics/index.rst
+++ b/docs/source/topics/index.rst
@@ -24,3 +24,4 @@ Topics
    domainname
    experimental
    testing
+   middleware

--- a/docs/source/topics/middleware.rst
+++ b/docs/source/topics/middleware.rst
@@ -1,0 +1,132 @@
+==========
+Middleware
+==========
+
+Chalice provides numerous features and capabilities right out of the box, but
+there are often times where you'll want to customize the behavior of Chalice
+for your specific needs.  You can accomplish this by using middleware, which
+lets you alter the request and response lifecycle.  Chalice middleware
+is a function that you register as part of your application that will
+automatically be invoked by Chalice whenever your Lambda functions are called.
+
+Below is an example of Chalice middleware:
+
+.. code-block:: python
+
+    from chalice import Chalice
+
+    app = Chalice(app_name='demo-middleware')
+
+    @app.middleware('all')
+    def my_middleware(event, get_response):
+        app.log.info("Before calling my main Lambda function.")
+        response = get_response(event)
+        app.log.info("After calling my main Lambda function.")
+        return response
+
+    @app.route('/')
+    def index():
+        return {'hello': 'world'}
+
+    @app.on_sns_message('mytopic')
+    def sns_handler(event):
+        pass
+
+In this example, our middleware is emitting a log message before and after
+our Lambda function has been invoked.  Because we specified an event type of
+``all``, the ``my_middleware`` function will be called when either our REST
+API's ``index()`` or our ``sns_handler()`` Lambda function is invoked.
+
+
+Writing Middleware
+==================
+
+Middleware must adhere to these requirements:
+
+* Must be a callable object that accepts two parameters, an ``event``, and
+  a ``get_response`` function.  The ``event`` type will depend on what type
+  of handlers the middleware has been registered for (see "Registering
+  Middleware" below).
+* Must return a response.  This will be the response that gets returned back
+  to the caller.
+* In order to invoke the next middleware in the chain and eventually call the
+  actual Lambda handler, it must invoke ``get_response(event)``.
+* Middleware can short-circuit the request be returning its own response.
+  It does not have to invoke ``get_response(event)`` if not needed.
+
+Below is the simplest middleware in Chalice that does nothing:
+
+.. code-block:: python
+
+   @app.middleware('all')
+   def noop_middleware(event, get_response):
+       return get_response(event)
+
+
+Registering Middleware
+----------------------
+
+In order to register middleware, you use the ``@app.middleware()`` decorator.
+This function accepts a single arg that specifies what type of Lambda function
+it wants to be registered for.  This allows you to apply middleware to only
+specific type of event handlers, e.g. only for REST APIs, or Websockets, or
+S3 event handlers.  To register middleware for all Lambda functions, you can
+specify ``all``.  Below are the supported event types along with the
+corresponding type of event that will be provided to the middleware:
+
+* ``all`` - ``Any``
+* ``s3`` - ``chalice.S3Event``
+* ``sns`` - ``chalice.SNSEvent``
+* ``sqs`` - ``chalice.SQSEvent``
+* ``cloudwatch`` - ``chalice.CloudWatchEvent``
+* ``scheduled`` - ``chalice.CloudWatchEvent``
+* ``websocket`` - ``chalice.WebsocketEvent``
+* ``http`` - ``chalice.Request``
+* ``pure_lambda`` - ``chalice.LambdaFunctionEvent``
+
+
+Examples
+========
+
+Below are some examples of common middleware patterns.
+
+Short Circuiting a Request
+--------------------------
+
+In this example, we want to return a 400 bad response if a specific
+header is missing from a request.  Because this is HTTP specific, we only
+want to register this handler for our ``http`` event type.
+
+.. code-block:: python
+
+   from chalice Response
+
+   @app.middleware('http')
+   def require_header(event, get_response):
+       # From the list above, because this is an ``http`` event
+       # type, we know that event will be of type ``chalice.Request``.
+       if 'X-Custom-Header' not in event.headers:
+           return Response(
+               status_code=400,
+               body={"Error": "Missing required 'X-Custom-Header'"})
+       # If the header exists then we'll defer to our normal request flow.
+       return get_response(event)
+
+Modifying a Response
+--------------------
+
+In this example, we want to measure the processing time and inject it as
+a key in our Lambda response.
+
+.. code-block:: python
+
+   import time
+   from chalice Response
+
+   @app.middleware('pure_lambda')
+   def inject_time(event, get_response):
+       start = time.time()
+       response = get_response(event)
+       total = time.time() - start
+       response.setdefault('metadata', {})['duration'] = total
+       return response

--- a/docs/source/topics/middleware.rst
+++ b/docs/source/topics/middleware.rst
@@ -134,6 +134,8 @@ apply this wrapper to every Lambda function in your app.
 
 .. code-block:: python
 
+    from chalice import ConvertToMiddleware
+
     app.register_middleware(ConvertToMiddleware(log_invoation))
 
 This is also useful to integrate with existing libraries that provide

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -15,6 +15,7 @@ import six
 
 from chalice import app
 from chalice import NotFoundError
+from chalice.test import Client
 from chalice.app import (
     APIGateway,
     Request,
@@ -248,6 +249,74 @@ def sample_websocket_app():
         calls.append(('default', event))
 
     return demo, calls
+
+
+@fixture
+def sample_middleware_app():
+    demo = app.Chalice('app-name')
+    demo.calls = []
+
+    @demo.middleware('all')
+    def mymiddleware(event, get_response):
+        demo.calls.append({'type': 'all',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.middleware('s3')
+    def mymiddleware_s3(event, get_response):
+        demo.calls.append({'type': 's3',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.middleware('sns')
+    def mymiddleware_sns(event, get_response):
+        demo.calls.append({'type': 'sns',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.middleware('http')
+    def mymiddleware_http(event, get_response):
+        demo.calls.append({'type': 'http',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.middleware('websocket')
+    def mymiddleware_websocket(event, get_response):
+        demo.calls.append({'type': 'websocket',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.middleware('pure_lambda')
+    def mymiddleware_pure_lambda(event, get_response):
+        demo.calls.append({'type': 'pure_lambda',
+                           'event': event.__class__.__name__})
+        return get_response(event)
+
+    @demo.route('/')
+    def index():
+        return {}
+
+    @demo.on_s3_event(bucket='foo')
+    def s3_handler(event):
+        pass
+
+    @demo.on_sns_message(topic='foo')
+    def sns_handler(event):
+        pass
+
+    @demo.on_sqs_message(queue='foo')
+    def sqs_handler(event):
+        pass
+
+    @demo.lambda_function()
+    def lambda_handler(event, context):
+        pass
+
+    @demo.on_ws_message()
+    def ws_handler(event):
+        pass
+
+    return demo
 
 
 @fixture
@@ -1986,7 +2055,7 @@ def test_can_mount_lambda_functions_with_name_prefix():
 
     @foo.lambda_function()
     def myfunction(event, context):
-        return event, context
+        return event
 
     myapp.register_blueprint(foo, name_prefix='myprefix_')
     assert len(myapp.pure_lambda_functions) == 1
@@ -1995,7 +2064,11 @@ def test_can_mount_lambda_functions_with_name_prefix():
     assert lambda_function.handler_string == (
         'app.chalicelib.blueprints.foo.myfunction')
 
-    assert myfunction('foo', 'bar') == ('foo', 'bar')
+    with Client(myapp) as c:
+        response = c.lambda_.invoke(
+            'myprefix_myfunction', {'foo': 'bar'}
+        )
+    assert response.payload == {'foo': 'bar'}
 
 
 def test_can_mount_event_sources_with_blueprint():
@@ -2713,3 +2786,362 @@ def test_does_raise_on_invalid_json_wbsocket_body(create_websocket_event):
 
     event = create_websocket_event('$default', body='foo bar')
     demo(event, context=None)
+
+
+class TestMiddleware:
+    def test_middleware_basic_api(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def myhandler(event, get_response):
+            called.append({'name': 'myhandler', 'bucket': event.bucket})
+            return get_response(event)
+
+        @demo.middleware('all')
+        def myhandler2(event, get_response):
+            called.append({'name': 'myhandler2', 'bucket': event.bucket})
+            return get_response(event)
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+        assert response.payload == {'bucket': 'mybucket'}
+        assert called == [
+            {'name': 'myhandler', 'bucket': 'mybucket'},
+            {'name': 'myhandler2', 'bucket': 'mybucket'},
+            {'name': 'main', 'bucket': 'mybucket'},
+        ]
+
+    def test_can_short_circuit_response(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def myhandler(event, get_response):
+            called.append({'name': 'myhandler', 'bucket': event.bucket})
+            return {'short-circuit': True}
+
+        @demo.middleware('all')
+        def myhandler2(event, get_response):
+            called.append({'name': 'myhandler2', 'bucket': event.bucket})
+            return get_response(event)
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+        assert response.payload == {'short-circuit': True}
+        assert called == [
+            {'name': 'myhandler', 'bucket': 'mybucket'},
+        ]
+
+    def test_can_alter_response(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def myhandler(event, get_response):
+            called.append({'name': 'myhandler', 'bucket': event.bucket})
+            response = get_response(event)
+            response['myhandler'] = True
+            return response
+
+        @demo.middleware('all')
+        def myhandler2(event, get_response):
+            called.append({'name': 'myhandler2', 'bucket': event.bucket})
+            response = get_response(event)
+            response['myhandler2'] = True
+            return response
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+        assert response.payload == {
+            'bucket': 'mybucket',
+            'myhandler': True,
+            'myhandler2': True,
+        }
+        assert called == [
+            {'name': 'myhandler', 'bucket': 'mybucket'},
+            {'name': 'myhandler2', 'bucket': 'mybucket'},
+            {'name': 'main', 'bucket': 'mybucket'},
+        ]
+
+    def test_can_change_order_of_definitions(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        @demo.middleware('all')
+        def myhandler(event, get_response):
+            called.append({'name': 'myhandler', 'bucket': event.bucket})
+            response = get_response(event)
+            response['myhandler'] = True
+            return response
+
+        @demo.middleware('all')
+        def myhandler2(event, get_response):
+            called.append({'name': 'myhandler2', 'bucket': event.bucket})
+            response = get_response(event)
+            response['myhandler2'] = True
+            return response
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+        assert response.payload == {
+            'bucket': 'mybucket',
+            'myhandler': True,
+            'myhandler2': True,
+        }
+        assert called == [
+            {'name': 'myhandler', 'bucket': 'mybucket'},
+            {'name': 'myhandler2', 'bucket': 'mybucket'},
+            {'name': 'main', 'bucket': 'mybucket'},
+        ]
+
+    def test_can_use_middleware_for_pure_lambda(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def mymiddleware(event, get_response):
+            called.append({'name': 'mymiddleware', 'event': event.to_dict()})
+            return get_response(event)
+
+        @demo.lambda_function()
+        def myfunction(event, context):
+            called.append({'name': 'myfunction', 'event': event})
+            return {'foo': 'bar'}
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'myfunction', {'input-event': True}
+            )
+
+        assert response.payload == {'foo': 'bar'}
+        assert called == [
+            {'name': 'mymiddleware', 'event': {'input-event': True}},
+            {'name': 'myfunction', 'event': {'input-event': True}},
+        ]
+
+    def test_can_use_for_websocket_handlers(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def mymiddleware(event, get_response):
+            called.append({'name': 'mymiddleware', 'event': event.to_dict()})
+            return get_response(event)
+
+        @demo.on_ws_message()
+        def myfunction(event):
+            called.append({'name': 'myfunction', 'event': event.to_dict()})
+            return {'foo': 'bar'}
+
+        with Client(demo) as c:
+            event = {
+                'requestContext': {
+                    'domainName': 'example.com',
+                    'stage': 'dev',
+                    'connectionId': 'abcd',
+                },
+                'body': "body"
+            }
+            response = c.lambda_.invoke('myfunction', event)
+
+        assert response.payload == {'statusCode': 200}
+        assert called == [
+            {'name': 'mymiddleware', 'event': event},
+            {'name': 'myfunction', 'event': event},
+        ]
+
+    def test_can_use_rest_api_for_middleware(self):
+        demo = app.Chalice('app-name')
+        called = []
+
+        @demo.middleware('all')
+        def mymiddleware(event, get_response):
+            called.append({'name': 'mymiddleware', 'method': event.method})
+            response = get_response(event)
+            response.status_code = 201
+            return response
+
+        @demo.route('/')
+        def index():
+            called.append({'url': '/'})
+            return {'index': True}
+
+        @demo.route('/hello')
+        def hello():
+            called.append({'url': '/hello'})
+            return {'hello': True}
+
+        with Client(demo) as c:
+            assert c.http.get('/').json_body == {'index': True}
+            response = c.http.get('/hello')
+            assert response.json_body == {'hello': True}
+            # Verify middleware can alter the response.
+            assert response.status_code == 201
+
+        assert called == [
+            {'name': 'mymiddleware', 'method': 'GET'},
+            {'url': '/'},
+            {'name': 'mymiddleware', 'method': 'GET'},
+            {'url': '/hello'},
+        ]
+
+    def test_can_filter_middleware_registration(self, sample_middleware_app):
+        with Client(sample_middleware_app) as c:
+            c.http.get('/')
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'Request'},
+                {'type': 'http', 'event': 'Request'},
+            ]
+            sample_middleware_app.calls[:] = []
+            c.lambda_.invoke(
+                's3_handler', c.events.generate_s3_event('bucket', 'key'))
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'S3Event'},
+                {'type': 's3', 'event': 'S3Event'},
+            ]
+            sample_middleware_app.calls[:] = []
+            c.lambda_.invoke(
+                'sns_handler', c.events.generate_sns_event('topic', 'message'))
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'SNSEvent'},
+                {'type': 'sns', 'event': 'SNSEvent'},
+            ]
+            sample_middleware_app.calls[:] = []
+            c.lambda_.invoke(
+                'sqs_handler', c.events.generate_sns_event('queue', 'message'))
+            # There is no sqs specific middleware.
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'SQSEvent'},
+            ]
+            sample_middleware_app.calls[:] = []
+            c.lambda_.invoke('lambda_handler', {})
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'LambdaFunctionEvent'},
+                {'type': 'pure_lambda', 'event': 'LambdaFunctionEvent'},
+            ]
+            sample_middleware_app.calls[:] = []
+            c.lambda_.invoke('ws_handler', {
+                'requestContext': {
+                    'domainName': 'example.com',
+                    'stage': 'dev',
+                    'connectionId': 'abcd',
+                },
+                'body': "body"
+            })
+            assert sample_middleware_app.calls == [
+                {'type': 'all', 'event': 'WebsocketEvent'},
+                {'type': 'websocket', 'event': 'WebsocketEvent'},
+            ]
+
+    def test_can_register_middleware_on_blueprints(self):
+        demo = app.Chalice('app-name')
+        bp = app.Blueprint('bpmiddleware')
+        called = []
+
+        @demo.middleware('all')
+        def mymiddleware(event, get_response):
+            called.append({'name': 'fromapp', 'bucket': event.bucket})
+            return get_response(event)
+
+        @bp.middleware('all')
+        def bp_middleware(event, get_response):
+            called.append({'name': 'frombp', 'bucket': event.bucket})
+            return get_response(event)
+
+        @bp.on_s3_event('mybucket')
+        def bp_handler(event):
+            called.append({'name': 'bp_handler', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        @bp.route('/')
+        def index():
+            pass
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        demo.register_blueprint(bp)
+
+        with Client(demo) as c:
+            # The order is particular here.  When we're invoking the lambda
+            # function from the "app" (demo) object, we expect
+            # the order to be mymiddleware, bp_middleware because mymiddleware
+            # is registered before the .register_blueprint().
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+            assert response.payload == {'bucket': 'mybucket'}
+            assert called == [
+                {'name': 'fromapp', 'bucket': 'mybucket'},
+                {'name': 'frombp', 'bucket': 'mybucket'},
+                {'name': 'main', 'bucket': 'mybucket'},
+            ]
+            called[:] = []
+            response = c.lambda_.invoke(
+                'bp_handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+            assert response.payload == {'bucket': 'mybucket'}
+            assert called == [
+                {'name': 'fromapp', 'bucket': 'mybucket'},
+                {'name': 'frombp', 'bucket': 'mybucket'},
+                {'name': 'bp_handler', 'bucket': 'mybucket'},
+            ]
+
+    def test_blueprint_gets_middlware_added(self):
+        demo = app.Chalice('app-name')
+        bp = app.Blueprint('bpmiddleware')
+        called = []
+
+        @bp.middleware('all')
+        def bp_middleware(event, get_response):
+            called.append({'name': 'frombp', 'bucket': 'mybucket'})
+            return get_response(event)
+
+        @demo.on_s3_event('mybucket')
+        def handler(event):
+            called.append({'name': 'main', 'bucket': event.bucket})
+            return {'bucket': event.bucket}
+
+        demo.register_blueprint(bp)
+
+        with Client(demo) as c:
+            response = c.lambda_.invoke(
+                'handler', c.events.generate_s3_event('mybucket', 'key')
+            )
+
+        assert response.payload == {'bucket': 'mybucket'}
+        assert called == [
+            {'name': 'frombp', 'bucket': 'mybucket'},
+            {'name': 'main', 'bucket': 'mybucket'},
+        ]


### PR DESCRIPTION
Implements #1509.

A few notes on implementation specific details:

The middleware proposes a unified interface regardless of the
type of lambda function you're working with (event handlers, REST APIs,
Websockets, pure lambda, etc).  However, the underlying implementation
of these handlers were not consistent, so a large chunk of this change
was refactoring the code to be more consistent.  Notably:

* Created a new base class BaseLambdaHandler.  The idea is that all
  event handlers from now on will subclass from this class if they
  can't use an existing handler class.
* I moved all the REST API handling code from `Chalice.__call__` to
  a new RestAPIEventHandler, which implements BaseLambdaHandler.
  Because of backwards compat/legacy reason I can't actually change
  the entry point of the REST APIs to be `Chalice.__call__` so the
  best compromise we have for now is to have `Chalice.__call__`
  call out to the `RestAPIEventHandler`.
* I created a new `LambdaFunctionEvent` that matches our existing
  event handlers.  For backwards compat reasons I can't change
  the interface of `@app.lambda_function()`, but we require a
  consistent interface for middleware where your handler takes
  a single `event` arg.  Perhaps in Chalice 2.0 we can unify this
  and have everything take a single event arg.
