### PR TITLE
Add a CHALICE_CLI_MODE when running CLI commands

### DIFF
--- a/.changes/next-release/27246844313-enhancement-CLI-62329.json
+++ b/.changes/next-release/27246844313-enhancement-CLI-62329.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "CLI",
-  "description": "Add `CHALICE_CLI_MODE` whenever a Chalice CLI command is run (#1200)"
+  "description": "Set `AWS_CHALICE_CLI_MODE` env var whenever a Chalice CLI command is run (#1200)"
 }

--- a/.changes/next-release/27246844313-enhancement-CLI-62329.json
+++ b/.changes/next-release/27246844313-enhancement-CLI-62329.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "CLI",
+  "description": "Add `CHALICE_CLI_MODE` whenever a Chalice CLI command is run (#1200)"
+}

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -122,7 +122,7 @@ def _configure_cli_env_vars():
     # we're running a Chalice CLI command.  This is useful if you want
     # conditional behavior only when we're actually running in Lambda
     # in your app.py file.
-    os.environ['CHALICE_CLI_MODE'] = 'true'
+    os.environ['AWS_CHALICE_CLI_MODE'] = 'true'
 
 
 @cli.command()

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -109,10 +109,20 @@ def cli(ctx, project_dir, debug=False):
         project_dir = os.path.abspath(project_dir)
     if debug is True:
         _configure_logging(logging.DEBUG)
+    _configure_cli_env_vars()
     ctx.obj['project_dir'] = project_dir
     ctx.obj['debug'] = debug
     ctx.obj['factory'] = CLIFactory(project_dir, debug, environ=os.environ)
     os.chdir(project_dir)
+
+
+def _configure_cli_env_vars():
+    # type: () -> None
+    # This will set chalice specific env vars so users can detect if
+    # we're running a Chalice CLI command.  This is useful if you want
+    # conditional behavior only when we're actually running in Lambda
+    # in your app.py file.
+    os.environ['CHALICE_CLI_MODE'] = 'true'
 
 
 @cli.command()

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -154,7 +154,7 @@ Environment Variables
 As part of the packaging and deployment process, Chalice will import your
 ``app.py`` file.  This will result in any top level module code being
 executed.  This can sometimes have undesireable behavior.
-When running any Chalice CLI commands, a ``CHALICE_CLI_MODE`` environment
+When running any Chalice CLI commands, a ``AWS_CHALICE_CLI_MODE`` environment
 variable is set.  You can check if this env var is set in your ``app.py``
 if you have code that you don't want to run whenever your app is packaged
 and deployed.
@@ -166,7 +166,7 @@ and deployed.
    app = Chalice(app_name='testimport')
 
    expensive_connection = None
-   if 'CHALICE_CLI_MODE' not in os.environ:
+   if 'AWS_CHALICE_CLI_MODE' not in os.environ:
        # We're running in Lambda, we want to start up
        # our connection to our DB.
        expensive_connection = ConnectToDB()

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -148,6 +148,29 @@ your file::
            if os.path.isfile(full_path):
                return open(full_path)
 
+Environment Variables
+---------------------
+
+As part of the packaging and deployment process, Chalice will import your
+``app.py`` file.  This will result in any top level module code being
+executed.  This can sometimes have undesireable behavior.
+When running any Chalice CLI commands, a ``CHALICE_CLI_MODE`` environment
+variable is set.  You can check if this env var is set in your ``app.py``
+if you have code that you don't want to run whenever your app is packaged
+and deployed.
+
+.. code-block:: python
+
+   import os
+
+   app = Chalice(app_name='testimport')
+
+   expensive_connection = None
+   if 'CHALICE_CLI_MODE' not in os.environ:
+       # We're running in Lambda, we want to start up
+       # our connection to our DB.
+       expensive_connection = ConnectToDB()
+
 
 .. _package-examples:
 

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -708,3 +708,10 @@ def test_can_generate_appgraph(runner, mock_cli_factory):
         # Just sanity checking some of the output
         assert 'Application' in result.output
         assert 'RestAPI(' in result.output
+
+
+def test_chalice_cli_mode_env_var_always_set(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli.new_project, ['testproject'])
+        assert result.exit_code == 0
+        assert os.environ['CHALICE_CLI_MODE'] == 'true'

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -714,4 +714,4 @@ def test_chalice_cli_mode_env_var_always_set(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(cli.new_project, ['testproject'])
         assert result.exit_code == 0
-        assert os.environ['CHALICE_CLI_MODE'] == 'true'
+        assert os.environ['AWS_CHALICE_CLI_MODE'] == 'true'


### PR DESCRIPTION
Fixes https://github.com/aws/chalice/issues/1200

This also makes is possible if other tools want to check
if Chalice is running in CLI mode and disable any
additional functionality as needed.

cc @stealthycoin 