### PR TITLE
Update middleware/xray based on feedback/issues

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -399,7 +399,7 @@ class Request(object):
         self._raw_body = b''
         self.context = event_dict['requestContext']
         self.stage_vars = event_dict['stageVariables']
-        self.uri = event_dict['requestContext']['resourcePath']
+        self.path = event_dict['requestContext']['resourcePath']
         self.lambda_context = lambda_context
         self._event_dict = event_dict
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -381,6 +381,8 @@ class CORSConfig(object):
 class Request(object):
     """The current request from API gateway."""
 
+    _NON_SERIALIZED_ATTRS = ['lambda_context']
+
     def __init__(self, event_dict, lambda_context=None):
         query_params = event_dict['multiValueQueryStringParameters']
         self.query_params = None if query_params is None \
@@ -430,8 +432,11 @@ class Request(object):
 
     def to_dict(self):
         # Don't copy internal attributes.
-        copied = {k: v for k, v in self.__dict__.items()
-                  if not k.startswith('_')}
+        copied = {
+            k: v for k, v in self.__dict__.items()
+            if not k.startswith('_') and
+            k not in self._NON_SERIALIZED_ATTRS
+        }
         # We want the output of `to_dict()` to be
         # JSON serializable, so we need to remove the CaseInsensitive dict.
         copied['headers'] = dict(copied['headers'])

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1089,7 +1089,7 @@ class TypedAWSClient(object):
         client.create_deployment(
             restApiId=rest_api_id,
             stageName=api_gateway_stage,
-            tracingEnabled=xray
+            tracingEnabled=bool(xray),
         )
 
     def add_permission_for_apigateway(self, function_name,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -483,9 +483,9 @@ Request
               pass
 
 
-  .. attribute:: uri
+  .. attribute:: path
 
-     The URI of the HTTP request.
+     The path of the HTTP request.
 
   .. attribute:: query_params
 

--- a/docs/source/topics/middleware.rst
+++ b/docs/source/topics/middleware.rst
@@ -236,18 +236,18 @@ to all Lambda functions in our application.
     )
 
     # Here we're writing Chalice specific middleware where for any HTTP
-    # APIs, we want to add the request uri to our structured log message.
+    # APIs, we want to add the request path to our structured log message.
     # This shows how we can combine both Chalice-style middleware with
     # other existing tools.
     @app.middleware('http')
     def inject_route_info(event, get_response):
-        logger.structure_logs(append=True, request_uri=event.uri)
+        logger.structure_logs(append=True, request_path=event.path)
         return get_response(event)
 
 
     @app.route('/')
     def index():
-        logger.info("In index() function, this will have a 'request_uri' key.")
+        logger.info("In index() function, this will have a 'path' key.")
         return {'hello': 'world'}
 
 

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -50,6 +50,18 @@ def test_deploy_rest_api(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_defaults_to_false_if_none_deploy_rest_api(stubbed_session):
+    stub_client = stubbed_session.stub('apigateway')
+    stub_client.create_deployment(
+        restApiId='api_id', stageName='stage',
+        tracingEnabled=False).returns({})
+
+    stubbed_session.activate_stubs()
+    awsclient = TypedAWSClient(stubbed_session)
+    awsclient.deploy_rest_api('api_id', 'stage', None)
+    stubbed_session.verify_stubs()
+
+
 def test_put_role_policy(stubbed_session):
     stubbed_session.stub('iam').put_role_policy(
         RoleName='role_name',

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -41,7 +41,7 @@ STR_TO_LIST_MAP = st.dictionaries(
 )
 HTTP_METHOD = st.sampled_from(['GET', 'POST', 'PUT', 'PATCH',
                                'OPTIONS', 'HEAD', 'DELETE'])
-URIS = st.sampled_from(['/', '/foo/bar'])
+PATHS = st.sampled_from(['/', '/foo/bar'])
 HTTP_BODY = st.none() | st.text()
 HTTP_REQUEST = st.fixed_dictionaries({
     'query_params': STR_TO_LIST_MAP,
@@ -52,7 +52,7 @@ HTTP_REQUEST = st.fixed_dictionaries({
     'context': STR_MAP,
     'stage_vars': STR_MAP,
     'is_base64_encoded': st.booleans(),
-    'uri': URIS,
+    'path': PATHS,
 })
 HTTP_REQUEST = st.fixed_dictionaries({
     'multiValueQueryStringParameters': st.fixed_dictionaries({}),
@@ -60,7 +60,7 @@ HTTP_REQUEST = st.fixed_dictionaries({
     'pathParameters': STR_MAP,
     'requestContext': st.fixed_dictionaries({
         'httpMethod': HTTP_METHOD,
-        'resourcePath': URIS,
+        'resourcePath': PATHS,
     }),
     'body': HTTP_BODY,
     'stageVariables': STR_MAP,
@@ -2877,7 +2877,7 @@ class TestMiddleware:
             response = c.http.get('/')
         assert response.json_body == {'hello': 'world'}
         actual_event = called[0]['event']
-        assert actual_event.uri == '/'
+        assert actual_event.path == '/'
         assert actual_event.lambda_context.function_name == 'api_handler'
         assert actual_event.to_original_event()[
             'requestContext']['resourcePath'] == '/'

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -167,7 +167,7 @@ def create_request_with_content_type(content_type):
         'stageVariables': {},
         'isBase64Encoded': False,
     }
-    return app.Request(event)
+    return app.Request(event, FakeLambdaContext())
 
 
 def assert_response_body_is(response, body):
@@ -1711,7 +1711,7 @@ def test_raw_body_is_none_if_body_is_none():
         'stageVariables': {},
         'isBase64Encoded': False,
     }
-    request = app.Request(event)
+    request = app.Request(event, FakeLambdaContext())
     assert request.raw_body == b''
 
 
@@ -1732,7 +1732,7 @@ def test_http_request_to_dict_is_json_serializable(http_request_event):
             http_request_event['body'].encode('utf-8'))
         http_request_event['body'] = body.decode('ascii')
 
-    request = Request(http_request_event)
+    request = Request(http_request_event, FakeLambdaContext())
     assert isinstance(request.raw_body, bytes)
     request_dict = request.to_dict()
     # We should always be able to dump the request dict


### PR DESCRIPTION
1. Don't serialize lambda context to preserve the property that `to_dict()` is always JSON serializable.
2. Rename `uri` to `path` attribute to make it more clear (and correct) as to what this attr is.
3. Ensure tracing enabled is always a boolean when deploying a REST API.