### PR TITLE
Check for acceptable action when multiple actions are provided.

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -382,7 +382,8 @@ class LocalGatewayAuthorizer(object):
         allow_resource_statements = []
         for statement in statements:
             if statement.get('Effect') == 'Allow' and \
-               statement.get('Action') == 'execute-api:Invoke':
+               statement.get('Action') == 'execute-api:Invoke' or \
+               'execute-api:Invoke' in statement.get('Action'):
                 for resource in statement.get('Resource'):
                     allow_resource_statements.append(resource)
 


### PR DESCRIPTION
*Issue #, if available:*
I didn't file an Issue, just opened this PR.

*Description of changes:*
In an IAM policy, the `Action` field may be a list of actions. But when running Chalice locally, the comparison for permitted action only compares directly against the string `'execute-api:Invoke'`, not allowing for it to be included in a list, like `['execute-api:Invoke']`.

This change supports Chalice running locally to accept `['execute-api:Invoke']`.

Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
