### PR TITLE
Support returning native python types with binary types

### DIFF
--- a/.changes/next-release/51581685415-enhancement-Binary-64168.json
+++ b/.changes/next-release/51581685415-enhancement-Binary-64168.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Binary",
+  "description": "Support returning native python types when using `*/*` for binary types (#1501)"
+}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -494,12 +494,17 @@ class Response(object):
         body = response_dict['body']
 
         if _matches_content_type(content_type, binary_types):
-            if _matches_content_type(content_type, ['application/json']):
+            if _matches_content_type(content_type, ['application/json']) or \
+                    not content_type:
                 # There's a special case when a user configures
                 # ``application/json`` as a binary type.  The default
                 # json serialization results in a string type, but for binary
                 # content types we need a type bytes().  So we need to special
                 # case this scenario and encode the JSON body to bytes().
+                #
+                # If a user does not provide a content type header, which can
+                # happen if they return a python type instead of a ``Response``
+                # type, then we assume the content is application/json.
                 body = body if isinstance(body, bytes) \
                     else body.encode('utf-8')
             body = self._base64encode(body)


### PR DESCRIPTION
When using `*/*` for binary types, we'll always return binary
back to the user.  However, we previously required that you
have to use a `Response` return type if you wanted to provide
a JSON response.  With this change, you can now return a native
python type, and we'll automatically convert it to a binary
response type (i.e encode the type as json, then base64 encode
it and set the isBase64Encoded flag).

The current behavior is to fail with a ValueError saying that we
expected a ``bytes`` type instead of a ``str`` type, so this change
is flipping an existing error case to a success case.

See https://github.com/aws/chalice/issues/1501#issuecomment-696286897

Fixes #1501.