### PR TITLE
Add support for kinesis/dynamodb stream handlers

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1804,8 +1804,6 @@ class KinesisRecord(BaseLambdaEvent):
     def _extract_attributes(self, event_dict):
         kinesis = event_dict['kinesis']
         encoded_payload = kinesis['data']
-        # Double check on python3 on this.  I think we
-        # might need to encode as ascii the encoded_payload.
         self.data = base64.b64decode(encoded_payload)
         self.sequence_number = kinesis['sequenceNumber']
         self.partition_key = kinesis['partitionKey']

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -706,10 +706,10 @@ class DecoratorAPI(object):
                                  'starting_position': starting_position},
         )
 
-    def on_dynamodb_message(self, stream_arn, batch_size=100,
-                            starting_position='LATEST', name=None):
+    def on_dynamodb_record(self, stream_arn, batch_size=100,
+                           starting_position='LATEST', name=None):
         return self._create_registration_function(
-            handler_type='on_dynamodb_message',
+            handler_type='on_dynamodb_record',
             name=name,
             registration_kwargs={'stream_arn': stream_arn,
                                  'batch_size': batch_size,
@@ -775,7 +775,7 @@ class DecoratorAPI(object):
             'on_sqs_message': SQSEvent,
             'on_cw_event': CloudWatchEvent,
             'on_kinesis_record': KinesisEvent,
-            'on_dynamodb_message': DynamoDBEvent,
+            'on_dynamodb_record': DynamoDBEvent,
             'schedule': CloudWatchEvent,
             'lambda_function': LambdaFunctionEvent,
         }
@@ -785,7 +785,7 @@ class DecoratorAPI(object):
             'on_sqs_message': 'sqs',
             'on_cw_event': 'cloudwatch',
             'on_kinesis_record': 'kinesis',
-            'on_dynamodb_message': 'dynamodb',
+            'on_dynamodb_record': 'dynamodb',
             'schedule': 'scheduled',
             'lambda_function': 'pure_lambda',
         }
@@ -969,8 +969,8 @@ class _HandlerRegistration(object):
         )
         self.event_sources.append(kinesis_config)
 
-    def _register_on_dynamodb_message(self, name, handler_string,
-                                      kwargs, **unused):
+    def _register_on_dynamodb_record(self, name, handler_string,
+                                     kwargs, **unused):
         ddb_config = DynamoDBEventConfig(
             name=name,
             handler_string=handler_string,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1827,6 +1827,7 @@ class DynamoDBRecord(BaseLambdaEvent):
     def _extract_attributes(self, event_dict):
         dynamodb = event_dict['dynamodb']
         self.timestamp = datetime.datetime.utcfromtimestamp(
+        self.keys = dynamodb.get('Keys')
         self.new_image = dynamodb.get('NewImage')
         self.old_image = dynamodb.get('OldImage')
         self.sequence_number = dynamodb['SequenceNumber']

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1827,6 +1827,7 @@ class DynamoDBRecord(BaseLambdaEvent):
     def _extract_attributes(self, event_dict):
         dynamodb = event_dict['dynamodb']
         self.timestamp = datetime.datetime.utcfromtimestamp(
+            dynamodb['ApproximateCreationDateTime'])
         self.keys = dynamodb.get('Keys')
         self.new_image = dynamodb.get('NewImage')
         self.old_image = dynamodb.get('OldImage')

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1832,6 +1832,28 @@ class DynamoDBRecord(BaseLambdaEvent):
         self.sequence_number = dynamodb['SequenceNumber']
         self.size_bytes = dynamodb['SizeBytes']
         self.stream_view_type = dynamodb['StreamViewType']
+        # These are from the top level keys in a record.
+        self.aws_region = event_dict['awsRegion']
+        self.event_id = event_dict['eventID']
+        self.event_name = event_dict['eventName']
+        self.event_source_arn = event_dict['eventSourceARN']
+
+    @property
+    def table_name(self):
+        # Converts:
+        # "arn:aws:dynamodb:us-west-2:12345:table/MyTable/"
+        # "stream/2020-09-28T16:49:14.209"
+        #
+        # into:
+        # "MyTable"
+        parts = self.event_source_arn.split(':', 5)
+        if not len(parts) == 6:
+            return ''
+        full_name = parts[-1]
+        name_parts = full_name.split('/')
+        if len(name_parts) >= 2:
+            return name_parts[1]
+        return ''
 
 
 class Blueprint(DecoratorAPI):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -696,10 +696,10 @@ class DecoratorAPI(object):
                                  'description': description},
         )
 
-    def on_kinesis_message(self, stream, batch_size=100,
-                           starting_position='LATEST', name=None):
+    def on_kinesis_record(self, stream, batch_size=100,
+                          starting_position='LATEST', name=None):
         return self._create_registration_function(
-            handler_type='on_kinesis_message',
+            handler_type='on_kinesis_record',
             name=name,
             registration_kwargs={'stream': stream,
                                  'batch_size': batch_size,
@@ -774,7 +774,7 @@ class DecoratorAPI(object):
             'on_sns_message': SNSEvent,
             'on_sqs_message': SQSEvent,
             'on_cw_event': CloudWatchEvent,
-            'on_kinesis_message': KinesisEvent,
+            'on_kinesis_record': KinesisEvent,
             'on_dynamodb_message': DynamoDBEvent,
             'schedule': CloudWatchEvent,
             'lambda_function': LambdaFunctionEvent,
@@ -784,7 +784,7 @@ class DecoratorAPI(object):
             'on_sns_message': 'sns',
             'on_sqs_message': 'sqs',
             'on_cw_event': 'cloudwatch',
-            'on_kinesis_message': 'kinesis',
+            'on_kinesis_record': 'kinesis',
             'on_dynamodb_message': 'dynamodb',
             'schedule': 'scheduled',
             'lambda_function': 'pure_lambda',
@@ -958,8 +958,8 @@ class _HandlerRegistration(object):
         )
         self.event_sources.append(sqs_config)
 
-    def _register_on_kinesis_message(self, name, handler_string,
-                                     kwargs, **unused):
+    def _register_on_kinesis_record(self, name, handler_string,
+                                    kwargs, **unused):
         kinesis_config = KinesisEventConfig(
             name=name,
             handler_string=handler_string,

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -167,11 +167,11 @@ class DecoratorAPI(object):
                           startition_position: str='LATEST',
                           name: Optional[str]=None) -> Callable[..., Any]: ...
 
-    def on_dynamodb_message(self,
-                            stream_arn: str,
-                            batch_size: int=100,
-                            startition_position: str='LATEST',
-                            name: Optional[str]=None) -> Callable[..., Any]: ...
+    def on_dynamodb_record(self,
+                           stream_arn: str,
+                           batch_size: int=100,
+                           startition_position: str='LATEST',
+                           name: Optional[str]=None) -> Callable[..., Any]: ...
 
     def schedule(self,
                  expression: str,

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -161,11 +161,11 @@ class DecoratorAPI(object):
                        batch_size: int=1,
                        name: Optional[str]=None) -> Callable[..., Any]: ...
 
-    def on_kinesis_message(self,
-                           stream: str,
-                           batch_size: int=100,
-                           startition_position: str='LATEST',
-                           name: Optional[str]=None) -> Callable[..., Any]: ...
+    def on_kinesis_record(self,
+                          stream: str,
+                          batch_size: int=100,
+                          startition_position: str='LATEST',
+                          name: Optional[str]=None) -> Callable[..., Any]: ...
 
     def on_dynamodb_message(self,
                             stream_arn: str,

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -167,6 +167,12 @@ class DecoratorAPI(object):
                            startition_position: str='LATEST',
                            name: Optional[str]=None) -> Callable[..., Any]: ...
 
+    def on_dynamodb_message(self,
+                            stream_arn: str,
+                            batch_size: int=100,
+                            startition_position: str='LATEST',
+                            name: Optional[str]=None) -> Callable[..., Any]: ...
+
     def schedule(self,
                  expression: str,
                  name: Optional[str]=None,

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -161,6 +161,12 @@ class DecoratorAPI(object):
                        batch_size: int=1,
                        name: Optional[str]=None) -> Callable[..., Any]: ...
 
+    def on_kinesis_message(self,
+                           stream: str,
+                           batch_size: int=100,
+                           startition_position: str='LATEST',
+                           name: Optional[str]=None) -> Callable[..., Any]: ...
+
     def schedule(self,
                  expression: str,
                  name: Optional[str]=None,
@@ -288,6 +294,12 @@ class ScheduledEventConfig(BaseEventSourceConfig):
 
 class CloudWatchEventConfig(BaseEventSourceConfig):
     event_pattern = ...  # type: Dict
+
+
+class KinesisEventConfig(BaseEventSourceConfig):
+    stream = ...             # type: str
+    batch_size = ...         # type: int
+    starting_position = ...  # type: str
 
 
 class Blueprint(DecoratorAPI):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -302,6 +302,12 @@ class KinesisEventConfig(BaseEventSourceConfig):
     starting_position = ...  # type: str
 
 
+class DynamoDBEventConfig(BaseEventSourceConfig):
+    stream_arn = ...             # type: str
+    batch_size = ...             # type: int
+    starting_position = ...      # type: str
+
+
 class Blueprint(DecoratorAPI):
     current_request = ... # type: Request
     lambda_context = ... # type: LambdaContext

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1601,20 +1601,23 @@ class TypedAWSClient(object):
                     StatementId=statement['Sid'],
                 )
 
-    def create_sqs_event_source(self, queue_arn, function_name, batch_size):
-        # type: (str, str, int) -> None
+    def create_lambda_event_source(self, event_source_arn, function_name,
+                                   batch_size, starting_position=None):
+        # type: (str, str, int, Optional[str]) -> None
         lambda_client = self._client('lambda')
         kwargs = {
-            'EventSourceArn': queue_arn,
+            'EventSourceArn': event_source_arn,
             'FunctionName': function_name,
             'BatchSize': batch_size,
         }
+        if starting_position is not None:
+            kwargs['StartingPosition'] = starting_position
         return self._call_client_method_with_retries(
             lambda_client.create_event_source_mapping, kwargs,
             max_attempts=self.LAMBDA_CREATE_ATTEMPTS
         )['UUID']
 
-    def update_sqs_event_source(self, event_uuid, batch_size):
+    def update_lambda_event_source(self, event_uuid, batch_size):
         # type: (str, int) -> None
         lambda_client = self._client('lambda')
         self._call_client_method_with_retries(
@@ -1624,7 +1627,7 @@ class TypedAWSClient(object):
             should_retry=self._is_settling_error,
         )
 
-    def remove_sqs_event_source(self, event_uuid):
+    def remove_lambda_event_source(self, event_uuid):
         # type: (str) -> None
         lambda_client = self._client('lambda')
         self._call_client_method_with_retries(

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1665,6 +1665,27 @@ class TypedAWSClient(object):
         except client.exceptions.ResourceNotFoundException:
             return False
 
+    def verify_event_source_arn_current(self, event_uuid, event_source_arn,
+                                        function_arn):
+        # type: (str, str, str) -> bool
+        """Check if the uuid matches the event and function ARN.
+
+        This is similar to verify_event_source_current, except that you provide
+        an explicit event_source_arn here.  This is useful for cases where you
+        know the event source ARN or where you can't construct the event source
+        arn solely based on the resource_name and the service_name.
+
+        """
+        client = self._client('lambda')
+        try:
+            attributes = client.get_event_source_mapping(UUID=event_uuid)
+        except client.exceptions.ResourceNotFoundException:
+            return False
+        return bool(
+            event_source_arn == attributes['EventSourceArn'] and
+            function_arn == attributes['FunctionArn']
+        )
+
     def create_websocket_api(self, name):
         # type: (str) -> str
         client = self._client('apigatewayv2')

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -263,6 +263,18 @@ KINESIS_EVENT_SOURCE_POLICY = {
 }
 
 
+DDB_EVENT_SOURCE_POLICY = {
+    "Effect": "Allow",
+    "Action": [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams"
+    ],
+    "Resource": "*"
+}
+
+
 POST_TO_WEBSOCKET_CONNECTION_POLICY = {
     "Effect": "Allow",
     "Action": [

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -251,6 +251,18 @@ SQS_EVENT_SOURCE_POLICY = {
 }
 
 
+KINESIS_EVENT_SOURCE_POLICY = {
+    "Effect": "Allow",
+    "Action": [
+        "kinesis:GetRecords",
+        "kinesis:GetShardIterator",
+        "kinesis:DescribeStream",
+        "kinesis:ListStreams",
+    ],
+    "Resource": "*",
+}
+
+
 POST_TO_WEBSOCKET_CONNECTION_POLICY = {
     "Effect": "Allow",
     "Action": [

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -114,6 +114,12 @@ class ApplicationGraphBuilder(object):
                         config, deployment, event_source, stage_name,
                     )
                 )
+            elif isinstance(event_source, app.KinesisEventConfig):
+                resources.append(
+                    self._create_kinesis_subscription(
+                        config, deployment, event_source, stage_name,
+                    )
+                )
         return resources
 
     def _create_rest_api_model(self,
@@ -555,6 +561,28 @@ class ApplicationGraphBuilder(object):
             lambda_function=lambda_function,
         )
         return sqs_event_source
+
+    def _create_kinesis_subscription(
+        self,
+        config,          # type: Config
+        deployment,      # type: models.DeploymentPackage
+        kinesis_config,  # type: app.KinesisEventConfig
+        stage_name,      # type: str
+    ):
+        # type: (...) -> models.KinesisEventSource
+        lambda_function = self._create_lambda_model(
+            config=config, deployment=deployment, name=kinesis_config.name,
+            handler_name=kinesis_config.handler_string, stage_name=stage_name
+        )
+        resource_name = kinesis_config.name + '-kinesis-event-source'
+        kinesis_event_source = models.KinesisEventSource(
+            resource_name=resource_name,
+            stream=kinesis_config.stream,
+            batch_size=kinesis_config.batch_size,
+            starting_position=kinesis_config.starting_position,
+            lambda_function=lambda_function,
+        )
+        return kinesis_event_source
 
 
 class DependencyBuilder(object):

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -120,6 +120,12 @@ class ApplicationGraphBuilder(object):
                         config, deployment, event_source, stage_name,
                     )
                 )
+            elif isinstance(event_source, app.DynamoDBEventConfig):
+                resources.append(
+                    self._create_ddb_subscription(
+                        config, deployment, event_source, stage_name,
+                    )
+                )
         return resources
 
     def _create_rest_api_model(self,
@@ -583,6 +589,28 @@ class ApplicationGraphBuilder(object):
             lambda_function=lambda_function,
         )
         return kinesis_event_source
+
+    def _create_ddb_subscription(
+        self,
+        config,          # type: Config
+        deployment,      # type: models.DeploymentPackage
+        ddb_config,      # type: app.DynamoDBEventConfig
+        stage_name,      # type: str
+    ):
+        # type: (...) -> models.DynamoDBEventSource
+        lambda_function = self._create_lambda_model(
+            config=config, deployment=deployment, name=ddb_config.name,
+            handler_name=ddb_config.handler_string, stage_name=stage_name
+        )
+        resource_name = ddb_config.name + '-dynamodb-event-source'
+        ddb_event_source = models.DynamoDBEventSource(
+            resource_name=resource_name,
+            stream_arn=ddb_config.stream_arn,
+            batch_size=ddb_config.batch_size,
+            starting_position=ddb_config.starting_position,
+            lambda_function=lambda_function,
+        )
+        return ddb_event_source
 
 
 class DependencyBuilder(object):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -334,3 +334,11 @@ class SQSEventSource(FunctionEventSubscriber):
     resource_type = 'sqs_event'
     queue = attrib()            # type: str
     batch_size = attrib()       # type: int
+
+
+@attrs
+class KinesisEventSource(FunctionEventSubscriber):
+    resource_type = 'kinesis_event'
+    stream = attrib()                # type: str
+    batch_size = attrib()            # type: int
+    starting_position = attrib()     # type: str

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -342,3 +342,11 @@ class KinesisEventSource(FunctionEventSubscriber):
     stream = attrib()                # type: str
     batch_size = attrib()            # type: int
     starting_position = attrib()     # type: str
+
+
+@attrs
+class DynamoDBEventSource(FunctionEventSubscriber):
+    resource_type = 'dynamodb_event'
+    stream_arn = attrib()            # type: str
+    batch_size = attrib()            # type: int
+    starting_position = attrib()     # type: str

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -705,7 +705,7 @@ class PlanStage(object):
                     ['partition', 'region_name', 'account_id'],
                 ),
             )
-        )  # type: List[InstructionMsg]
+        )
         if self._remote_state.resource_exists(resource):
             deployed = self._remote_state.resource_deployed_values(resource)
             uuid = deployed['event_uuid']
@@ -759,7 +759,7 @@ class PlanStage(object):
                     ['partition', 'region_name', 'account_id'],
                 ),
             )
-        )  # type: List[InstructionMsg]
+        )
         if self._remote_state.resource_exists(resource):
             deployed = self._remote_state.resource_deployed_values(resource)
             uuid = deployed['event_uuid']

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -112,6 +112,19 @@ class RemoteState(object):
             function_arn=deployed_values['lambda_arn'],
         )
 
+    def _resource_exists_dynamodbeventsource(self, resource):
+        # type: (models.DynamoDBEventSource) -> bool
+        try:
+            deployed_values = self._deployed_resources.resource_values(
+                resource.resource_name)
+        except ValueError:
+            return False
+        return self._client.verify_event_source_arn_current(
+            event_uuid=deployed_values['event_uuid'],
+            event_source_arn=deployed_values['stream_arn'],
+            function_arn=deployed_values['lambda_arn'],
+        )
+
     def _resource_exists_lambdalayer(self, resource):
         # type: (models.LambdaLayer) -> bool
         try:
@@ -623,21 +636,8 @@ class PlanStage(object):
             # To keep the user API simple, we only require the topic
             # name and not the ARN.  However, the APIs require the topic
             # ARN so we need to reconstruct it here in the planner.
-            instruction_for_topic_arn += [
-                models.BuiltinFunction(
-                    'parse_arn',
-                    [function_arn],
-                    output_var='parsed_lambda_arn',
-                ),
-                models.JPSearch('account_id',
-                                input_var='parsed_lambda_arn',
-                                output_var='account_id'),
-                models.JPSearch('region',
-                                input_var='parsed_lambda_arn',
-                                output_var='region_name'),
-                models.JPSearch('partition',
-                                input_var='parsed_lambda_arn',
-                                output_var='partition'),
+            instruction_for_topic_arn += self._arn_parse_instructions(
+                function_arn) + [
                 models.StoreValue(
                     name=topic_arn_varname,
                     value=StringFormat(
@@ -646,7 +646,7 @@ class PlanStage(object):
                         ),
                         ['partition', 'region_name', 'account_id'],
                     ),
-                ),
+                )
             ]
         if self._remote_state.resource_exists(resource):
             # Given there's nothing about an SNS subscription you can
@@ -729,21 +729,8 @@ class PlanStage(object):
         function_arn = Variable(
             '%s_lambda_arn' % resource.lambda_function.resource_name
         )
-        instruction_for_queue_arn = [
-            models.BuiltinFunction(
-                'parse_arn',
-                [function_arn],
-                output_var='parsed_lambda_arn',
-            ),
-            models.JPSearch('account_id',
-                            input_var='parsed_lambda_arn',
-                            output_var='account_id'),
-            models.JPSearch('region',
-                            input_var='parsed_lambda_arn',
-                            output_var='region_name'),
-            models.JPSearch('partition',
-                            input_var='parsed_lambda_arn',
-                            output_var='partition'),
+        instruction_for_queue_arn = self._arn_parse_instructions(function_arn)
+        instruction_for_queue_arn.append(
             models.StoreValue(
                 name=queue_arn_varname,
                 value=StringFormat(
@@ -752,8 +739,8 @@ class PlanStage(object):
                     ),
                     ['partition', 'region_name', 'account_id'],
                 ),
-            ),
-        ]  # type: List[InstructionMsg]
+            )
+        )  # type: List[InstructionMsg]
         if self._remote_state.resource_exists(resource):
             deployed = self._remote_state.resource_deployed_values(resource)
             uuid = deployed['event_uuid']
@@ -762,32 +749,15 @@ class PlanStage(object):
                     method_name='update_sqs_event_source',
                     params={'event_uuid': uuid,
                             'batch_size': resource.batch_size}
-                ),
-                models.RecordResourceValue(
-                    resource_type='sqs_event',
-                    resource_name=resource.resource_name,
-                    name='queue_arn',
-                    value=deployed['queue_arn'],
-                ),
-                models.RecordResourceValue(
-                    resource_type='sqs_event',
-                    resource_name=resource.resource_name,
-                    name='event_uuid',
-                    value=uuid,
-                ),
-                models.RecordResourceValue(
-                    resource_type='sqs_event',
-                    resource_name=resource.resource_name,
-                    name='queue',
-                    value=resource.queue,
-                ),
-                models.RecordResourceValue(
-                    resource_type='sqs_event',
-                    resource_name=resource.resource_name,
-                    name='lambda_arn',
-                    value=deployed['lambda_arn'],
-                ),
-            ]
+                )
+            ] + self._batch_record_resource(
+                'sqs_event', resource.resource_name, {
+                    'queue_arn': deployed['queue_arn'],
+                    'event_uuid': uuid,
+                    'queue': resource.queue,
+                    'lambda_arn': deployed['lambda_arn'],
+                }
+            )
         return instruction_for_queue_arn + [
             (models.APICall(
                 method_name='create_lambda_event_source',
@@ -798,33 +768,14 @@ class PlanStage(object):
             ), 'Subscribing %s to SQS queue %s\n'
                 % (resource.lambda_function.function_name, resource.queue)
             ),
-            models.RecordResourceVariable(
-                resource_type='sqs_event',
-                resource_name=resource.resource_name,
-                name='queue_arn',
-                variable_name=queue_arn_varname,
-            ),
-            # We record this because this is what's used to unsubscribe
-            # lambda to the SQS queue.
-            models.RecordResourceVariable(
-                resource_type='sqs_event',
-                resource_name=resource.resource_name,
-                name='event_uuid',
-                variable_name=uuid_varname,
-            ),
-            models.RecordResourceValue(
-                resource_type='sqs_event',
-                resource_name=resource.resource_name,
-                name='queue',
-                value=resource.queue,
-            ),
-            models.RecordResourceVariable(
-                resource_type='sqs_event',
-                resource_name=resource.resource_name,
-                name='lambda_arn',
-                variable_name=function_arn.name,
-            ),
-        ]
+        ] + self._batch_record_resource(
+            'sqs_event', resource.resource_name, {
+                'queue_arn': Variable(queue_arn_varname),
+                'event_uuid': Variable(uuid_varname),
+                'queue': resource.queue,
+                'lambda_arn': Variable(function_arn.name)
+            }
+        )
 
     def _plan_kinesiseventsource(self, resource):
         # type: (models.KinesisEventSource) -> Sequence[InstructionMsg]
@@ -833,30 +784,17 @@ class PlanStage(object):
         function_arn = Variable(
             '%s_lambda_arn' % resource.lambda_function.resource_name
         )
-        instruction_for_stream_arn = [
-            models.BuiltinFunction(
-                'parse_arn',
-                [function_arn],
-                output_var='parsed_lambda_arn',
-            ),
-            models.JPSearch('account_id',
-                            input_var='parsed_lambda_arn',
-                            output_var='account_id'),
-            models.JPSearch('region',
-                            input_var='parsed_lambda_arn',
-                            output_var='region_name'),
-            models.JPSearch('partition',
-                            input_var='parsed_lambda_arn',
-                            output_var='partition'),
+        instruction_for_stream_arn = self._arn_parse_instructions(function_arn)
+        instruction_for_stream_arn.append(
             models.StoreValue(
                 name=stream_arn_varname,
                 value=StringFormat(
                     'arn:{partition}:kinesis:{region_name}:{account_id}:'
-                    'stream/%s' % (resource.stream),
+                    'stream/%s' % resource.stream,
                     ['partition', 'region_name', 'account_id'],
                 ),
-            ),
-        ]  # type: List[InstructionMsg]
+            )
+        )  # type: List[InstructionMsg]
         if self._remote_state.resource_exists(resource):
             deployed = self._remote_state.resource_deployed_values(resource)
             uuid = deployed['event_uuid']
@@ -909,7 +847,7 @@ class PlanStage(object):
                 variable_name=stream_arn_varname,
             ),
             # We record this because this is what's used to unsubscribe
-            # lambda to the SQS queue.
+            # lambda to the Kinesis stream.
             models.RecordResourceVariable(
                 resource_type='kinesis_event',
                 resource_name=resource.resource_name,
@@ -929,6 +867,62 @@ class PlanStage(object):
                 variable_name=function_arn.name,
             ),
         ]
+
+    def _plan_dynamodbeventsource(self, resource):
+        # type: (models.DynamoDBEventSource) -> Sequence[InstructionMsg]
+        uuid_varname = '%s_uuid' % resource.resource_name
+        function_arn = Variable(
+            '%s_lambda_arn' % resource.lambda_function.resource_name
+        )
+        instructions = []  # type: List[InstructionMsg]
+        if self._remote_state.resource_exists(resource):
+            deployed = self._remote_state.resource_deployed_values(resource)
+            uuid = deployed['event_uuid']
+            return instructions + [
+                models.APICall(
+                    method_name='update_lambda_event_source',
+                    params={'event_uuid': uuid,
+                            'batch_size': resource.batch_size}
+                )
+            ] + self._batch_record_resource(
+                'dynamodb_event', resource.resource_name, {
+                    'stream_arn': deployed['stream_arn'],
+                    'event_uuid': deployed['event_uuid'],
+                    'lambda_arn': deployed['lambda_arn'],
+                }
+            )
+        return instructions + [
+            (models.APICall(
+                method_name='create_lambda_event_source',
+                params={'event_source_arn': resource.stream_arn,
+                        'batch_size': resource.batch_size,
+                        'function_name': function_arn,
+                        'starting_position': resource.starting_position},
+                output_var=uuid_varname,
+            ), 'Subscribing %s to Kinesis stream %s\n'
+                % (resource.lambda_function.function_name,
+                   resource.stream_arn))
+        ] + self._batch_record_resource(
+            'dynamodb_event', resource.resource_name, {
+                'stream_arn': resource.stream_arn,
+                'event_uuid': Variable(uuid_varname),
+                'lambda_arn': function_arn,
+            }
+        )
+
+    def _arn_parse_instructions(self, function_arn):
+        # type: (Variable) -> List[InstructionMsg]
+        instruction_for_stream_arn = [
+            models.BuiltinFunction('parse_arn', [function_arn],
+                                   output_var='parsed_lambda_arn'),
+            models.JPSearch('account_id', input_var='parsed_lambda_arn',
+                            output_var='account_id'),
+            models.JPSearch('region', input_var='parsed_lambda_arn',
+                            output_var='region_name'),
+            models.JPSearch('partition', input_var='parsed_lambda_arn',
+                            output_var='partition'),
+        ]  # type: List[InstructionMsg]
+        return instruction_for_stream_arn
 
     def _plan_s3bucketnotification(self, resource):
         # type: (models.S3BucketNotification) -> Sequence[InstructionMsg]
@@ -1094,25 +1088,7 @@ class PlanStage(object):
         # Which lambda function we use here does not matter. We are only using
         # it to find the account id and the region.
         lambda_arn_var = list(configs.values())[0]['lambda_arn_var']
-        shared_plan_preamble = [
-            # The various API gateway API calls need
-            # to know the region name and account id so
-            # we'll take care of that up front and store
-            # them in variables.
-            models.BuiltinFunction(
-                'parse_arn',
-                [lambda_arn_var],
-                output_var='parsed_lambda_arn',
-            ),
-            models.JPSearch('account_id',
-                            input_var='parsed_lambda_arn',
-                            output_var='account_id'),
-            models.JPSearch('region',
-                            input_var='parsed_lambda_arn',
-                            output_var='region_name'),
-            models.JPSearch('partition',
-                            input_var='parsed_lambda_arn',
-                            output_var='partition'),
+        shared_plan_preamble = self._arn_parse_instructions(lambda_arn_var) + [
             models.JPSearch('dns_suffix',
                             input_var='parsed_lambda_arn',
                             output_var='dns_suffix'),
@@ -1252,25 +1228,7 @@ class PlanStage(object):
         # There's a set of shared instructions that are needed
         # in both the update as well as the initial create case.
         # That's what this shared_plan_premable is for.
-        shared_plan_preamble = [
-            # The various API gateway API calls need
-            # to know the region name and account id so
-            # we'll take care of that up front and store
-            # them in variables.
-            models.BuiltinFunction(
-                'parse_arn',
-                [lambda_arn_var],
-                output_var='parsed_lambda_arn',
-            ),
-            models.JPSearch('account_id',
-                            input_var='parsed_lambda_arn',
-                            output_var='account_id'),
-            models.JPSearch('region',
-                            input_var='parsed_lambda_arn',
-                            output_var='region_name'),
-            models.JPSearch('partition',
-                            input_var='parsed_lambda_arn',
-                            output_var='partition'),
+        shared_plan_preamble = self._arn_parse_instructions(lambda_arn_var) + [
             models.JPSearch('dns_suffix',
                             input_var='parsed_lambda_arn',
                             output_var='dns_suffix'),
@@ -1416,6 +1374,34 @@ class PlanStage(object):
             return Variable('%s_role_arn' % resource.role_name)
         # Make mypy happy.
         raise RuntimeError("Unknown resource type: %s" % resource)
+
+    def _batch_record_resource(self, resource_type, resource_name,
+                               mapping):
+        # type: (str, str, Dict[str, Any]) -> List[InstructionMsg]
+        # This is a helper function for recording multiple values into
+        # the same resource dict.  The mapping is the set of variables
+        # you want to record.  If the value in a pair is a Variable type,
+        # then RecordResourceVariable is used, otherwise, RecordResourceValue
+        # is used.
+        instructions = []  # type: List[InstructionMsg]
+        for key, value in mapping.items():
+            instruction = cast(InstructionMsg, None)
+            if isinstance(value, Variable):
+                instruction = models.RecordResourceVariable(
+                    resource_type=resource_type,
+                    resource_name=resource_name,
+                    name=key,
+                    variable_name=value.name
+                )
+            else:
+                instruction = models.RecordResourceValue(
+                    resource_type=resource_type,
+                    resource_name=resource_name,
+                    name=key,
+                    value=value
+                )
+            instructions.append(instruction)
+        return instructions
 
 
 class NoopPlanner(PlanStage):

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -828,7 +828,7 @@ class PlanStage(object):
                         'function_name': function_arn,
                         'starting_position': resource.starting_position},
                 output_var=uuid_varname,
-            ), 'Subscribing %s to Kinesis stream %s\n'
+            ), 'Subscribing %s to DynamoDB stream %s\n'
                 % (resource.lambda_function.function_name,
                    resource.stream_arn))
         ] + self._batch_record_resource(

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -672,6 +672,25 @@ class SAMTemplateGenerator(TemplateGenerator):
             }
         }
 
+    def _generate_dynamodbeventsource(self, resource, template):
+        # type: (models.DynamoDBEventSource, Dict[str, Any]) -> None
+        function_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        function_cfn = template['Resources'][function_cfn_name]
+        ddb_cfn_name = self._register_cfn_resource_name(
+            resource.resource_name)
+        properties = {
+            'Stream': resource.stream_arn,
+            'BatchSize': resource.batch_size,
+            'StartingPosition': resource.starting_position,
+        }
+        function_cfn['Properties']['Events'] = {
+            ddb_cfn_name: {
+                'Type': 'DynamoDB',
+                'Properties': properties
+            }
+        }
+
     def _generate_apimapping(self, resource, template):
         # type: (models.APIMapping, Dict[str, Any]) -> None
         pass
@@ -899,6 +918,16 @@ class TerraformGenerator(TemplateGenerator):
                 "arn:%(partition)s:kinesis:%(region)s"
                 ":%(account_id)s:stream/%(stream)s",
                 stream=resource.stream),
+            'batch_size': resource.batch_size,
+            'starting_position': resource.starting_position,
+            'function_name': resource.lambda_function.function_name,
+        }
+
+    def _generate_dynamodbeventsource(self, resource, template):
+        # type: (models.DynamoDBEventSource, Dict[str, Any]) -> None
+        template['resource'].setdefault('aws_lambda_event_source_mapping', {})[
+            resource.resource_name] = {
+            'event_source_arn': resource.stream_arn,
             'batch_size': resource.batch_size,
             'starting_position': resource.starting_position,
             'function_name': resource.lambda_function.function_name,

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -647,6 +647,31 @@ class SAMTemplateGenerator(TemplateGenerator):
             }
         }
 
+    def _generate_kinesiseventsource(self, resource, template):
+        # type: (models.KinesisEventSource, Dict[str, Any]) -> None
+        function_cfn_name = to_cfn_resource_name(
+            resource.lambda_function.resource_name)
+        function_cfn = template['Resources'][function_cfn_name]
+        kinesis_cfn_name = self._register_cfn_resource_name(
+            resource.resource_name)
+        properties = {
+            'Stream': {
+                'Fn::Sub': (
+                    'arn:${AWS::Partition}:kinesis:${AWS::Region}'
+                    ':${AWS::AccountId}:stream/%s' %
+                    resource.stream
+                )
+            },
+            'BatchSize': resource.batch_size,
+            'StartingPosition': resource.starting_position,
+        }
+        function_cfn['Properties']['Events'] = {
+            kinesis_cfn_name: {
+                'Type': 'Kinesis',
+                'Properties': properties
+            }
+        }
+
     def _generate_apimapping(self, resource, template):
         # type: (models.APIMapping, Dict[str, Any]) -> None
         pass
@@ -863,6 +888,19 @@ class TerraformGenerator(TemplateGenerator):
                 ":%(account_id)s:%(queue)s",
                 queue=resource.queue),
             'batch_size': resource.batch_size,
+            'function_name': resource.lambda_function.function_name,
+        }
+
+    def _generate_kinesiseventsource(self, resource, template):
+        # type: (models.KinesisEventSource, Dict[str, Any]) -> None
+        template['resource'].setdefault('aws_lambda_event_source_mapping', {})[
+            resource.resource_name] = {
+            'event_source_arn': self._arnref(
+                "arn:%(partition)s:kinesis:%(region)s"
+                ":%(account_id)s:stream/%(stream)s",
+                stream=resource.stream),
+            'batch_size': resource.batch_size,
+            'starting_position': resource.starting_position,
             'function_name': resource.lambda_function.function_name,
         }
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -372,7 +372,7 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_dynamodb_message(stream_arn, batch_size=100,
+   .. method:: on_dynamodb_record(stream_arn, batch_size=100,
                                    starting_position='LATEST', name=None)
 
       Create a lambda function and configure it to be automatically invoked
@@ -392,7 +392,7 @@ Chalice
 
           app.debug = True
 
-          @app.on_dynamodb_message(stream_arn='arn:aws:dynamodb:...:stream')
+          @app.on_dynamodb_record(stream_arn='arn:aws:dynamodb:...:stream')
           def handler(event):
               app.log.info("Event: %s", event.to_dict())
               for record in event:
@@ -1435,7 +1435,7 @@ Event Sources
 
    .. code-block:: python
 
-      @app.on_dynamodb_message(stream_arn='arn:aws:us-west-2:.../stream')
+      @app.on_dynamodb_record(stream_arn='arn:aws:us-west-2:.../stream')
       def event_handler(event: DynamoDBEvent):
           app.log.info("Event: %s", event.to_dict())
           for record in event:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -326,8 +326,8 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_kinesis_message(stream, batch_size=100,
-                                  starting_position='LATEST', name=None)
+   .. method:: on_kinesis_record(stream, batch_size=100,
+                                 starting_position='LATEST', name=None)
 
       Create a lambda function and configure it to be automatically invoked
       whenever data is published to the specified Kinesis stream.
@@ -346,7 +346,7 @@ Chalice
 
           app.debug = True
 
-          @app.on_kinesis_message(stream='mystream')
+          @app.on_kinesis_record(stream='mystream')
           def handler(event):
               app.log.info("Event: %s", event.to_dict())
               for record in event:
@@ -1361,7 +1361,7 @@ Event Sources
 
    .. code-block:: python
 
-      @app.on_kinesis_message(stream='mystream')
+      @app.on_kinesis_record(stream='mystream')
       def event_handler(event: KinesisEvent):
           app.log.info("Event: %s", event.to_dict())
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -353,7 +353,7 @@ Chalice
                   app.log.info("Message body: %s", record.data)
 
       :param stream: The name of the Kinesis stream you want to subscribe to.
-        This is the name of the queue, not the ARN.
+        This is the name of the data stream, not the ARN.
 
       :param batch_size: The maximum number of messages to retrieve
         when polling for Kinesis messages.  The event parameter can have
@@ -372,7 +372,7 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_dynamodb_message(stream, batch_size=100,
+   .. method:: on_dynamodb_message(stream_arn, batch_size=100,
                                    starting_position='LATEST', name=None)
 
       Create a lambda function and configure it to be automatically invoked

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1398,7 +1398,7 @@ Event Sources
    .. attribute:: data
 
       The payload data for the Kinesis record.  This data is automatically
-      base64 decoded for you.
+      base64 decoded for you and will be a ``bytes`` type.
 
    .. attribute:: sequence_number
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1500,6 +1500,29 @@ Event Sources
 
       The type of data from the modified DynamoDB item.
 
+   .. attribute:: aws_region
+
+      The region associated with the event.
+
+   .. attribute:: event_id
+
+      A unique identifier for the event.
+
+   .. attribute:: event_name
+
+      The type of data modification that was performed on the DynamoDB table.
+      This can be: ``INSERT``, ``MODIFY``, or ``DELETE``.
+
+   .. attribute:: event_source_arn
+
+      The ARN of the DynamoDB stream.
+
+   .. attribute:: table_name
+
+      The name of the DynamoDB table associated with the stream.  This value is
+      computed from the ``event_source_arn`` parameter and will be an empty string
+      if Chalice is unable to parse the table name from the event source ARN.
+
    .. attribute:: context
 
       A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -326,7 +326,7 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_kinesis_message(stream, batch_size=1,
+   .. method:: on_kinesis_message(stream, batch_size=100,
                                   starting_position='LATEST', name=None)
 
       Create a lambda function and configure it to be automatically invoked
@@ -358,6 +358,54 @@ Chalice
       :param batch_size: The maximum number of messages to retrieve
         when polling for Kinesis messages.  The event parameter can have
         multiple Kinesis records associated with it.  This is why the
+        event parameter passed to the lambda function is iterable.  The
+        batch size controls how many messages can be in a single event.
+
+      :param starting_position: Specifies where to start processing records.
+        This can have the following values:
+
+        * ``LATEST`` - Process new records that are added to the stream.
+        * ``TRIM_HORIZON`` - Process all records in the stream.
+
+      :param name: The name of the function to use.  This name is combined
+        with the chalice app name as well as the stage name to create the
+        entire lambda function name.  This parameter is optional.  If it is
+        not provided, the name of the python function will be used.
+
+   .. method:: on_dynamodb_message(stream, batch_size=100,
+                                   starting_position='LATEST', name=None)
+
+      Create a lambda function and configure it to be automatically invoked
+      whenever data is written to a DynamoDB stream.
+
+      The lambda function must accept a single parameter which
+      is of type :class:`DynamoDBEvent`.
+
+      If the decorated function raises an exception, Lambda retries the
+      batch until processing succeeds or the data expires.
+
+      See
+      `Using AWS Lambda with Amazon DynamoDB <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html>`__
+      for more information on how Lambda integrates with DynamoDB Streams.
+
+      .. code-block:: python
+
+          app.debug = True
+
+          @app.on_dynamodb_message(stream_arn='arn:aws:dynamodb:...:stream')
+          def handler(event):
+              app.log.info("Event: %s", event.to_dict())
+              for record in event:
+                  app.log.info("New: %s", record.new_image)
+
+      :param stream_arn: The name of the DynamoDB stream ARN you want to
+        subscribe to.  Note that, unlike other event handlers that accept
+        the resource name, you must provide the stream ARN when subscribing
+        to the DynamoDB stream ARN.
+
+      :param batch_size: The maximum number of messages to retrieve
+        when polling for DynamoDB messages.  The event parameter can have
+        multiple DynamoDB records associated with it.  This is why the
         event parameter passed to the lambda function is iterable.  The
         batch size controls how many messages can be in a single event.
 
@@ -1305,6 +1353,164 @@ Event Sources
       Return the original dictionary associated with the given
       message. This is useful if you need direct
       access to the lambda event.
+
+
+.. class:: KinesisEvent()
+
+   This is the input argument for a Kinesis data stream event handler.
+
+   .. code-block:: python
+
+      @app.on_kinesis_message(stream='mystream')
+      def event_handler(event: KinesisEvent):
+          app.log.info("Event: %s", event.to_dict())
+
+   In the code example above, the ``event`` argument is of
+   type ``KinesisEvent``.  A ``KinesisEvent`` can have multiple
+   messages associated with it.  To access the multiple
+   messages, you can iterate over the ``KinesisEvent``.
+
+   .. method:: __iter__()
+
+      Iterate over individual Kinesis records associated with
+      the event.  Each element in the iterable is of type
+      :class:`KinesisRecord`.
+
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
+   .. method:: to_dict()
+
+      Return the original event dictionary provided
+      from Lambda.  This is useful if you need direct
+      access to the lambda event, for example if a
+      new key is added to the lambda event that has not
+      been mapped as an attribute to the ``SQSEvent``
+      object.
+
+.. class:: KinesisRecord()
+
+   Represents a single Kinesis record within a :class:`KinesisEvent`.
+
+   .. attribute:: data
+
+      The payload data for the Kinesis record.  This data is automatically
+      base64 decoded for you.
+
+   .. attribute:: sequence_number
+
+      The unique identifier of the record within its shard.
+
+   .. attribute:: partition_key
+
+      Identifies which shard in the stream the data record is assigned to.
+
+   .. attribute:: schema_version
+
+      Schema version for the record.
+
+   .. attribute:: timestamp
+
+      The approximate time that the record was inserted into the stream.  This
+      is automatically converted to a ``datetime.datetime`` object.
+
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda.
+
+   .. method:: to_dict()
+
+      Return the original dictionary associated with the given
+      message. This is useful if you need direct
+      access to the lambda event.
+
+
+.. class:: DynamoDBEvent()
+
+   This is the input argument for a DynamoDB stream event handler.
+
+   .. code-block:: python
+
+      @app.on_dynamodb_message(stream_arn='arn:aws:us-west-2:.../stream')
+      def event_handler(event: DynamoDBEvent):
+          app.log.info("Event: %s", event.to_dict())
+          for record in event:
+              app.log.info(record.to_dict())
+
+   In the code example above, the ``event`` argument is of
+   type ``DynamoDBEvent``.  A ``DynamoDBEvent`` can have multiple
+   messages associated with it.  To access the multiple
+   messages, you can iterate over the ``DynamoDBEvent``.
+
+   .. method:: __iter__()
+
+      Iterate over individual DynamoDB records associated with
+      the event.  Each element in the iterable is of type
+      :class:`DynamoDBRecord`.
+
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda. This is useful if you need
+      the AWS request ID for tracing, or any other data in the context object.
+
+   .. method:: to_dict()
+
+      Return the original event dictionary provided
+      from Lambda.  This is useful if you need direct
+      access to the lambda event, for example if a
+      new key is added to the lambda event that has not
+      been mapped as an attribute to the ``SQSEvent``
+      object.
+
+.. class:: DynamoDBRecord()
+
+   Represents a single DynamoDB record within a :class:`DynamoDBEvent`.
+
+   .. attribute:: timestamp
+
+      The approximate time that the record was the stream record was created.
+      This is automatically converted to a ``datetime.datetime`` object.
+
+   .. attribute:: keys
+
+      The primary key attribute(s) for the DynamoDB item that was modified.
+
+   .. attribute:: new_image
+
+      The item in the DynamoDB table as it appeared after it was modified.
+
+   .. attribute:: old_image
+
+      The item in the DynamoDB table as it appeared before it was modified.
+
+   .. attribute:: sequence_number
+
+      The sequence number of the stream record.
+
+   .. attribute:: size_bytes
+
+      The size of the stream record, in bytes.
+
+   .. attribute:: stream_view_type
+
+      The type of data from the modified DynamoDB item.
+
+   .. attribute:: context
+
+      A `Lambda context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html>`_
+      that is passed to the handler by AWS Lambda.
+
+   .. method:: to_dict()
+
+      Return the original dictionary associated with the given
+      message. This is useful if you need direct
+      access to the lambda event.
+
 
 .. class:: LambdaFunctionEvent()
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -326,6 +326,52 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
+   .. method:: on_kinesis_message(stream, batch_size=1,
+                                  starting_position='LATEST', name=None)
+
+      Create a lambda function and configure it to be automatically invoked
+      whenever data is published to the specified Kinesis stream.
+
+      The lambda function must accept a single parameter which
+      is of type :class:`KinesisEvent`.
+
+      If the decorated function raises an exception, Lambda retries the
+      batch until processing succeeds or the data expires.
+
+      See
+      `Using AWS Lambda with Amazon Kinesis <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html>`__
+      for more information on how Lambda integrates with Kinesis.
+
+      .. code-block:: python
+
+          app.debug = True
+
+          @app.on_kinesis_message(stream='mystream')
+          def handler(event):
+              app.log.info("Event: %s", event.to_dict())
+              for record in event:
+                  app.log.info("Message body: %s", record.data)
+
+      :param stream: The name of the Kinesis stream you want to subscribe to.
+        This is the name of the queue, not the ARN.
+
+      :param batch_size: The maximum number of messages to retrieve
+        when polling for Kinesis messages.  The event parameter can have
+        multiple Kinesis records associated with it.  This is why the
+        event parameter passed to the lambda function is iterable.  The
+        batch size controls how many messages can be in a single event.
+
+      :param starting_position: Specifies where to start processing records.
+        This can have the following values:
+
+        * ``LATEST`` - Process new records that are added to the stream.
+        * ``TRIM_HORIZON`` - Process all records in the stream.
+
+      :param name: The name of the function to use.  This name is combined
+        with the chalice app name as well as the stage name to create the
+        entire lambda function name.  This parameter is optional.  If it is
+        not provided, the name of the python function will be used.
+
    .. method:: lambda_function(name=None)
 
       Create a pure lambda function that's not connected to anything.

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -349,6 +349,39 @@ previously.  There are a few options available to mitigate this:
 For more information on Lambda and SQS,
 see the `AWS documentation`_.
 
+.. _kinesis-events:
+
+Kinesis Events
+==============
+
+You can configure a Lambda function to be invoked whenever messages are
+published to an Amazon Kinesis data stream.  To configure this, use the
+:meth:`Chalice.on_kinesis_message` decorator and provide the name of the
+Kinesis stream.
+
+The :class:`KinesisEvent` that is passed in as the ``event`` argument
+to the event handler is also iterable.  This allows you to iterate over
+all the records in the event.  Additionally, each record has a ``.data``
+attribute that is automatically base64 decoded for you.
+
+Here's an example:
+
+.. code-block:: python
+
+    from chalice import Chalice
+
+    app = chalice.Chalice(app_name='kinesiseventdemo')
+    app.debug = True
+
+    @app.on_kinesis_message(stream='mystream')
+    def handle_kinesis_message(event):
+        for record in event:
+            # The .data attribute is automatically base64 decoded for you.
+            app.log.debug("Received message with contents: %s", record.data)
+
+For more information on using Kinesis and Lambda, see
+`Using AWS Lambda with Amazon Kinesis <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html>`__.
+
 .. _event notifications: https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
 .. _AWS documentation: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
 .. _Understanding Scaling Behavior: https://docs.aws.amazon.com/lambda/latest/dg/scaling.html

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -389,7 +389,7 @@ DynamoDB Events
 
 You can configure a Lambda function to be invoked whenever messages are
 published to an Amazon DynamoDB stream.  To configure this, use the
-:meth:`Chalice.on_dynamodb_message` decorator and provide the name of the
+:meth:`Chalice.on_dynamodb_record` decorator and provide the name of the
 DynamoDB stream ARN.
 
 .. note::

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -382,6 +382,48 @@ Here's an example:
 For more information on using Kinesis and Lambda, see
 `Using AWS Lambda with Amazon Kinesis <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html>`__.
 
+.. _dynamodb-events:
+
+DynamoDB Events
+===============
+
+You can configure a Lambda function to be invoked whenever messages are
+published to an Amazon DynamoDB stream.  To configure this, use the
+:meth:`Chalice.on_dynamodb_message` decorator and provide the name of the
+DynamoDB stream ARN.
+
+.. note::
+   Other event handlers such as :meth:`Chalice.on_kinesis_message`,
+   :meth:`Chalice.on_sqs_message`, and :meth:`Chalice.on_sns_message`
+   only require the resource name and not the full ARN.  In the case
+   of DynamoDB streams, there are auto-generated portions of the
+   stream ARN that cannot be computed based on the resource name.  This
+   is why Chalice requires that full stream ARN when configuring
+   a DynamoDB stream handler.
+
+The :class:`DynamoDBEvent` that is passed in as the ``event`` argument
+to the event handler is also iterable.  This allows you to iterate over
+all the records in the event.
+
+Here's an example:
+
+.. code-block:: python
+
+    from chalice import Chalice
+
+    app = chalice.Chalice(app_name='ddb-event-demo')
+    app.debug = True
+
+    @app.on_kinesis_message(stream_arn='arn:aws:dynamodb:.../stream/2020')
+    def handle_ddb_message(event):
+        for record in event:
+            app.log.debug("New: %s", record.new_image)
+
+
+For more information on using Lambda and DynamoDB, see
+`Using AWS Lambda with Amazon DynamoDB <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html>`__.
+
+
 .. _event notifications: https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
 .. _AWS documentation: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
 .. _Understanding Scaling Behavior: https://docs.aws.amazon.com/lambda/latest/dg/scaling.html

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -356,7 +356,7 @@ Kinesis Events
 
 You can configure a Lambda function to be invoked whenever messages are
 published to an Amazon Kinesis data stream.  To configure this, use the
-:meth:`Chalice.on_kinesis_message` decorator and provide the name of the
+:meth:`Chalice.on_kinesis_record` decorator and provide the name of the
 Kinesis stream.
 
 The :class:`KinesisEvent` that is passed in as the ``event`` argument
@@ -373,7 +373,7 @@ Here's an example:
     app = chalice.Chalice(app_name='kinesiseventdemo')
     app.debug = True
 
-    @app.on_kinesis_message(stream='mystream')
+    @app.on_kinesis_record(stream='mystream')
     def handle_kinesis_message(event):
         for record in event:
             # The .data attribute is automatically base64 decoded for you.
@@ -393,7 +393,7 @@ published to an Amazon DynamoDB stream.  To configure this, use the
 DynamoDB stream ARN.
 
 .. note::
-   Other event handlers such as :meth:`Chalice.on_kinesis_message`,
+   Other event handlers such as :meth:`Chalice.on_kinesis_record`,
    :meth:`Chalice.on_sqs_message`, and :meth:`Chalice.on_sns_message`
    only require the resource name and not the full ARN.  In the case
    of DynamoDB streams, there are auto-generated portions of the
@@ -414,7 +414,7 @@ Here's an example:
     app = chalice.Chalice(app_name='ddb-event-demo')
     app.debug = True
 
-    @app.on_kinesis_message(stream_arn='arn:aws:dynamodb:.../stream/2020')
+    @app.on_kinesis_record(stream_arn='arn:aws:dynamodb:.../stream/2020')
     def handle_ddb_message(event):
         for record in event:
             app.log.debug("New: %s", record.new_image)

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -3436,6 +3436,28 @@ def test_can_remove_s3_permission(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_can_create_kinesis_event_source(stubbed_session):
+    kinesis_arn = 'arn:aws:kinesis:us-west-2:...:stream/MyStream'
+    function_name = 'myfunction'
+    batch_size = 100
+    starting_position = 'TRIM_HORIZON'
+    lambda_stub = stubbed_session.stub('lambda')
+    lambda_stub.create_event_source_mapping(
+        EventSourceArn=kinesis_arn,
+        FunctionName=function_name,
+        BatchSize=batch_size,
+        StartingPosition=starting_position,
+    ).returns({'UUID': 'my-uuid'})
+
+    stubbed_session.activate_stubs()
+    client = TypedAWSClient(stubbed_session)
+    result = client.create_lambda_event_source(
+        kinesis_arn, function_name, batch_size, starting_position
+    )
+    assert result == 'my-uuid'
+    stubbed_session.verify_stubs()
+
+
 def test_can_create_sqs_event_source(stubbed_session):
     queue_arn = 'arn:sqs:queue-name'
     function_name = 'myfunction'
@@ -3450,7 +3472,7 @@ def test_can_create_sqs_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session)
-    result = client.create_sqs_event_source(
+    result = client.create_lambda_event_source(
         queue_arn, function_name, batch_size
     )
     assert result == 'my-uuid'
@@ -3480,7 +3502,7 @@ def test_can_retry_create_sqs_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
-    result = client.create_sqs_event_source(
+    result = client.create_lambda_event_source(
         queue_arn, function_name, batch_size
     )
     assert result == 'my-uuid'
@@ -3496,7 +3518,7 @@ def test_can_delete_sqs_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
-    client.remove_sqs_event_source(
+    client.remove_lambda_event_source(
         'my-uuid',
     )
     stubbed_session.verify_stubs()
@@ -3517,7 +3539,7 @@ def test_can_retry_delete_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
-    client.remove_sqs_event_source(
+    client.remove_lambda_event_source(
         'my-uuid',
     )
     stubbed_session.verify_stubs()
@@ -3534,7 +3556,7 @@ def test_only_retry_settling_errors(stubbed_session):
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
     with pytest.raises(botocore.exceptions.ClientError):
-        client.remove_sqs_event_source('my-uuid')
+        client.remove_lambda_event_source('my-uuid')
     stubbed_session.verify_stubs()
 
 
@@ -3547,7 +3569,7 @@ def test_can_retry_update_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session)
-    client.update_sqs_event_source(
+    client.update_lambda_event_source(
         event_uuid='my-uuid', batch_size=5
     )
     stubbed_session.verify_stubs()
@@ -3600,7 +3622,7 @@ def test_event_source_does_not_exist(stubbed_session):
     stubbed_session.verify_stubs()
 
 
-def test_can_update_sqs_event_source(stubbed_session):
+def test_can_update_lambda_event_source(stubbed_session):
     lambda_stub = stubbed_session.stub('lambda')
     lambda_stub.update_event_source_mapping(
         UUID='my-uuid',
@@ -3609,7 +3631,7 @@ def test_can_update_sqs_event_source(stubbed_session):
 
     stubbed_session.activate_stubs()
     client = TypedAWSClient(stubbed_session)
-    client.update_sqs_event_source(
+    client.update_lambda_event_source(
         event_uuid='my-uuid', batch_size=5
     )
     stubbed_session.verify_stubs()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,6 +78,17 @@ def sample_sqs_event_app():
 
 
 @fixture
+def sample_kinesis_event_app():
+    app = Chalice('kinesis-event')
+
+    @app.on_kinesis_message(stream='mystream')
+    def handler(event):
+        pass
+
+    return app
+
+
+@fixture
 def sample_app_lambda_only():
     app = Chalice('lambda_only')
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -92,7 +92,7 @@ def sample_kinesis_event_app():
 def sample_ddb_event_app():
     app = Chalice('ddb-event')
 
-    @app.on_dynamodb_message(stream_arn='arn:aws:...:stream')
+    @app.on_dynamodb_record(stream_arn='arn:aws:...:stream')
     def handler(event):
         pass
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,7 +81,7 @@ def sample_sqs_event_app():
 def sample_kinesis_event_app():
     app = Chalice('kinesis-event')
 
-    @app.on_kinesis_message(stream='mystream')
+    @app.on_kinesis_record(stream='mystream')
     def handler(event):
         pass
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,6 +89,17 @@ def sample_kinesis_event_app():
 
 
 @fixture
+def sample_ddb_event_app():
+    app = Chalice('ddb-event')
+
+    @app.on_dynamodb_message(stream_arn='arn:aws:...:stream')
+    def handler(event):
+        pass
+
+    return app
+
+
+@fixture
 def sample_app_lambda_only():
     app = Chalice('lambda_only')
 

--- a/tests/unit/deploy/test_appgraph.py
+++ b/tests/unit/deploy/test_appgraph.py
@@ -541,6 +541,21 @@ class TestApplicationGraphBuilder(object):
         assert lambda_function.resource_name == 'handler'
         assert lambda_function.handler == 'app.handler'
 
+    def test_can_create_ddb_event_handler(self, sample_ddb_event_app):
+        config = self.create_config(sample_ddb_event_app,
+                                    app_name='ddb-event-app',
+                                    autogen_policy=True)
+        builder = ApplicationGraphBuilder()
+        application = builder.build(config, stage_name='dev')
+        assert len(application.resources) == 1
+        ddb_event = application.resources[0]
+        assert isinstance(ddb_event, models.DynamoDBEventSource)
+        assert ddb_event.resource_name == 'handler-dynamodb-event-source'
+        assert ddb_event.stream_arn == 'arn:aws:...:stream'
+        lambda_function = ddb_event.lambda_function
+        assert lambda_function.resource_name == 'handler'
+        assert lambda_function.handler == 'app.handler'
+
     def test_can_create_websocket_event_handler(self, sample_websocket_app):
         config = self.create_config(sample_websocket_app,
                                     app_name='websocket-app',

--- a/tests/unit/deploy/test_appgraph.py
+++ b/tests/unit/deploy/test_appgraph.py
@@ -526,6 +526,21 @@ class TestApplicationGraphBuilder(object):
         assert lambda_function.resource_name == 'handler'
         assert lambda_function.handler == 'app.handler'
 
+    def test_can_create_kinesis_event_handler(self, sample_kinesis_event_app):
+        config = self.create_config(sample_kinesis_event_app,
+                                    app_name='kinesis-event-app',
+                                    autogen_policy=True)
+        builder = ApplicationGraphBuilder()
+        application = builder.build(config, stage_name='dev')
+        assert len(application.resources) == 1
+        kinesis_event = application.resources[0]
+        assert isinstance(kinesis_event, models.KinesisEventSource)
+        assert kinesis_event.resource_name == 'handler-kinesis-event-source'
+        assert kinesis_event.stream == 'mystream'
+        lambda_function = kinesis_event.lambda_function
+        assert lambda_function.resource_name == 'handler'
+        assert lambda_function.handler == 'app.handler'
+
     def test_can_create_websocket_event_handler(self, sample_websocket_app):
         config = self.create_config(sample_websocket_app,
                                     app_name='websocket-app',

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -41,6 +41,8 @@ from chalice.deploy.sweeper import ResourceSweeper
 from chalice.deploy.models import APICall
 from chalice.constants import VPC_ATTACH_POLICY
 from chalice.constants import SQS_EVENT_SOURCE_POLICY
+from chalice.constants import KINESIS_EVENT_SOURCE_POLICY
+from chalice.constants import DDB_EVENT_SOURCE_POLICY
 from chalice.constants import POST_TO_WEBSOCKET_CONNECTION_POLICY
 from chalice.deploy.deployer import LambdaEventSourcePolicyInjector
 from chalice.deploy.deployer import WebsocketPolicyInjector
@@ -1114,6 +1116,33 @@ class TestLambdaEventSourcePolicyInjector(object):
         # inject the policy once.
         assert role.policy.document == {
             'Statement': [SQS_EVENT_SOURCE_POLICY.copy()],
+        }
+
+    def test_can_inject_policy_for_kinesis(self, sample_kinesis_event_app):
+        config = Config.create(chalice_app=sample_kinesis_event_app,
+                               autogen_policy=True,
+                               project_dir='.')
+        event_source = self.create_model_from_app(sample_kinesis_event_app,
+                                                  config)
+        role = event_source.lambda_function.role
+        role.policy.document = {'Statement': []}
+        injector = LambdaEventSourcePolicyInjector()
+        injector.handle(config, event_source)
+        assert role.policy.document == {
+            'Statement': [KINESIS_EVENT_SOURCE_POLICY],
+        }
+
+    def test_can_inject_policy_for_ddb(self, sample_ddb_event_app):
+        config = Config.create(chalice_app=sample_ddb_event_app,
+                               autogen_policy=True,
+                               project_dir='.')
+        event_source = self.create_model_from_app(sample_ddb_event_app, config)
+        role = event_source.lambda_function.role
+        role.policy.document = {'Statement': []}
+        injector = LambdaEventSourcePolicyInjector()
+        injector.handle(config, event_source)
+        assert role.policy.document == {
+            'Statement': [DDB_EVENT_SOURCE_POLICY],
         }
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2078,7 +2078,7 @@ def test_can_map_kinesis_event(sample_app):
 
 
 def test_can_create_ddb_handler(sample_app):
-    @sample_app.on_dynamodb_message(
+    @sample_app.on_dynamodb_record(
         stream_arn='arn:aws:dynamodb:...:stream', batch_size=10,
         starting_position='TRIM_HORIZON')
     def handler(event):
@@ -2092,7 +2092,7 @@ def test_can_create_ddb_handler(sample_app):
 
 
 def test_can_map_ddb_event(sample_app):
-    @sample_app.on_dynamodb_message(stream_arn='arn:aws:...:stream')
+    @sample_app.on_dynamodb_record(stream_arn='arn:aws:...:stream')
     def handler(event):
         return event
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2007,9 +2007,9 @@ def test_can_map_sqs_event(sample_app):
 
 
 def test_can_create_kinesis_handler(sample_app):
-    @sample_app.on_kinesis_message(stream='MyStream',
-                                   batch_size=1,
-                                   starting_position='TRIM_HORIZON')
+    @sample_app.on_kinesis_record(stream='MyStream',
+                                  batch_size=1,
+                                  starting_position='TRIM_HORIZON')
     def handler(event):
         pass
 
@@ -2021,7 +2021,7 @@ def test_can_create_kinesis_handler(sample_app):
 
 
 def test_can_map_kinesis_event(sample_app):
-    @sample_app.on_kinesis_message(stream='MyStream')
+    @sample_app.on_kinesis_record(stream='MyStream')
     def handler(event):
         return event
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2126,6 +2126,15 @@ def test_can_map_ddb_event(sample_app):
     assert records[0].sequence_number == '1700000000020701978607'
     assert records[0].size_bytes == 20
     assert records[0].stream_view_type == 'NEW_AND_OLD_IMAGES'
+    # Mapping from top level keys in a record.
+    assert records[0].aws_region == 'us-west-2'
+    assert records[0].event_id == 'da037887f71a88a1f6f4cfd149709d5a'
+    assert records[0].event_name == 'INSERT'
+    assert records[0].event_source_arn == (
+        'arn:aws:dynamodb:us-west-2:12345:table/MyTable/stream/'
+        '2020-09-28T16:49:14.209')
+    # Computed value.
+    assert records[0].table_name == 'MyTable'
 
 
 def test_bytes_when_binary_type_is_application_json():

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -729,8 +729,8 @@ class TestTerraformTemplate(TemplateTestBase):
                }
 
     def test_can_package_kinesis_handler(self, sample_app):
-        @sample_app.on_kinesis_message(stream='mystream', batch_size=5,
-                                       starting_position='TRIM_HORIZON')
+        @sample_app.on_kinesis_record(stream='mystream', batch_size=5,
+                                      starting_position='TRIM_HORIZON')
         def handler(event):
             pass
 
@@ -1472,7 +1472,7 @@ class TestSAMTemplate(TemplateTestBase):
         }
 
     def test_can_package_kinesis_handler(self, sample_app):
-        @sample_app.on_kinesis_message(stream='mystream', batch_size=5)
+        @sample_app.on_kinesis_record(stream='mystream', batch_size=5)
         def handler(event):
             pass
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -754,9 +754,9 @@ class TestTerraformTemplate(TemplateTestBase):
                }
 
     def test_can_package_dynamodb_handler(self, sample_app):
-        @sample_app.on_dynamodb_message(stream_arn='arn:aws:...:stream',
-                                        batch_size=5,
-                                        starting_position='TRIM_HORIZON')
+        @sample_app.on_dynamodb_record(stream_arn='arn:aws:...:stream',
+                                       batch_size=5,
+                                       starting_position='TRIM_HORIZON')
         def handler(event):
             pass
 
@@ -1498,8 +1498,8 @@ class TestSAMTemplate(TemplateTestBase):
         }
 
     def test_can_package_dynamodb_handler(self, sample_app):
-        @sample_app.on_dynamodb_message(stream_arn='arn:aws:...:stream',
-                                        batch_size=5)
+        @sample_app.on_dynamodb_record(stream_arn='arn:aws:...:stream',
+                                       batch_size=5)
         def handler(event):
             pass
 


### PR DESCRIPTION
Issue #987.

This implements the proposal in #987 with a few modifications.

* This handlers were renamed to `on_kinesis_message` and `on_dynamodb_message`.  I'm not tied to the names.  I was trying to stay consistent with `on_sqs_message`, `on_sns_message`, but we could also call this `on_kinesis_stream_event` as originally suggested.
* The DynamoDB stream must accept a full stream ARN, and not the table name.  There's autogenerated parts in the stream ARN that we can't calculate (explained [here](https://github.com/aws/chalice/issues/987#issuecomment-700183881)).  We could support only a table name for the `chalice deploy` case, but that's also an additive change we can add later.

Other caveats, follow up actions after this PR:

* Not all the underlying Lambda params are supported when subscribing to an event source.  These were added after the original proposal, but I'm fine with starting with this initial set of params.
* Need to update the test client to support generating these new events.