### PR TITLE
Fix regression with blueprint invocation

### DIFF
--- a/.changes/next-release/28759404254-bugfix-Blueprints-51536.json
+++ b/.changes/next-release/28759404254-bugfix-Blueprints-51536.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Blueprints",
+  "description": "Fix regression when invoking Lambda functions from blueprints (#1535)"
+}

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2185,6 +2185,23 @@ def test_can_combine_multiple_blueprints_in_single_app():
     assert sorted(list(myapp.routes)) == ['/bar', '/foo']
 
 
+def test_can_preserve_signature_on_blueprint():
+    myapp = app.Chalice('myapp')
+    foo = app.Blueprint('foo')
+
+    @foo.lambda_function()
+    def first(event, context):
+        return {'foo': 'bar'}
+
+    myapp.register_blueprint(foo)
+
+    # The handler string given to a blueprint
+    # is the "module.function_name" so we have
+    # to ensure we can continue to invoke the
+    # function with its expected signature.
+    assert first({}, None) == {'foo': 'bar'}
+
+
 def test_doc_saved_on_route():
     myapp = app.Chalice('myapp')
 


### PR DESCRIPTION
This regressed when middleware was introduced in Chalice (#1514).
It made the assumption that modifications could deferred to the
wrapping and modification of handlers until registration time.
However, the handler string for blueprints references the module
directly, e.g. `chalicelib.my_function` which means that the
app registration is bypassed entirely.

This is problematic in general and needs a follow up PR, but
will require a significant change from how blueprints currently
work.  For now, this puts back the original behavior and
instead allows for middleware to be set directly on the event
handler so that we don't need to wrap the blueprint handlers.

Fixes #1535

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
