### PR TITLE
Update method name in sqs update code path

### DIFF
--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -711,7 +711,7 @@ class PlanStage(object):
             uuid = deployed['event_uuid']
             return instruction_for_queue_arn + [
                 models.APICall(
-                    method_name='update_sqs_event_source',
+                    method_name='update_lambda_event_source',
                     params={'event_uuid': uuid,
                             'batch_size': resource.batch_size}
                 )

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1823,7 +1823,7 @@ class TestPlanSQSSubscription(BasePlannerTests):
             )
         ]
         assert plan[5] == models.APICall(
-            method_name='update_sqs_event_source',
+            method_name='update_lambda_event_source',
             params={
                 'event_uuid': 'my-uuid',
                 'batch_size': 10,


### PR DESCRIPTION
Missed as part of the refactoring when generalizing event sources.
Will follow up with improved planner validation/tests.