### PR TITLE
Configure websocket endpoint from rest API id

### DIFF
--- a/.changes/next-release/30774531330-bugfix-Websocket-824.json
+++ b/.changes/next-release/30774531330-bugfix-Websocket-824.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Websocket",
+  "description": "Fix websocket client configuration when using a custom domain (#1503)"
+}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -187,9 +187,10 @@ def create_websocket_event():
         return {
             'requestContext': {
                 'routeKey': route_key,
-                'domainName': 'abcd1234.us-west-2.amazonaws.com',
+                'domainName': 'abcd1234.execute-api.us-west-2.amazonaws.com',
                 'stage': 'api',
                 'connectionId': 'ABCD1234=',
+                'apiId': 'abcd1234',
             },
             'body': body,
         }


### PR DESCRIPTION
We were previously using the domainName to construct the endpoint URL.
If the user configures a custom domain name for the websocket API, we'll
use the custom domain name as the endpoint URL.  However, we always need
to use the auto-generated value from API gateway when constructing the
endpoint URL for the websocket client.

We have to keep the existing `.configure()` method as is, it's part of
the public API.  To fix this, I added a new method,
`.configure_from_api_id()` that constructs the endpoint given an
apiId and stage.  The websocket handler then uses this new
method when configuring your websocket API.

Fixes #1503

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
