### PR TITLE
Use chalice partition variable instead of wildcard

### DIFF
--- a/.changes/next-release/19399802349-bugfix-Terraform-93436.json
+++ b/.changes/next-release/19399802349-bugfix-Terraform-93436.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Terraform",
+  "description": "Fix issue with wildcard partition names in s3 event handlers (#1508)"
+}

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -791,7 +791,7 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 0.13.0'
+                'required_version': '> 0.11.0, < 0.14.0'
             },
             'provider': {
                 'template': {'version': '~> 2'},
@@ -895,7 +895,8 @@ class TerraformGenerator(TemplateGenerator):
             'action': 'lambda:InvokeFunction',
             'function_name': resource.lambda_function.function_name,
             'principal': self._options.service_principal('s3'),
-            'source_arn': 'arn:*:s3:::%s' % resource.bucket
+            'source_arn': ('arn:${data.aws_partition.chalice.partition}:'
+                           's3:::%s' % resource.bucket)
         }
 
     def _generate_sqseventsource(self, resource, template):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -642,7 +642,8 @@ class TestTerraformTemplate(TemplateTestBase):
                    'action': 'lambda:InvokeFunction',
                    'function_name': 'sample_app-dev-handler',
                    'principal': 's3.amazonaws.com',
-                   'source_arn': 'arn:*:s3:::foo',
+                   'source_arn': (
+                       'arn:${data.aws_partition.chalice.partition}:s3:::foo'),
                    'statement_id': 'handler-s3event'
                }
 


### PR DESCRIPTION
Fixes an issue with terraform where it improperly validates
that `*` instead allowed for a partition name (confirmed that
this works when using the AWS APIs directly).  This change
is also more specific in that it uses the currently configured
partition instead of a wildcard.

Fixes #1508.