### PR TITLE
Remove special casing of builtin auth URL

### DIFF
--- a/.changes/next-release/19507148882-bugfix-Auth-75903.json
+++ b/.changes/next-release/19507148882-bugfix-Auth-75903.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Auth",
+  "description": "Fix special case processing for root URL auth (#1271)"
+}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1326,11 +1326,9 @@ class AuthResponse(object):
         # '/'.join(...)'d properly.
         base.extend([method, route[1:]])
         last_arn_segment = '/'.join(base)
-        if route in ['/', '*']:
-            # We have to special case the '/' case.  For whatever
-            # reason, API gateway adds an extra '/' to the method_arn
-            # of the auth request, so we need to do the same thing.
-            # We also have to handle the '*' case which is for wildcards
+        if route == '*':
+            # We also have to handle the '*' case which matches
+            # all routes.
             last_arn_segment += route
         final_arn = '%s:%s' % (parts[0], last_arn_segment)
         return final_arn

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1460,14 +1460,11 @@ def test_can_mix_auth_routes_and_strings(auth_request):
     }
 
 
-def test_special_cased_root_resource(auth_request):
-    # Not sure why, but API gateway uses `//` for the root
-    # resource.  I've confirmed it doesn't do this for non-root
-    # URLs.  We don't to let that leak out to the APIs we expose.
+def test_root_resource(auth_request):
     auth_request.method_arn = (
-        "arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET//")
+        "arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET/")
     expected = [
-        "arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET//"
+        "arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET/"
     ]
     response = app.AuthResponse(
         [app.AuthRoute('/', ['GET'])],


### PR DESCRIPTION
API Gateway originally added an additional `/` to the
method_arn for the root URL.  For example, the `method_arn`
for the root URL previously looked like this:

```
"arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET//"
```

We were working around this bug by special casing the root URL
and adding the the additional `/` at the end of the URL.
API Gateway fixed this bug, which means that our workaround no
longer produced the correct results.  The `method_arn` for the
root URL now looks like this:

```
"arn:aws:execute-api:us-west-2:123:rest-api-id/dev/GET/"
```

By removing the special case logic, the code example
from #1271 now works for the root URL.

Fixes #1271