### PR TITLE
Load local custom chalice class

### DIFF
--- a/.changes/next-release/20059390204-enhancement-Local-37528.json
+++ b/.changes/next-release/20059390204-enhancement-Local-37528.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Local",
+  "description": "Allow custom Chalice class in local mode (#1502)"
+}

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -57,7 +57,8 @@ class Clock(object):
 
 def create_local_server(app_obj, config, host, port):
     # type: (Chalice, Config, str, int) -> LocalDevServer
-    app_obj.__class__ = LocalChalice
+    CustomLocalChalice.__bases__ = (LocalChalice, app_obj.__class__)
+    app_obj.__class__ = CustomLocalChalice
     return LocalDevServer(app_obj, config, host, port)
 
 
@@ -750,3 +751,7 @@ class LocalChalice(Chalice):
     def current_request(self, value):  # type: ignore
         # type: (Request) -> None
         self._THREAD_LOCAL.current_request = value
+
+
+class CustomLocalChalice(LocalChalice):
+    pass

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -60,6 +60,10 @@ class ChaliceStubbedHandler(local.ChaliceRequestHandler):
         pass
 
 
+class CustomSampleChalice(app.Chalice):
+    pass
+
+
 @pytest.fixture
 def arn_builder():
     return LocalARNBuilder()
@@ -71,6 +75,14 @@ def lambda_context_args():
     # care about for the timing tests, this gives reasonable defaults for
     # those arguments.
     return ['lambda_name', 256]
+
+
+@fixture
+def custom_sample_app():
+    demo = CustomSampleChalice(app_name='custom-demo-app')
+    demo.debug = True
+
+    return demo
 
 
 @fixture
@@ -721,6 +733,13 @@ def test_can_provide_host_to_local_server(sample_app):
     dev_server = local.create_local_server(sample_app, None, host='0.0.0.0',
                                            port=23456)
     assert dev_server.host == '0.0.0.0'
+
+
+def test_wraps_custom_sample_app_with_local_chalice(custom_sample_app):
+    dev_server = local.create_local_server(custom_sample_app, None,
+                                           host='0.0.0.0', port=23456)
+    assert isinstance(dev_server.app_object, local.LocalChalice)
+    assert isinstance(dev_server.app_object, custom_sample_app.__class__)
 
 
 class TestLambdaContext(object):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -61,7 +61,8 @@ class ChaliceStubbedHandler(local.ChaliceRequestHandler):
 
 
 class CustomSampleChalice(app.Chalice):
-    pass
+    def custom_method(self):
+        return "foo"
 
 
 @pytest.fixture
@@ -740,6 +741,7 @@ def test_wraps_custom_sample_app_with_local_chalice(custom_sample_app):
                                            host='0.0.0.0', port=23456)
     assert isinstance(dev_server.app_object, local.LocalChalice)
     assert isinstance(dev_server.app_object, custom_sample_app.__class__)
+    assert dev_server.app_object.custom_method() == 'foo'
 
 
 class TestLambdaContext(object):


### PR DESCRIPTION
*Issue #1502 *

*Description of changes:* Load a custom Chalice class in local environment.

Let's suppose we have the following case:
```python
from chalice import Chalice

class CustomChalice(Chalice):
    def custom_method(self):
        pass

app = CustomChalice(app_name="custom")
```

Locally the `custom_method` was not available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
