### PR TITLE
Enhancement/add validation check for env vars #1543

### DIFF
--- a/.changes/next-release/29519535057-enhancement-Config-66219.json
+++ b/.changes/next-release/29519535057-enhancement-Config-66219.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Config",
+  "description": "Validate env var values are strings (#1543)"
+}

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -267,4 +267,3 @@ def validate_environment_variables_type(config):
         if not isinstance(env_value, str):
             raise ValueError("environment variable must be of type str."
                              "Invalid value: %s" % env_value)
-

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -48,6 +48,7 @@ def validate_configuration(config):
     validate_endpoint_type(config)
     validate_resource_policy(config)
     validate_sqs_configuration(config.chalice_app)
+    validate_environment_variables_type(config)
 
 
 def validate_resource_policy(config):
@@ -255,3 +256,15 @@ def _is_valid_queue_name(queue_name):
     # want to detect the case where a user puts the queue URL/ARN instead of
     # the name.
     return True
+
+
+def validate_environment_variables_type(config):
+    # type: (Config) -> None
+    for env_key, env_value in config.environment_variables.items():
+        if not isinstance(env_key, str):
+            raise ValueError("environment variable must be of type str."
+                             "Invalid key: %s" % env_key)
+        if not isinstance(env_value, str):
+            raise ValueError("environment variable must be of type str."
+                             "Invalid value: %s" % env_value)
+

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -1,7 +1,7 @@
 import sys
 import warnings
 
-from typing import Dict, List, Set, Iterator, Optional  # noqa
+from typing import Dict, List, Set, Iterator, Optional, Any  # noqa
 
 from chalice import app  # noqa
 from chalice.config import Config  # noqa
@@ -260,10 +260,16 @@ def _is_valid_queue_name(queue_name):
 
 def validate_environment_variables_type(config):
     # type: (Config) -> None
-    for env_key, env_value in config.environment_variables.items():
-        if not isinstance(env_key, str):
-            raise ValueError("environment variable must be of type str."
-                             "Invalid key: %s" % env_key)
-        if not isinstance(env_value, str):
-            raise ValueError("environment variable must be of type str."
-                             "Invalid value: %s" % env_value)
+    _validate_environment_variables(config.environment_variables)
+    for name in _get_all_function_names(config.chalice_app):
+        _validate_environment_variables(
+            config.scope(config.chalice_stage, name).environment_variables)
+
+
+def _validate_environment_variables(environment_variables):
+    # type: (Dict[str, Any]) -> None
+    for key, value in environment_variables.items():
+        if not isinstance(value, str):
+            raise ValueError("Environment variable values must be strings, "
+                             "got 'type' %s for key '%s'" % (
+                                 type(value).__name__, key))

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -331,3 +331,24 @@ def test_validate_sqs_queue_name(sample_app):
     config = Config.create(chalice_app=sample_app)
     with pytest.raises(ValueError):
         validate_configuration(config)
+
+
+def test_validate_environment_variables_value_type_not_str(sample_app):
+    config = Config.create(chalice_app=sample_app,
+                           environment_variables={"ENV_KEY": 1})
+    with pytest.raises(ValueError):
+        validate_configuration(config)
+
+
+def test_validate_environment_variables_key_type_not_str(sample_app):
+    config = Config.create(chalice_app=sample_app,
+                           environment_variables={1: "ENV_VALUE"})
+    with pytest.raises(ValueError):
+        validate_configuration(config)
+
+
+def test_validate_environment_variables_key_value_type_not_str(sample_app):
+    config = Config.create(chalice_app=sample_app,
+                           environment_variables={1: 2})
+    with pytest.raises(ValueError):
+        validate_configuration(config)

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -340,15 +340,22 @@ def test_validate_environment_variables_value_type_not_str(sample_app):
         validate_configuration(config)
 
 
-def test_validate_environment_variables_key_type_not_str(sample_app):
-    config = Config.create(chalice_app=sample_app,
-                           environment_variables={1: "ENV_VALUE"})
-    with pytest.raises(ValueError):
-        validate_configuration(config)
+def test_validate_env_var_is_string_for_lambda_functions(sample_app):
+    @sample_app.lambda_function()
+    def foo(event, context):
+        pass
 
-
-def test_validate_environment_variables_key_value_type_not_str(sample_app):
-    config = Config.create(chalice_app=sample_app,
-                           environment_variables={1: 2})
+    config = Config(
+        chalice_stage='dev',
+        config_from_disk={
+            'stages': {
+                'dev': {
+                    'lambda_functions': {
+                        'foo': {'environment_variables': {'BAR': 2}}}
+                }
+            }
+        },
+        user_provided_params={'chalice_app': sample_app}
+    )
     with pytest.raises(ValueError):
         validate_configuration(config)


### PR DESCRIPTION
*Issue #, if available:*
 #1543 

*Description of changes:*
Added a validation method to check that the key-value pairs of the environment variables as provided in the config are all of type str.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
