### PR TITLE
Add generate_kinesis_event test client method

### DIFF
--- a/.changes/next-release/18925849009-enhancement-Test-68239.json
+++ b/.changes/next-release/18925849009-enhancement-Test-68239.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Test",
+  "description": "Add test client methods for generating sample kinesis events"
+}

--- a/chalice/test.py
+++ b/chalice/test.py
@@ -298,6 +298,29 @@ class TestEventsClient(BaseClient):
         }
         return event
 
+    def generate_kinesis_event(self, message_bodies,
+                               stream_name='stream-name'):
+        # type: (List[bytes], str) -> Dict[str, Any]
+        records = [{
+            "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "1",
+                "sequenceNumber": "12345",
+                "data": base64.b64encode(body).decode('ascii'),
+                "approximateArrivalTimestamp": 1545084650.987
+            },
+            "eventSource": "aws:kinesis",
+            "eventVersion": "1.0",
+            "eventID": "shardId-000000000006:12345",
+            "eventName": "aws:kinesis:record",
+            "invokeIdentityArn": "arn:aws:iam::123:role/lambda-role",
+            "awsRegion": "us-west-2",
+            "eventSourceARN": (
+                "arn:aws:kinesis:us-east-2:123:stream/%s" % stream_name
+            )
+        } for body in message_bodies]
+        return {'Records': records}
+
 
 class TestLambdaClient(BaseClient):
     def __init__(self, app, config):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1767,17 +1767,21 @@ Testing
 
       Generates a sample SNS event.
 
-   .. method:: generate_s3_event(message, subject='')
+   .. method:: generate_s3_event(bucket, key, event_name='ObjectCreated:Put')
 
       Generates a sample S3 event.
 
-   .. method:: generate_sqs_event(message, subject='')
+   .. method:: generate_sqs_event(message_bodies, queue_name='queue-name')
 
       Generates a sample SQS event.
 
-   .. method:: generate_cw_event(message, subject='')
+   .. method:: generate_cw_event(source, detail_type, detail, resources, region='us-west-2')
 
       Generates a sample CloudWatch event.
+
+   .. method:: generate_kinesis_event(message_bodies, stream_name='stream-name')
+
+      Generates a Kinesis event.
 
 
 .. class:: HTTPResponse()

--- a/tests/unit/test_test.py
+++ b/tests/unit/test_test.py
@@ -286,6 +286,20 @@ def test_can_generate_cloudwatch_event():
                                                'state': 'pending'}}
 
 
+def test_can_generate_kinesis_event():
+    app = Chalice('kinesis')
+
+    @app.on_kinesis_record(stream='mystream')
+    def foo(event):
+        return [record.data for record in event]
+
+    with Client(app) as client:
+        event = client.events.generate_kinesis_event(
+            message_bodies=[b'foo', b'bar', b'baz'])
+        response = client.lambda_.invoke('foo', event)
+        assert response.payload == [b'foo', b'bar', b'baz']
+
+
 def test_can_mix_pure_lambda_and_event_handlers():
     app = Chalice('lambda-only')
 


### PR DESCRIPTION
This allows you to test kinesis event handlers using the
Chalice test client.

It's still missing dynamodb message, but that will require some
API design work because the records contain more than just a
message body for each record.