### PR TITLE
Ensure only a single reference to a managed layer

### DIFF
--- a/.changes/next-release/45843828685-bugfix-Layers-14950.json
+++ b/.changes/next-release/45843828685-bugfix-Layers-14950.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Layers",
+  "description": "Ensure single reference to managed layer (#1563)"
+}

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -272,7 +272,7 @@ class SAMTemplateGenerator(TemplateGenerator):
             lambdafunction_definition['Properties'].update(
                 reserved_concurrency_config)
 
-        layers = resource.layers or []  # type: List[Any]
+        layers = list(resource.layers) or []  # type: List[Any]
         if self._chalice_layer:
             layers.insert(0, {'Ref': self._chalice_layer})
 


### PR DESCRIPTION
When packaging a SAM application, ensure that there's only
a single reference to the managed layer for each Lambda function.
The issue was that the `resource.layers` was using the same
reference to a list from the loaded config file so mutating
this list to add in the managed layer was updating the list of
Lambda layers for all Lambda functions.  Now we make a copy of
this list to ensure each Lambda function gets a unique list
of layers and mutations are local to each Lambda function.

Fixes #1563.