### PR TITLE
1449 propagate VPC Endpoint registration for PRIVATE Api Gateway's

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -25,7 +25,7 @@ import re
 import uuid
 from collections import OrderedDict
 from typing import Any, Optional, Dict, Callable, List, Iterator, Iterable, \
-    Sequence, IO  # noqa
+    Sequence, IO, Union  # noqa
 
 import botocore.session  # noqa
 from botocore.loaders import create_loader
@@ -1062,12 +1062,18 @@ class TypedAWSClient(object):
         except client.exceptions.NotFoundException:
             return {}
 
-    def import_rest_api(self, swagger_document, endpoint_type):
-        # type: (Dict[str, Any], str) -> str
+    def import_rest_api(self, swagger_document, endpoint):
+        # type: (Dict[str, Any], Dict[str, Union[str, List[str]]]) -> str
         client = self._client('apigateway')
+        parameters = {
+            'endpointConfigurationTypes': endpoint['type']
+        }
+        if endpoint.get('vpce_ids'):
+            parameters['endpointConfigurationVpcEndpointIds'] = \
+                endpoint['vpce_ids']
         response = client.import_rest_api(
             body=json.dumps(swagger_document, indent=2),
-            parameters={'endpointConfigurationTypes': endpoint_type}
+            parameters=parameters
         )
         rest_api_id = response['id']
         return rest_api_id

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -180,7 +180,7 @@ class ApplicationGraphBuilder(object):
         return models.RestAPI(
             resource_name='rest_api',
             swagger_doc=models.Placeholder.BUILD_STAGE,
-            endpoint_type=config.api_gateway_endpoint_type,
+            endpoint=models.Endpoint(endpoint_type=config.api_gateway_endpoint_type, endpoint_vpce=config.api_gateway_endpoint_vpce),
             minimum_compression=minimum_compression,
             api_gateway_stage=config.api_gateway_stage,
             lambda_function=lambda_function,

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -180,7 +180,10 @@ class ApplicationGraphBuilder(object):
         return models.RestAPI(
             resource_name='rest_api',
             swagger_doc=models.Placeholder.BUILD_STAGE,
-            endpoint=models.Endpoint(endpoint_type=config.api_gateway_endpoint_type, endpoint_vpce=config.api_gateway_endpoint_vpce),
+            endpoint=models.Endpoint(
+                endpoint_type=config.api_gateway_endpoint_type,
+                endpoint_vpce=config.api_gateway_endpoint_vpce
+            ),
             minimum_compression=minimum_compression,
             api_gateway_stage=config.api_gateway_stage,
             lambda_function=lambda_function,

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -181,8 +181,8 @@ class ApplicationGraphBuilder(object):
             resource_name='rest_api',
             swagger_doc=models.Placeholder.BUILD_STAGE,
             endpoint=models.Endpoint(
-                endpoint_type=config.api_gateway_endpoint_type,
-                endpoint_vpce=config.api_gateway_endpoint_vpce
+                type=config.api_gateway_endpoint_type,
+                vpce_ids=config.api_gateway_endpoint_vpce
             ),
             minimum_compression=minimum_compression,
             api_gateway_stage=config.api_gateway_stage,

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -291,8 +291,8 @@ class RestAPI(ManagedModel):
 
 @attrs
 class Endpoint(Model):
-    endpoint_type = attrib()                     # type: str
-    endpoint_vpce = attrib(default=None)         # type: str
+    type = attrib()                         # type: str
+    vpce_ids = attrib(default=None)         # type: Union[str, List[str]]
 
 
 @attrs

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -278,7 +278,7 @@ class RestAPI(ManagedModel):
     xray = attrib(default=False)                 # type: bool
     policy = attrib(default=None)                # type: Opt[IAMPolicy]
     authorizers = attrib(default=Factory(list))  # type: List[LambdaFunction]
-    domain_name = attrib(default=None)    # type: Opt[DomainName]
+    domain_name = attrib(default=None)           # type: Opt[DomainName]
 
     def dependencies(self):
         # type: () -> List[Model]
@@ -291,7 +291,7 @@ class RestAPI(ManagedModel):
 @attrs
 class Endpoint(Model):
     endpoint_type = attrib()                     # type: str
-    endpoint_vpce = attrib()                     # type: str
+    endpoint_vpce = attrib(default=None)         # type: str
 
 @attrs
 class WebsocketAPI(ManagedModel):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -288,10 +288,12 @@ class RestAPI(ManagedModel):
             resources.append(self.domain_name)
         return cast(List[Model], resources)
 
+
 @attrs
 class Endpoint(Model):
     endpoint_type = attrib()                     # type: str
     endpoint_vpce = attrib(default=None)         # type: str
+
 
 @attrs
 class WebsocketAPI(ManagedModel):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -273,7 +273,7 @@ class RestAPI(ManagedModel):
     swagger_doc = attrib()                       # type: DV[Dict[str, Any]]
     minimum_compression = attrib()               # type: str
     api_gateway_stage = attrib()                 # type: str
-    endpoint_type = attrib()                     # type: str
+    endpoint = attrib()                          # type: Endpoint
     lambda_function = attrib()                   # type: LambdaFunction
     xray = attrib(default=False)                 # type: bool
     policy = attrib(default=None)                # type: Opt[IAMPolicy]
@@ -288,6 +288,10 @@ class RestAPI(ManagedModel):
             resources.append(self.domain_name)
         return cast(List[Model], resources)
 
+@attrs
+class Endpoint(Model):
+    endpoint_type = attrib()                     # type: str
+    endpoint_vpce = attrib()                     # type: str
 
 @attrs
 class WebsocketAPI(ManagedModel):

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1227,7 +1227,7 @@ class PlanStage(object):
                 (models.APICall(
                     method_name='import_rest_api',
                     params={'swagger_document': resource.swagger_doc,
-                            'endpoint_type': resource.endpoint.endpoint_type},
+                            'endpoint': resource.endpoint},
                     output_var='rest_api_id',
                 ), "Creating Rest API\n"),
                 models.RecordResourceVariable(
@@ -1252,8 +1252,14 @@ class PlanStage(object):
                     '/endpointConfiguration/types/%s' % (
                         '{rest_api[endpointConfiguration][types][0]}'),
                     ['rest_api']),
-                'value': resource.endpoint.endpoint_type}
-            )
+                'value': resource.endpoint.type
+            })
+            if resource.endpoint.vpce_ids:
+                shared_plan_patch_ops.append({
+                    'op': 'add',
+                    'path': '/endpointConfiguration/vpcEndpointIds',
+                    'value': resource.endpoint.vpce_ids
+                })
             plan = shared_plan_preamble + [
                 models.StoreValue(
                     name='rest_api_id',
@@ -1277,7 +1283,7 @@ class PlanStage(object):
 
         if resource.domain_name:
             custom_domain_plan = self._add_custom_domain_plan(
-                resource.domain_name, resource.endpoint.endpoint_type
+                resource.domain_name, resource.endpoint.type
             )
             plan += custom_domain_plan
         return plan

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -1227,7 +1227,7 @@ class PlanStage(object):
                 (models.APICall(
                     method_name='import_rest_api',
                     params={'swagger_document': resource.swagger_doc,
-                            'endpoint_type': resource.endpoint_type},
+                            'endpoint_type': resource.endpoint.endpoint_type},
                     output_var='rest_api_id',
                 ), "Creating Rest API\n"),
                 models.RecordResourceVariable(
@@ -1252,7 +1252,7 @@ class PlanStage(object):
                     '/endpointConfiguration/types/%s' % (
                         '{rest_api[endpointConfiguration][types][0]}'),
                     ['rest_api']),
-                'value': resource.endpoint_type}
+                'value': resource.endpoint.endpoint_type}
             )
             plan = shared_plan_preamble + [
                 models.StoreValue(
@@ -1277,7 +1277,7 @@ class PlanStage(object):
 
         if resource.domain_name:
             custom_domain_plan = self._add_custom_domain_plan(
-                resource.domain_name, resource.endpoint_type
+                resource.domain_name, resource.endpoint.endpoint_type
             )
             plan += custom_domain_plan
         return plan

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -317,8 +317,8 @@ class SAMTemplateGenerator(TemplateGenerator):
             properties = resources['RestAPI']['Properties']
             properties['EndpointConfiguration']['VPCEndpointIds'] = \
                 resource.endpoint.vpce_ids \
-                    if isinstance(resource.endpoint.vpce_ids, List) \
-                    else [resource.endpoint.vpce_ids]
+                if isinstance(resource.endpoint.vpce_ids, List) \
+                else [resource.endpoint.vpce_ids]
 
         if resource.minimum_compression:
             properties = resources['RestAPI']['Properties']

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -710,7 +710,7 @@ class SAMTemplateGenerator(TemplateGenerator):
         if resource.domain_name is None:
             return
         domain_name = resource.domain_name
-        endpoint_type = resource.endpoint_type
+        endpoint_type = resource.endpoint.endpoint_type
         cfn_name = to_cfn_resource_name(domain_name.resource_name)
         properties = {
             'DomainName': domain_name.domain_name,
@@ -1088,7 +1088,7 @@ class TerraformGenerator(TemplateGenerator):
             'name': swagger_doc['info']['title'],
             'binary_media_types': swagger_doc[
                 'x-amazon-apigateway-binary-media-types'],
-            'endpoint_configuration': {'types': [resource.endpoint_type]}
+            'endpoint_configuration': {'types': [resource.endpoint.endpoint_type]}
         }
 
         if 'x-amazon-apigateway-policy' in swagger_doc:
@@ -1155,7 +1155,7 @@ class TerraformGenerator(TemplateGenerator):
         if resource.domain_name is None:
             return
         domain_name = resource.domain_name
-        endpoint_type = resource.endpoint_type
+        endpoint_type = resource.endpoint.endpoint_type
         properties = {
             'domain_name': domain_name.domain_name,
             'endpoint_configuration': {'types': [endpoint_type]},

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -312,8 +312,8 @@ class SAMTemplateGenerator(TemplateGenerator):
             }
         }
         if resource.endpoint.endpoint_vpce:
-            properties = resources['RestAPI']['Properties']['EndpointConfiguration']
-            properties['VPCEndpointIds'] = [
+            properties = resources['RestAPI']['Properties']
+            properties['EndpointConfiguration']['VPCEndpointIds'] = [
                 {'Ref': resource.endpoint.endpoint_vpce}
             ]
 
@@ -1088,7 +1088,9 @@ class TerraformGenerator(TemplateGenerator):
             'name': swagger_doc['info']['title'],
             'binary_media_types': swagger_doc[
                 'x-amazon-apigateway-binary-media-types'],
-            'endpoint_configuration': {'types': [resource.endpoint.endpoint_type]}
+            'endpoint_configuration': {
+                'types': [resource.endpoint.endpoint_type]
+            }
         }
 
         if 'x-amazon-apigateway-policy' in swagger_doc:

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -306,11 +306,17 @@ class SAMTemplateGenerator(TemplateGenerator):
         resources['RestAPI'] = {
             'Type': 'AWS::Serverless::Api',
             'Properties': {
-                'EndpointConfiguration': resource.endpoint_type,
+                'EndpointConfiguration': resource.endpoint.endpoint_type,
                 'StageName': resource.api_gateway_stage,
                 'DefinitionBody': resource.swagger_doc,
             }
         }
+        if resource.endpoint.endpoint_vpce:
+            properties = resources['RestAPI']['Properties']['EndpointConfiguration']
+            properties['VPCEndpointIds'] = [
+                {'Ref': resource.endpoint.endpoint_vpce}
+            ]
+
         if resource.minimum_compression:
             properties = resources['RestAPI']['Properties']
             properties['MinimumCompressionSize'] = \

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -2904,7 +2904,7 @@ def test_import_rest_api(stubbed_session):
 
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
-    rest_api_id = awsclient.import_rest_api(swagger_doc, 'EDGE')
+    rest_api_id = awsclient.import_rest_api(swagger_doc, {'type': 'EDGE'})
     stubbed_session.verify_stubs()
     assert rest_api_id == 'rest_api_id'
 

--- a/tests/unit/deploy/test_appgraph.py
+++ b/tests/unit/deploy/test_appgraph.py
@@ -417,6 +417,10 @@ class TestApplicationGraphBuilder(object):
         application = builder.build(config, stage_name='dev')
         rest_api = application.resources[0]
         assert isinstance(rest_api, models.RestAPI)
+        assert rest_api.endpoint == models.Endpoint(
+            type='PRIVATE',
+            vpce_ids='vpce-abc123'
+        )
         assert rest_api.policy.document == {
             'Version': '2012-10-17',
             'Statement': [

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -706,7 +706,7 @@ class TestSwaggerBuilder(object):
             resource_name='foo',
             swagger_doc=models.Placeholder.BUILD_STAGE,
             minimum_compression='',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             api_gateway_stage='api',
             lambda_function=None,
             xray=False,

--- a/tests/unit/deploy/test_models.py
+++ b/tests/unit/deploy/test_models.py
@@ -20,7 +20,7 @@ def test_can_default_to_no_auths_in_rest_api(lambda_function):
         swagger_doc={'swagger': '2.0'},
         minimum_compression='',
         api_gateway_stage='api',
-        endpoint_type='EDGE',
+        endpoint=models.Endpoint(endpoint_type='EDGE'),
         lambda_function=lambda_function,
         xray=False
     )
@@ -35,7 +35,7 @@ def test_can_add_authorizers_to_dependencies(lambda_function):
         swagger_doc={'swagger': '2.0'},
         minimum_compression='',
         api_gateway_stage='api',
-        endpoint_type='EDGE',
+        endpoint=models.Endpoint(endpoint_type='EDGE'),
         lambda_function=lambda_function,
         xray=False,
         authorizers=[auth1, auth2],

--- a/tests/unit/deploy/test_models.py
+++ b/tests/unit/deploy/test_models.py
@@ -20,7 +20,7 @@ def test_can_default_to_no_auths_in_rest_api(lambda_function):
         swagger_doc={'swagger': '2.0'},
         minimum_compression='',
         api_gateway_stage='api',
-        endpoint=models.Endpoint(endpoint_type='EDGE'),
+        endpoint=models.Endpoint(type='EDGE'),
         lambda_function=lambda_function,
         xray=False
     )
@@ -35,7 +35,7 @@ def test_can_add_authorizers_to_dependencies(lambda_function):
         swagger_doc={'swagger': '2.0'},
         minimum_compression='',
         api_gateway_stage='api',
-        endpoint=models.Endpoint(endpoint_type='EDGE'),
+        endpoint=models.Endpoint(type='EDGE'),
         lambda_function=lambda_function,
         xray=False,
         authorizers=[auth1, auth2],

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -292,7 +292,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             lambda_function=lambda_function,
             domain_name=create_http_domain_name()
         )
@@ -367,7 +367,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -413,7 +413,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -457,7 +457,7 @@ class TestPlanCreateUpdateDomainName(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -1372,7 +1372,7 @@ class TestPlanRestAPI(BasePlannerTests):
         rest_api = models.RestAPI(
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             minimum_compression='100',
             api_gateway_stage='api',
             xray=False,
@@ -1385,7 +1385,7 @@ class TestPlanRestAPI(BasePlannerTests):
             models.APICall(
                 method_name='import_rest_api',
                 params={'swagger_document': {'swagger': '2.0'},
-                        'endpoint_type': 'EDGE'},
+                        'endpoint': models.Endpoint(type='EDGE')},
                 output_var='rest_api_id',
             ),
             models.RecordResourceVariable(
@@ -1444,7 +1444,7 @@ class TestPlanRestAPI(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             policy="{'Statement': []}",
             lambda_function=function,
         )
@@ -1476,7 +1476,7 @@ class TestPlanRestAPI(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint=models.Endpoint(endpoint_type='REGIONAL'),
+            endpoint=models.Endpoint(type='REGIONAL'),
             xray=False,
             lambda_function=function,
         )
@@ -2022,7 +2022,7 @@ class TestRemoteState(object):
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             api_gateway_stage='api',
             xray=False,
             lambda_function=None,
@@ -2941,7 +2941,7 @@ class TestUnreferencedResourcePlanner(BasePlannerTests):
         rest_api = models.RestAPI(
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
-            endpoint=models.Endpoint(endpoint_type='EDGE'),
+            endpoint=models.Endpoint(type='EDGE'),
             minimum_compression='100',
             api_gateway_stage='api',
             lambda_function=function,

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -292,7 +292,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             lambda_function=lambda_function,
             domain_name=create_http_domain_name()
         )
@@ -367,7 +367,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -413,7 +413,7 @@ class TestPlanCreateUpdateAPIMapping(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -457,7 +457,7 @@ class TestPlanCreateUpdateDomainName(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             lambda_function=lambda_function,
             domain_name=domain_name
         )
@@ -1372,7 +1372,7 @@ class TestPlanRestAPI(BasePlannerTests):
         rest_api = models.RestAPI(
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             minimum_compression='100',
             api_gateway_stage='api',
             xray=False,
@@ -1444,7 +1444,7 @@ class TestPlanRestAPI(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             policy="{'Statement': []}",
             lambda_function=function,
         )
@@ -1476,7 +1476,7 @@ class TestPlanRestAPI(BasePlannerTests):
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
             api_gateway_stage='api',
-            endpoint_type='REGIONAL',
+            endpoint=models.Endpoint(endpoint_type='REGIONAL'),
             xray=False,
             lambda_function=function,
         )
@@ -2022,7 +2022,7 @@ class TestRemoteState(object):
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
             minimum_compression='',
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             api_gateway_stage='api',
             xray=False,
             lambda_function=None,
@@ -2941,7 +2941,7 @@ class TestUnreferencedResourcePlanner(BasePlannerTests):
         rest_api = models.RestAPI(
             resource_name='rest_api',
             swagger_doc={'swagger': '2.0'},
-            endpoint_type='EDGE',
+            endpoint=models.Endpoint(endpoint_type='EDGE'),
             minimum_compression='100',
             api_gateway_stage='api',
             lambda_function=function,

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -782,7 +782,10 @@ def test_can_custom_resource_policy(sample_app, swagger_gen):
         lambda_function=None,
         minimum_compression="",
         api_gateway_stage="xyz",
-        endpoint=Endpoint(endpoint_type='PRIVATE', endpoint_vpce='vpce-abc123'),
+        endpoint=Endpoint(
+            endpoint_type='PRIVATE',
+            endpoint_vpce='vpce-abc123'
+        ),
         policy=IAMPolicy({
             'Statement': [{
                 "Effect": "Allow",
@@ -824,7 +827,10 @@ def test_can_auto_resource_policy_with_cfn(sample_app):
         lambda_function=None,
         minimum_compression="",
         api_gateway_stage="xyz",
-        endpoint=Endpoint(endpoint_type='PRIVATE', endpoint_vpce='vpce-abc123'),
+        endpoint=Endpoint(
+            endpoint_type='PRIVATE',
+            endpoint_vpce='vpce-abc123'
+        ),
         policy=IAMPolicy({
             'Statement': [{
                 "Effect": "Allow",

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -3,7 +3,7 @@ from chalice.deploy.swagger import (
 from chalice import CORSConfig
 from chalice.app import CustomAuthorizer, CognitoUserPoolAuthorizer
 from chalice.app import IAMAuthorizer, Chalice
-from chalice.deploy.models import RestAPI, IAMPolicy
+from chalice.deploy.models import RestAPI, IAMPolicy, Endpoint
 import mock
 from pytest import fixture
 
@@ -782,7 +782,7 @@ def test_can_custom_resource_policy(sample_app, swagger_gen):
         lambda_function=None,
         minimum_compression="",
         api_gateway_stage="xyz",
-        endpoint_type="PRIVATE",
+        endpoint=Endpoint(endpoint_type='PRIVATE', endpoint_vpce='vpce-abc123'),
         policy=IAMPolicy({
             'Statement': [{
                 "Effect": "Allow",
@@ -824,7 +824,7 @@ def test_can_auto_resource_policy_with_cfn(sample_app):
         lambda_function=None,
         minimum_compression="",
         api_gateway_stage="xyz",
-        endpoint_type="PRIVATE",
+        endpoint=Endpoint(endpoint_type='PRIVATE', endpoint_vpce='vpce-abc123'),
         policy=IAMPolicy({
             'Statement': [{
                 "Effect": "Allow",

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -783,8 +783,8 @@ def test_can_custom_resource_policy(sample_app, swagger_gen):
         minimum_compression="",
         api_gateway_stage="xyz",
         endpoint=Endpoint(
-            endpoint_type='PRIVATE',
-            endpoint_vpce='vpce-abc123'
+            type='PRIVATE',
+            vpce_ids='vpce-abc123'
         ),
         policy=IAMPolicy({
             'Statement': [{
@@ -828,8 +828,8 @@ def test_can_auto_resource_policy_with_cfn(sample_app):
         minimum_compression="",
         api_gateway_stage="xyz",
         endpoint=Endpoint(
-            endpoint_type='PRIVATE',
-            endpoint_vpce='vpce-abc123'
+            type='PRIVATE',
+            vpce_ids='vpce-abc123'
         ),
         policy=IAMPolicy({
             'Statement': [{

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -544,7 +544,8 @@ class TestTerraformTemplate(TemplateTestBase):
         assert resources['aws_api_gateway_rest_api'][
             'rest_api']['minimum_compression_size'] == 8192
         assert resources['aws_api_gateway_rest_api'][
-            'rest_api']['endpoint_configuration'] == {'types': ['PRIVATE'], 'vpc_endpoint_ids': ['vpce-abc123']}
+            'rest_api']['endpoint_configuration'] == \
+            {'types': ['PRIVATE'], 'vpc_endpoint_ids': ['vpce-abc123']}
 
         assert 'aws_api_gateway_stage' not in resources
         assert resources['aws_api_gateway_deployment']['rest_api'] == {

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -544,7 +544,7 @@ class TestTerraformTemplate(TemplateTestBase):
         assert resources['aws_api_gateway_rest_api'][
             'rest_api']['minimum_compression_size'] == 8192
         assert resources['aws_api_gateway_rest_api'][
-            'rest_api']['endpoint_configuration'] == {'types': ['PRIVATE']}
+            'rest_api']['endpoint_configuration'] == {'types': ['PRIVATE'], 'vpc_endpoint_ids': ['vpce-abc123']}
 
         assert 'aws_api_gateway_stage' not in resources
         assert resources['aws_api_gateway_deployment']['rest_api'] == {


### PR DESCRIPTION
https://github.com/aws/chalice/issues/1449


*Description of changes:*

Made VPCE available for the CLI usage and for the CloudFormation / Terraform code generation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
