### PR TITLE
Bump max pip version

### DIFF
--- a/.changes/next-release/21646028008-bugfix-Pip-85646.json
+++ b/.changes/next-release/21646028008-bugfix-Pip-85646.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Pip",
+  "description": "Bump pip version contraint (#1590)"
+}

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'typing==3.6.4;python_version<"3.7"',
     'mypy-extensions==0.4.3',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<20.3',
+    'pip>=9,<20.4',
     'attrs>=19.3.0,<20.3.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',


### PR DESCRIPTION
I have a follow task to investigate why dependabot didn't
auto-update this dependency for us, as it did previously
(see #1465).

Fixes #1590