### PR TITLE
Fix env var unicode validation on py27

### DIFF
--- a/.changes/next-release/17558483967-bugfix-Config-43747.json
+++ b/.changes/next-release/17558483967-bugfix-Config-43747.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Config",
+  "description": "Fix config validation for env vars on py27 (#1573)"
+}

--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -7,6 +7,9 @@ from typing import Dict, Any  # noqa
 from six import StringIO
 
 
+STRING_TYPES = six.string_types
+
+
 def pip_import_string():
     # type: () -> str
     import pip

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -8,6 +8,7 @@ from chalice.config import Config  # noqa
 from chalice.constants import EXPERIMENTAL_ERROR_MSG
 from chalice.constants import MIN_COMPRESSION_SIZE
 from chalice.constants import MAX_COMPRESSION_SIZE
+from chalice.compat import STRING_TYPES
 
 
 class ExperimentalFeatureError(Exception):
@@ -269,7 +270,7 @@ def validate_environment_variables_type(config):
 def _validate_environment_variables(environment_variables):
     # type: (Dict[str, Any]) -> None
     for key, value in environment_variables.items():
-        if not isinstance(value, str):
+        if not isinstance(value, STRING_TYPES):
             raise ValueError("Environment variable values must be strings, "
                              "got 'type' %s for key '%s'" % (
                                  type(value).__name__, key))

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -340,6 +340,12 @@ def test_validate_environment_variables_value_type_not_str(sample_app):
         validate_configuration(config)
 
 
+def test_validate_unicode_is_valid_env_var(sample_app):
+    config = Config.create(chalice_app=sample_app,
+                           environment_variables={"ENV_KEY": u'unicode-val'})
+    assert validate_configuration(config) is None
+
+
 def test_validate_env_var_is_string_for_lambda_functions(sample_app):
     @sample_app.lambda_function()
     def foo(event, context):


### PR DESCRIPTION
Regression originally introduced in #1561

Fixes #1573