### PR TITLE
Documentation update - websockets.rst

### DIFF
--- a/docs/source/topics/websockets.rst
+++ b/docs/source/topics/websockets.rst
@@ -9,7 +9,7 @@ Websockets
   .. code-block:: python
 
     app = Chalice('myapp')
-    app.experimental_feature_flags.extend([
+    app.experimental_feature_flags.update([
         'WEBSOCKETS'
     ])
 


### PR DESCRIPTION
```
    app.experimental_feature_flags.extend([
        'WEBSOCKETS'
    ])
```
`.extend` method in this documentation warning fails with
```
AttributeError: 'set' object has no attribute 'extend'
```

`.update` works and is consistent with
https://aws.github.io/chalice/topics/experimental.html#opting-in-to-experimental-apis


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
