### PR TITLE
terraform - increase upper bounds of aws provider to include 3.x

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -795,7 +795,7 @@ class TerraformGenerator(TemplateGenerator):
             },
             'provider': {
                 'template': {'version': '~> 2'},
-                'aws': {'version': '~> 2'},
+                'aws': {'version': '>= 2, < 4'},
                 'null': {'version': '~> 2'},
             },
             'data': {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Terraform AWS 3.x provider brings in a lot of great new features and bug fixes especially when running terraform in AWS environments and loading credentials from SDK/Config. However, 3.x provider does not support 0.11 of terraform. In order to avoid pushing all chalice terraform users to 0.12+ of TF I've opted to increase the upper bounds to `< 4.x`. This will result in aws provider 2.x for 0.11 users and 3.x for 0.12+.

All changes to the [AWS provider for 3.x](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.0.0) are compatible with the configurations produced by chalice in my testing.

If the chalice maintainers feel strongly about this, I'd be happy to update the pull request to move to 3.x aws provider and increase the lowest supported version of terraform to 0.12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
