### PR TITLE
feature - output cloudfront_zone_id and cloudfront_domain_name in terraform

### DIFF
--- a/.changes/next-release/28657849715-enhancement-Terraform-39810.json
+++ b/.changes/next-release/28657849715-enhancement-Terraform-39810.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Terraform",
+  "description": "Map custom domain outputs in Terraform packaging (#1601)"
+}

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1174,17 +1174,26 @@ class TerraformGenerator(TemplateGenerator):
                     resource.resource_name)
             }
         }
+        self._add_domain_name_outputs(domain_name.resource_name, endpoint_type,
+                                      template)
 
-        cf_domain_name_value = (
-            '${aws_api_gateway_domain_name.%s.cloudfront_domain_name}'
+    def _add_domain_name_outputs(self, domain_resource_name,
+                                 endpoint_type, template):
+        # type: (str, str, Dict[str, Any]) -> None
+        base = (
+            'aws_api_gateway_domain_name.%s' % domain_resource_name
         )
-
-        template.setdefault('output', {})['CloudFrontDomainName'] = {
-            'value': cf_domain_name_value % (domain_name.resource_name)
+        if endpoint_type == 'EDGE':
+            alias_domain_name = '${%s.cloudfront_domain_name}' % base
+            hosted_zone_id = '${%s.cloudfront_zone_id}' % base
+        else:
+            alias_domain_name = '${%s.regional_domain_name}' % base
+            hosted_zone_id = '${%s.regional_zone_id}' % base
+        template.setdefault('output', {})['AliasDomainName'] = {
+            'value': alias_domain_name
         }
-        template.setdefault('output', {})['CloudFrontZoneID'] = {
-            'value': '${aws_api_gateway_domain_name.%s.cloudfront_zone_id}' % (
-                domain_name.resource_name)
+        template.setdefault('output', {})['HostedZoneId'] = {
+            'value': hosted_zone_id
         }
 
     def _generate_apimapping(self, resource, template):

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1175,6 +1175,18 @@ class TerraformGenerator(TemplateGenerator):
             }
         }
 
+        cf_domain_name_value = (
+            '${aws_api_gateway_domain_name.%s.cloudfront_domain_name}'
+        )
+
+        template.setdefault('output', {})['CloudFrontDomainName'] = {
+            'value': cf_domain_name_value % (domain_name.resource_name)
+        }
+        template.setdefault('output', {})['CloudFrontZoneID'] = {
+            'value': '${aws_api_gateway_domain_name.%s.cloudfront_zone_id}' % (
+                domain_name.resource_name)
+        }
+
     def _generate_apimapping(self, resource, template):
         # type: (models.APIMapping, Dict[str, Any]) -> None
         pass

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -817,6 +817,15 @@ class TestTerraformTemplate(TemplateTestBase):
                 'stage_name': 'api',
                 'domain_name': 'example.com',
         }
+        outputs = template['output']
+        assert outputs['AliasDomainName']['value'] == (
+            '${aws_api_gateway_domain_name.api_gateway_custom_domain'
+            '.cloudfront_domain_name}'
+        )
+        assert outputs['HostedZoneId']['value'] == (
+            '${aws_api_gateway_domain_name.api_gateway_custom_domain'
+            '.cloudfront_zone_id}'
+        )
 
     def test_can_generate_domain_for_regional_endpoint(self, sample_app):
         config = Config.create(
@@ -842,6 +851,15 @@ class TestTerraformTemplate(TemplateTestBase):
                 'stage_name': 'api',
                 'domain_name': 'example.com',
         }
+        outputs = template['output']
+        assert outputs['AliasDomainName']['value'] == (
+            '${aws_api_gateway_domain_name.api_gateway_custom_domain'
+            '.regional_domain_name}'
+        )
+        assert outputs['HostedZoneId']['value'] == (
+            '${aws_api_gateway_domain_name.api_gateway_custom_domain'
+            '.regional_zone_id}'
+        )
 
 
 class TestSAMTemplate(TemplateTestBase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When using https://aws.github.io/chalice/topics/domainname.html, and terraform packaing, if the api_gateway_custom_domain `cloudfont_zone_id` and `cloudfront_domain_name` aren't provided as outputs, using the generated chalice output as a terraform module won't allow configuring route53 for the domain in question. This exposes those as outputs, similar to `EndpointURL` and `RestAPIId`

I'm uncertain how to generate a new changelog entry, there don't appear to be any documentation on the process or I'd include that as well with this as it is a feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
