### PR TITLE
Allow custom headers in built-in authorizers

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -690,12 +690,15 @@ class DecoratorAPI(object):
             return func
         return _middleware_wrapper
 
-    def authorizer(self, ttl_seconds=None, execution_role=None, name=None):
+    def authorizer(self, ttl_seconds=None, execution_role=None,
+                   name=None, header='Authorization'):
         return self._create_registration_function(
             handler_type='authorizer',
             name=name,
             registration_kwargs={
-                'ttl_seconds': ttl_seconds, 'execution_role': execution_role,
+                'ttl_seconds': ttl_seconds,
+                'execution_role': execution_role,
+                'header': header
             }
         )
 
@@ -1025,6 +1028,7 @@ class _HandlerRegistration(object):
         actual_kwargs = kwargs.copy()
         ttl_seconds = actual_kwargs.pop('ttl_seconds', None)
         execution_role = actual_kwargs.pop('execution_role', None)
+        header = actual_kwargs.pop('header', None)
         if actual_kwargs:
             raise TypeError(
                 'TypeError: authorizer() got unexpected keyword '
@@ -1034,6 +1038,7 @@ class _HandlerRegistration(object):
             handler_string=handler_string,
             ttl_seconds=ttl_seconds,
             execution_role=execution_role,
+            header=header,
         )
         wrapped_handler.config = auth_config
         self.builtin_auth_handlers.append(auth_config)
@@ -1200,12 +1205,13 @@ class Chalice(_HandlerRegistration, DecoratorAPI):
 
 class BuiltinAuthConfig(object):
     def __init__(self, name, handler_string, ttl_seconds=None,
-                 execution_role=None):
+                 execution_role=None, header='Authorization'):
         # We'd also support all the misc config options you can set.
         self.name = name
         self.handler_string = handler_string
         self.ttl_seconds = ttl_seconds
         self.execution_role = execution_role
+        self.header = header
 
 
 # ChaliceAuthorizer is unique in that the runtime component (the thing

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -144,7 +144,8 @@ class DecoratorAPI(object):
     def authorizer(self,
                    ttl_seconds: Optional[int]=None,
                    execution_role: Optional[str]=None,
-                   name: Optional[str]=None) -> Callable[..., Any]: ...
+                   name: Optional[str]=None,
+                   header: Optional[str]='Authorization') -> Callable[..., Any]: ...
 
     def on_s3_event(self,
                     bucket: str,

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -83,7 +83,7 @@ class SwaggerGenerator(object):
             config = {
                 'in': 'header',
                 'type': 'apiKey',
-                'name': 'Authorization',
+                'name': auth_config.header,
                 'x-amazon-apigateway-authtype': 'custom'
             }
             api_gateway_authorizer = {

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -143,6 +143,9 @@ Chalice
       :param execution_role: An optional IAM role to specify when invoking
         the Lambda function associated with the built-in authorizer.
 
+      :param header: The header where the auth token will be specified.
+        The default is ``Authorization``
+
    .. method:: schedule(expression, name=None)
 
       Register a scheduled event that's invoked on a regular schedule.


### PR DESCRIPTION
*Description of changes:*
Right now it is possible to set the header where the auth token will be specified only with `CustomAuthorizer`s, this PR makes it possible to change the default header also wit `Built-in` authorizers. The default is `Authorization`, preserving backward compatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
