### PR TITLE
Correct typos

### DIFF
--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -423,7 +423,7 @@ dev stage for REST API::
           "domain_name": "api.example.com",
           "security_policy": "TLS 1.2|TLS 1.0",
           "certificate_arn": "arn:aws:acm:example.com",
-          "url_prefixes": ["foo", "bar],
+          "url_prefixes": ["foo", "bar"],
           "tags": {
             "key": "tag1",
             "key1": "tag2"


### PR DESCRIPTION
Signed-off-by: hyeongjoo.kwon <hyeongjoo.kwon@plenet.co>

*Description of changes:*
* Correct typos in docs
  https://aws.github.io/chalice/topics/configfile.html?highlight=bar#custom-domain-name
  ```python
  "bar  =>  "bar"
  ```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
