### PR TITLE
terraform - bump upper bounds for terraform to include 0.14

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -791,7 +791,7 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 0.14.0'
+                'required_version': '> 0.11.0, < 0.15.0'
             },
             'provider': {
                 'template': {'version': '~> 2'},


### PR DESCRIPTION
*Issue #, if available:* #1650

*Description of changes:*
This allows terraform modules generated by chalice package to be consumed and deployed with the latest release of Terraform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
