### PR TITLE
fixing missing space in the build commands.

### DIFF
--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -55,7 +55,7 @@ def create_buildspec_legacy(pipeline_params):
         'chalice package /tmp/packaged',
         ('aws cloudformation package '
             '--template-file /tmp/packaged/sam.json'
-            ' --s3-bucket ${APP_S3_BUCKET}'
+            ' --s3-bucket ${APP_S3_BUCKET} '
             '--output-template-file transformed.yaml'),
     ]
     buildspec = {


### PR DESCRIPTION
*Description of changes:*
Using the Chalice Generate Pipeline command in my workshop, the build pipeline fails because the space is missing in the generated CI/CD Pipeline. In order to use the pipeline the BusilSpec YAML file needs to be edited and this command removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
