### PR TITLE
Update logging.rst : fix import logging

### DIFF
--- a/docs/source/topics/logging.rst
+++ b/docs/source/topics/logging.rst
@@ -63,7 +63,7 @@ We can make a change to set our log level to debug:
 .. code-block:: python
 
     import logging
-    
+
     from chalice import Chalice
 
     app = Chalice(app_name='demolog')

--- a/docs/source/topics/logging.rst
+++ b/docs/source/topics/logging.rst
@@ -62,6 +62,8 @@ We can make a change to set our log level to debug:
 
 .. code-block:: python
 
+    import logging
+    
     from chalice import Chalice
 
     app = Chalice(app_name='demolog')


### PR DESCRIPTION
Documentation improvement in [Logging](https://aws.github.io/chalice/topics/logging.html) topic.

The code block given in the documentation won't work if you don't `import logging`