### PR TITLE
Add env var for more rigorous hypothesis testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   prcheck:
     runs-on: ${{ matrix.os }}
+    env:
+      HYPOTHESIS_PROFILE=ci
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
This was missed in the original port from travis to github
actions and I've noticed that several PRs are failing because
of the Hypothesis health checks.  This should fix those failures.
