### PR TITLE
Fix env variable in GHA config

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,7 @@ jobs:
   prcheck:
     runs-on: ${{ matrix.os }}
     env:
-      HYPOTHESIS_PROFILE=ci
+      HYPOTHESIS_PROFILE: ci
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
Description of issue: 

After creating a [pull request](https://github.com/aws/chalice/pull/1677), I noticed that builds did not start and I found a mistake in the GitHub Actions configuration and added a small fix. 

Description of changes:

Fixed defining of env variable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
