### PR TITLE
packaging terraform - use references instead of strings

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -893,7 +893,7 @@ class TerraformGenerator(TemplateGenerator):
             resource.resource_name] = {
             'statement_id': resource.resource_name,
             'action': 'lambda:InvokeFunction',
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function),
             'principal': self._options.service_principal('s3'),
             'source_arn': ('arn:${data.aws_partition.chalice.partition}:'
                            's3:::%s' % resource.bucket)
@@ -908,7 +908,7 @@ class TerraformGenerator(TemplateGenerator):
                 ":%(account_id)s:%(queue)s",
                 queue=resource.queue),
             'batch_size': resource.batch_size,
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function)
         }
 
     def _generate_kinesiseventsource(self, resource, template):
@@ -921,7 +921,7 @@ class TerraformGenerator(TemplateGenerator):
                 stream=resource.stream),
             'batch_size': resource.batch_size,
             'starting_position': resource.starting_position,
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function)
         }
 
     def _generate_dynamodbeventsource(self, resource, template):
@@ -931,7 +931,7 @@ class TerraformGenerator(TemplateGenerator):
             'event_source_arn': resource.stream_arn,
             'batch_size': resource.batch_size,
             'starting_position': resource.starting_position,
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function),
         }
 
     def _generate_snslambdasubscription(self, resource, template):
@@ -952,7 +952,7 @@ class TerraformGenerator(TemplateGenerator):
         }
         template['resource'].setdefault('aws_lambda_permission', {})[
             resource.resource_name] = {
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function),
             'action': 'lambda:InvokeFunction',
             'principal': self._options.service_principal('sns'),
             'source_arn': topic_arn
@@ -994,7 +994,7 @@ class TerraformGenerator(TemplateGenerator):
         template['resource'].setdefault(
             'aws_lambda_permission', {})[
             resource.resource_name] = {
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function),
             'action': 'lambda:InvokeFunction',
             'principal': self._options.service_principal('events'),
             'source_arn': "${aws_cloudwatch_event_rule.%s.arn}" % (
@@ -1112,7 +1112,7 @@ class TerraformGenerator(TemplateGenerator):
 
         template['resource'].setdefault('aws_lambda_permission', {})[
             resource.resource_name + '_invoke'] = {
-            'function_name': resource.lambda_function.function_name,
+            'function_name': self._fref(resource.lambda_function),
             'action': 'lambda:InvokeFunction',
             'principal': self._options.service_principal('apigateway'),
             'source_arn':

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -1134,7 +1134,7 @@ class TerraformGenerator(TemplateGenerator):
         for auth in resource.authorizers:
             template['resource']['aws_lambda_permission'][
                 auth.resource_name + '_invoke'] = {
-                'function_name': auth.function_name,
+                'function_name': self._fref(auth),
                 'action': 'lambda:InvokeFunction',
                 'principal': self._options.service_principal('apigateway'),
                 'source_arn': (

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -515,7 +515,7 @@ class TestTerraformTemplate(TemplateTestBase):
         assert resources['aws_lambda_function']
         # Along with permission to invoke from API Gateway.
         assert list(resources['aws_lambda_permission'].values())[0] == {
-            'function_name': 'sample_app-dev',
+            'function_name': '${aws_lambda_function.api_handler.arn}',
             'action': 'lambda:InvokeFunction',
             'principal': 'apigateway.amazonaws.com',
             'source_arn': (
@@ -561,6 +561,7 @@ class TestTerraformTemplate(TemplateTestBase):
         # Along with permission to invoke from API Gateway.
         assert resources['aws_lambda_permission']['myauth_invoke'] == {
             'action': 'lambda:InvokeFunction',
+            # TODO: This should be updated.
             'function_name': 'sample_app-dev-myauth',
             'principal': 'apigateway.amazonaws.com',
             'source_arn': (
@@ -640,7 +641,7 @@ class TestTerraformTemplate(TemplateTestBase):
         assert template['resource']['aws_lambda_permission'][
                    'handler-s3event'] == {
                    'action': 'lambda:InvokeFunction',
-                   'function_name': 'sample_app-dev-handler',
+                   'function_name': '${aws_lambda_function.handler.arn}',
                    'principal': 's3.amazonaws.com',
                    'source_arn': (
                        'arn:${data.aws_partition.chalice.partition}:s3:::foo'),
@@ -701,7 +702,7 @@ class TestTerraformTemplate(TemplateTestBase):
 
         assert template['resource']['aws_lambda_permission'][
                    'handler-sns-subscription'] == {
-                   'function_name': 'sample_app-dev-handler',
+                   'function_name': '${aws_lambda_function.handler.arn}',
                    'action': 'lambda:InvokeFunction',
                    'principal': 'sns.amazonaws.com',
                    'source_arn': 'arn:aws:sns:space-leo-1:1234567890:foo'
@@ -725,7 +726,7 @@ class TestTerraformTemplate(TemplateTestBase):
                        'arn:${data.aws_partition.chalice.partition}:sqs'
                        ':${data.aws_region.chalice.name}:'
                        '${data.aws_caller_identity.chalice.account_id}:foo'),
-                   'function_name': 'sample_app-dev-handler',
+                   'function_name': '${aws_lambda_function.handler.arn}',
                    'batch_size': 5
                }
 
@@ -749,7 +750,7 @@ class TestTerraformTemplate(TemplateTestBase):
                        ':${data.aws_region.chalice.name}:'
                        '${data.aws_caller_identity.chalice.account_id}'
                        ':stream/mystream'),
-                   'function_name': 'sample_app-dev-handler',
+                   'function_name': '${aws_lambda_function.handler.arn}',
                    'starting_position': 'TRIM_HORIZON',
                    'batch_size': 5
                }
@@ -771,7 +772,7 @@ class TestTerraformTemplate(TemplateTestBase):
                    'aws_lambda_event_source_mapping'][
                    'handler-dynamodb-event-source'] == {
                        'event_source_arn': 'arn:aws:...:stream',
-                       'function_name': 'sample_app-dev-handler',
+                       'function_name': '${aws_lambda_function.handler.arn}',
                        'starting_position': 'TRIM_HORIZON',
                        'batch_size': 5
                    }

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -561,8 +561,7 @@ class TestTerraformTemplate(TemplateTestBase):
         # Along with permission to invoke from API Gateway.
         assert resources['aws_lambda_permission']['myauth_invoke'] == {
             'action': 'lambda:InvokeFunction',
-            # TODO: This should be updated.
-            'function_name': 'sample_app-dev-myauth',
+            'function_name': '${aws_lambda_function.myauth.arn}',
             'principal': 'apigateway.amazonaws.com',
             'source_arn': (
                 '${aws_api_gateway_rest_api.rest_api.execution_arn}/*')


### PR DESCRIPTION
The original terraform support used function name strings for several function
references, this caused non determinism in the dependency graph as terraform
couldn't properly order graphs without understanding the reference relationship
between resources. This typically only exhibits with more complex usages then
the sample application. This pr addresses by changing all cross resource
refs to functions to proper terraform references by function arn.

Signed-off-by: Kapil Thangavelu <.>

*Issue #, if available:*

fixes #1558

*Description of changes:*

This addresses a bug from my original pr/addition of terraform support for chalice 
that addresses instability in the dep graph with more complex applications.

As a drive by it also includes the neglected one liner pr #1651 for increasing compatibility
with current/modern versions of terraform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
