### PR TITLE
expose HTTP headers and cookies in AuthRequest

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -26,6 +26,7 @@ try:
     from urllib.parse import unquote_plus
     from collections.abc import Mapping
     from collections.abc import MutableMapping
+    from http.cookies import SimpleCookie
 
     unquote_str = unquote_plus
 
@@ -36,6 +37,7 @@ except ImportError:
     from urllib import unquote_plus
     from collections import Mapping
     from collections import MutableMapping
+    from Cookie import SimpleCookie
 
     # This is borrowed from botocore/compat.py
     def unquote_str(value, encoding='utf-8'):
@@ -1254,7 +1256,8 @@ class ChaliceAuthorizer(object):
     def _transform_event(self, event):
         return AuthRequest(event['type'],
                            event['authorizationToken'],
-                           event['methodArn'])
+                           event['methodArn'],
+                           event['headers'])
 
     def with_scopes(self, scopes):
         authorizer_with_scopes = copy.deepcopy(self)
@@ -1263,10 +1266,19 @@ class ChaliceAuthorizer(object):
 
 
 class AuthRequest(object):
-    def __init__(self, auth_type, token, method_arn):
+    def __init__(self, auth_type, token, method_arn, headers=None):
         self.auth_type = auth_type
         self.token = token
         self.method_arn = method_arn
+        self.headers = headers or {}
+
+    @property
+    def cookies(self):
+        cookie_str = self.headers.get('cookie', '')
+        # Parsing is based on: https://stackoverflow.com/a/32281245/2447082
+        cookie = SimpleCookie()
+        cookie.load(cookie_str)
+        return {key: morsel.value for key, morsel in cookie.items()}
 
 
 class AuthResponse(object):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -266,8 +266,10 @@ class AuthRequest(object):
     auth_type = ... # type: str
     token = ... # type: str
     method_arn = ... # type: str
+    header = ... # type: Optional[Dict[str, str]]
 
-    def __init__(self, auth_type: str, token: str, method_arn: str) -> None: ...
+    def __init__(self, auth_type: str, token: str, method_arn: str,
+                 headers: Optional[Dict[str, str]] = ...) -> None: ...
 
 
 class AuthRoute(object):

--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -114,7 +114,12 @@ built-in authorizers in chalice.
 Creating an authorizer in chalice requires you use the ``@app.authorizer``
 decorator to a function.  The function must accept a single arg, which will be
 an instance of :class:`AuthRequest`.  The function must return a
-:class:`AuthResponse`.  As an example, we'll port the example from the `API
+:class:`AuthResponse`.  An instance of :class:`AuthRequest` exposes the attributes:
+``token'' (which is taken from "Authorization" field of headers), dictionary
+``headers'' (which contains the full HTTP headers of request) and dictionary
+``cookies'' (which is parsed from the cookie string of the header).
+
+As an example, we'll port the example from the `API
 Gateway documentation`_.  First, we'll show the code and then walk through it:
 
 .. code-block:: python


### PR DESCRIPTION
*Description of changes:*

Class `AuthRequest` now exposes also HTTP headers (via an attribute) and cookies (via a property). 

This will allow to pass authentication tokens via cookies, and not only as a "Authorization" field in headers. This could be helpful when building websites on Chalice.

Sample usage (modified from the `@app.authorizer` example:

``` python
@app.authorizer()
def demo_auth(auth_request):
    token = auth_request.cookies['auth_token']

    if token == 'allow':
        return AuthResponse(routes=['/'], principal_id='user')
    else:
        return AuthResponse(routes=[], principal_id='user')
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
