### PR TITLE
Fixed mypy type declarations for AuthResponse routes (should be a List)

### DIFF
--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -284,13 +284,13 @@ class AuthRoute(object):
 
 class AuthResponse(object):
     ALL_HTTP_METHODS = ... # type: List[str]
-    routes = ... # type: Union[str, AuthRoute]
+    routes = ... # type: List[Union[str, AuthRoute]]
     principal_id = ... # type: str
     context = ... # type: Optional[Dict[str, str]]
 
     def __init__(
         self,
-        routes: Union[str, AuthRoute],
+        routes: List[Union[str, AuthRoute]],
         principal_id: str,
         context: Optional[Dict[str, str]] = ...
     ) -> None: ...


### PR DESCRIPTION
*Issue:*
Currently, expressions like `AuthResponse(routes=['*'], ...)` are flagged by the type checker because the `routes` argument is misdeclared as a `Union[str, AuthRoute]` whereas it should really be declared as a `List[Union[str, AuthRoute]]` (that's also what's in the chalice [docs](https://aws.github.io/chalice/api.html#AuthResponse)).

*Description of changes:*
The PR fixes the type declaration of the `routes` argument of `AuthResponse.__init__()` to be the list type above. It also fixes the type of the `.routes` field of the `AuthResponse` object in the same way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
