### PR TITLE
Fix to #1640 custom domain generation

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -733,7 +733,8 @@ class SAMTemplateGenerator(TemplateGenerator):
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
                 'BasePath': domain_name.api_mapping.mount_path,
-                'Stage': {'Ref': 'RestAPI.Stage'},
+                # Workaround for domainname in cdk deployment issue #1640
+                # 'Stage': {'Ref': 'RestAPI.Stage'},
             }
         }
 

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -733,8 +733,7 @@ class SAMTemplateGenerator(TemplateGenerator):
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
                 'BasePath': domain_name.api_mapping.mount_path,
-                # Workaround for domainname in cdk deployment issue #1640
-                # 'Stage': {'Ref': 'RestAPI.Stage'},
+                'Stage': resource.api_gateway_stage,
             }
         }
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1607,7 +1607,7 @@ class TestSAMTemplate(TemplateTestBase):
             'Properties': {
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
-                'Stage': {'Ref': 'RestAPI.Stage'},
+                'Stage': config.api_gateway_stage,
                 'BasePath': '(none)',
             }
         }
@@ -1641,7 +1641,7 @@ class TestSAMTemplate(TemplateTestBase):
             'Properties': {
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
-                'Stage': {'Ref': 'RestAPI.Stage'},
+                'Stage': config.api_gateway_stage,
                 'BasePath': '(none)',
             }
         }


### PR DESCRIPTION
Fix to issue #1640 - Custom Domain Generation breaks CDK chalice application synth and deploy.

Problem identified in issue is generating a Ref in SAM template when using CDK. Reference appears to be invalid.

The Stage element of the APIGateway in the template appears to be a simple string. The code has a reference to RestAPI.Stage. The RestAPI only appears to contain a StageName.

Thought is that the Stage provided in API gateway needs to be the same as the application stage being deployed. Instead of a reference, changed to the 'stage' from the resource.

Updated tests to verify the generated SAM templates contain the value from the test application configuration's stage.

Summary of changes:
1. Tweaked SAM template generation to output application stage and remove the reference to the RestAPI.
2. Updated tests to verify application's stage in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
