### PR TITLE
Add optional queue_arn to on_sqs_message

### DIFF
--- a/.changes/next-release/41104421952-feature-SQS-66900.json
+++ b/.changes/next-release/41104421952-feature-SQS-66900.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "SQS",
+  "description": "Add queue_arn parameter to enable CDK integration with SQS event handler (#1681)"
+}

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -354,11 +354,13 @@ class SNSEventConfig(BaseEventSourceConfig):
 
 
 class SQSEventConfig(BaseEventSourceConfig):
-    queue = ... # type: str
+    queue = ... # type: Optional[str]
+    queue_arn = ... # type: Optional[str]
     batch_size = ... # type: int
 
     def __init__(
-        self, name: str, handler_string: str, queue: str, batch_size: int
+        self, name: str, handler_string: str, queue: Optional[str],
+        queue_arn: Optional[str], batch_size: int
     ) -> None: ...
 
 

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -560,9 +560,14 @@ class ApplicationGraphBuilder(object):
             handler_name=sqs_config.handler_string, stage_name=stage_name
         )
         resource_name = sqs_config.name + '-sqs-event-source'
+        queue = ''  # type: Union[str, models.QueueARN]
+        if sqs_config.queue_arn is not None:
+            queue = models.QueueARN(arn=sqs_config.queue_arn)
+        elif sqs_config.queue is not None:
+            queue = sqs_config.queue
         sqs_event_source = models.SQSEventSource(
             resource_name=resource_name,
-            queue=sqs_config.queue,
+            queue=queue,
             batch_size=sqs_config.batch_size,
             lambda_function=lambda_function,
         )

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -330,9 +330,21 @@ class SNSLambdaSubscription(FunctionEventSubscriber):
 
 
 @attrs
+class QueueARN(object):
+    arn = attrib()  # type: str
+
+    @property
+    def queue_name(self):
+        # type: () -> str
+        # Pylint 2.x validates this correctly, but for py27, we have to
+        # use Pylint 1.x which doesn't support attrs.
+        return self.arn.rpartition(':')[2]  # pylint: disable=no-member
+
+
+@attrs
 class SQSEventSource(FunctionEventSubscriber):
     resource_type = 'sqs_event'
-    queue = attrib()            # type: str
+    queue = attrib()            # type: Union[str, QueueARN]
     batch_size = attrib()       # type: int
 
 

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -241,21 +241,24 @@ def validate_sqs_configuration(chalice_app):
     for event in chalice_app.event_sources:
         if not isinstance(event, app.SQSEventConfig):
             continue
-        if not _is_valid_queue_name(event.queue):
+        if not _is_valid_queue_name(event.queue, event.queue_arn):
             raise ValueError("The 'queue' parameter for the "
                              "'@app.on_sqs_message()' handler must be the "
                              "name of the queue, not the queue URL or the "
                              "queue ARN.  Invalid value: %s" % event.queue)
 
 
-def _is_valid_queue_name(queue_name):
-    # type: (str) -> bool
-    if queue_name.startswith(('https:', 'arn:')):
+def _is_valid_queue_name(queue_name, queue_arn):
+    # type: (Optional[str], Optional[str]) -> bool
+    # The mutually exclusiveness is verified in the on_sqs_message decorator.
+    if queue_name is not None and queue_name.startswith(('https:', 'arn:')):
+        return False
+    if queue_arn is not None and not queue_arn.startswith('arn:'):
         return False
     # We're not validating that the queue has only valid chars because SQS
     # won't let you create a queue with that name in the first place.  We just
     # want to detect the case where a user puts the queue URL/ARN instead of
-    # the name.
+    # the name for the queue_name.
     return True
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -282,7 +282,7 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_sqs_message(queue, batch_size=1, name=None)
+   .. method:: on_sqs_message(queue, batch_size=1, name=None, queue_arn=None)
 
       Create a lambda function and configure it to be automatically invoked
       whenever a message is published to the specified SQS queue.
@@ -328,6 +328,12 @@ Chalice
         with the chalice app name as well as the stage name to create the
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
+
+      :param queue_arn: The ARN of the SQS queue you want to subscribe to.
+        This argument is mutually exclusive with the ``queue`` parameter.
+        This is useful if you already know the exact ARN or when integrating
+        with the AWS CDK to create your SQS queue.
+
 
    .. method:: on_kinesis_record(stream, batch_size=100, starting_position='LATEST', name=None)
 

--- a/tests/unit/deploy/test_appgraph.py
+++ b/tests/unit/deploy/test_appgraph.py
@@ -526,6 +526,22 @@ class TestApplicationGraphBuilder(object):
         assert lambda_function.resource_name == 'handler'
         assert lambda_function.handler == 'app.handler'
 
+    def test_can_create_sqs_handler_with_queue_arn(self, sample_sqs_event_app):
+        @sample_sqs_event_app.on_sqs_message(queue_arn='arn:my:queue')
+        def new_handler(event):
+            pass
+
+        config = self.create_config(sample_sqs_event_app,
+                                    app_name='sqs-event-app',
+                                    autogen_policy=True)
+        builder = ApplicationGraphBuilder()
+        application = builder.build(config, stage_name='dev')
+        sqs_event = application.resources[1]
+        assert sqs_event.queue == models.QueueARN(arn='arn:my:queue')
+        lambda_function = sqs_event.lambda_function
+        assert lambda_function.resource_name == 'new_handler'
+        assert lambda_function.handler == 'app.new_handler'
+
     def test_can_create_kinesis_event_handler(self, sample_kinesis_event_app):
         config = self.create_config(sample_kinesis_event_app,
                                     app_name='kinesis-event-app',

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -333,6 +333,27 @@ def test_validate_sqs_queue_name(sample_app):
         validate_configuration(config)
 
 
+def test_can_use_queue_arn(sample_app):
+
+    @sample_app.on_sqs_message(queue_arn='arn:sqs:...:myqueue')
+    def handler(event):
+        pass
+
+    config = Config.create(chalice_app=sample_app)
+    assert validate_configuration(config) is None
+
+
+def test_queue_arn_must_be_arn(sample_app):
+    @sample_app.on_sqs_message(
+        queue_arn='https://sqs.us-west-2.amazonaws.com/12345/myqueue')
+    def handler(event):
+        pass
+
+    config = Config.create(chalice_app=sample_app)
+    with pytest.raises(ValueError):
+        validate_configuration(config)
+
+
 def test_validate_environment_variables_value_type_not_str(sample_app):
     config = Config.create(chalice_app=sample_app,
                            environment_variables={"ENV_KEY": 1})


### PR DESCRIPTION
This allows sqs handlers to be configured with the
Chalice/CDK integration.

More context on why this is needed [here](https://github.com/aws/chalice/issues/1681#issuecomment-813509116), but this is because CDK and it's token parsing doesn't play well with the `Fn::Sub` in CFN templates when using `CfnInclude` which we use for Chalice/CDK integration.


Couple notes:

* The public facing API now has a mutually exclusive `queue`/`queue_arn` to simplify the API (instead of having a union type on the `queue` param).
* The internal API (`models.py`) uses `Union[str, QueueARN]` as I think it's a little cleaner.

Fixes #1681