### PR TITLE
Support new manylinux tags and fix tests on Python 3.8.10

### DIFF
--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -436,10 +436,25 @@ class DependencyBuilder(object):
     into a site-packages directory, to be included in the bundle by the
     packager.
     """
-    _MANYLINUX_COMPATIBLE_PLATFORM = {'any', 'linux_x86_64',
-                                      'manylinux1_x86_64',
-                                      'manylinux2010_x86_64',
-                                      'manylinux2014_x86_64'}
+    _ADDITIONAL_COMPATIBLE_PLATFORM = {'any', 'linux_x86_64'}
+    _MANYLINUX_LEGACY_MAP = {
+        'manylinux1_x86_64': 'manylinux_2_5_x86_64',
+        'manylinux2010_x86_64': 'manylinux_2_12_x86_64',
+        'manylinux2014_x86_64': 'manylinux_2_17_x86_64',
+    }
+
+    # Mapping of abi to glibc version in Lambda runtime.
+    _RUNTIME_GLIBC = {
+        'cp27mu': (2, 17),
+        'cp36m': (2, 17),
+        'cp37m': (2, 17),
+        'cp38': (2, 26),
+    }
+    # Fallback version if we're on an unknown python version
+    # not in _RUNTIME_GLIBC.
+    # Unlikely to hit this case.
+    _DEFAULT_GLIBC = (2, 17)
+
     _COMPATIBLE_PACKAGE_WHITELIST = {
         'sqlalchemy',
         'pyyaml',
@@ -456,23 +471,74 @@ class DependencyBuilder(object):
     def _is_compatible_wheel_filename(self, expected_abi, filename):
         # type: (str, str) -> bool
         wheel = filename[:-4]
-        implementation, abi, platform = wheel.split('-')[-3:]
-        # Verify platform is compatible
-        if platform not in self._MANYLINUX_COMPATIBLE_PLATFORM:
-            return False
-        # Verify that the ABI is compatible with lambda. Either none or the
-        # correct type for the python version cp27mu for py27 and cp36m for
-        # py36.
-        if abi == 'none':
+        all_compatibility_tags = self._iter_all_compatibility_tags(wheel)
+        for implementation, abi, platform in all_compatibility_tags:
+            # Verify platform is compatible
+            if not self._is_compatible_platform_tag(expected_abi, platform):
+                continue
+            # Verify that the ABI is compatible with lambda. Either none or the
+            # correct type for the python version cp27mu for py27 and cp36m for
+            # py36.
+            if abi == 'none':
+                return True
+            prefix_version = implementation[:3]
+            expected_abis = [expected_abi]
+            if prefix_version == 'cp3':
+                # Deploying python 3 function which means we can accept the
+                # version specific abi, or we can accept the CPython 3 stable
+                # ABI of 'abi3'.
+                expected_abis.append('abi3')
+            if abi in expected_abis:
+                return True
+        return False
+
+    def _is_compatible_platform_tag(self, expected_abi, platform):
+        # type: (str, str) -> bool
+        # From PEP 600, the new manylinux tag is
+        # manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_${ARCH}
+        # e.g. manylinux_2_17_x86_64.
+        # To check if the wheel is compatible, we first need to map any of the
+        # legacy manylinux formats to the new perennial format.
+        # Then we verify that the glibc version is compatible with the version
+        # on the Lambda runtime (from _RUNTIME_GLIBC).
+        if platform in self._ADDITIONAL_COMPATIBLE_PLATFORM:
+            logger.debug("Found compatible platform tag: %s", platform)
             return True
-        prefix_version = implementation[:3]
-        expected_abis = [expected_abi]
-        if prefix_version == 'cp3':
-            # Deploying python 3 function which means we can accept the version
-            # specific abi, or we can accept the CPython 3 stable ABI of
-            # 'abi3'.
-            expected_abis.append('abi3')
-        return abi in expected_abis
+        elif platform.startswith('manylinux'):
+            # This is roughly based on the "Package Installers" section from
+            # PEP 600.
+            perennial_tag = self._MANYLINUX_LEGACY_MAP.get(platform, platform)
+            m = re.match("manylinux_([0-9]+)_([0-9]+)_(.*)", perennial_tag)
+            if m is None:
+                return False
+            tag_major, tag_minor = [int(x) for x in m.groups()[:2]]
+            runtime_major, runtime_minor = self._RUNTIME_GLIBC.get(
+                expected_abi, self._DEFAULT_GLIBC)
+            if (tag_major, tag_minor) <= (runtime_major, runtime_minor):
+                logger.debug(
+                    "Tag glibc (%s, %s) is compatible with "
+                    "runtime glibc (%s, %s)",
+                    tag_major, tag_minor, runtime_major, runtime_minor)
+                return True
+        return False
+
+    def _iter_all_compatibility_tags(self, wheel):
+        # type: (str) -> Iterator[Tuple[str, str, str]]
+        # From PEP 425, section "Compressed Tag Sets"
+        #
+        # "To allow for compact filenames of bdists that work with more than
+        # one compatibility tag triple, each tag in a filename can instead be a
+        # '.'-separated, sorted, set of tags."
+        #
+        # So this means that we have to iterate over all the possible
+        # compatibility tag tuples and check if the wheel is compatible.
+        # We just need any of the combinations to match for us to consider the
+        # wheel compatible.
+        implementation_tag, abi_tag, platform_tag = wheel.split('-')[-3:]
+        for implementation in implementation_tag.split('.'):
+            for abi in abi_tag.split('.'):
+                for platform in platform_tag.split('.'):
+                    yield (implementation, abi, platform)
 
     def _has_at_least_one_package(self, filename):
         # type: (str) -> bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def pytest_collection_modifyitems(config, items):
 @fixture(autouse=True)
 def teardown_function():
     sys.modules.pop('app', None)
+    sys.path_importer_cache.clear()
 
 
 class StubbedSession(botocore.session.Session):

--- a/tests/functional/cdk/test_construct.py
+++ b/tests/functional/cdk/test_construct.py
@@ -33,6 +33,7 @@ def load_chalice_construct(dirname, stack_name='testcdk'):
         sys.modules.pop('app', None)
         sys.modules.pop('stacks', None)
         sys.path.pop()
+        sys.path_importer_cache.clear()
 
 
 def filter_resources(template, resource_type):

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -46,6 +46,7 @@ def mock_cli_factory():
 
 def teardown_function(function):
     sys.modules.pop('app', None)
+    sys.path_importer_cache.clear()
 
 
 def assert_chalice_app_structure_created(dirname):

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -326,6 +326,49 @@ class TestDependencyBuilder(object):
         for req in reqs:
             assert req in installed_packages
 
+    def test_can_support_new_wheel_tags(self, tmpdir, pip_runner):
+        reqs = ['numpy']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        # This is the actual filename from numpy v1.20.3.
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'numpy-1.20.3-cp37-cp37m-manylinux_2_12_x86_64.whl',
+            ]
+        )
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages('cp37m', requirements_file, site_packages)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_support_compressed_tags(self, tmpdir, pip_runner):
+        reqs = ['numpy']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        # This is the actual filename from numpy v1.20.3.
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'numpy-1.20.3-cp37-cp37m-manylinux_2_12_x86_64'
+                '.manylinux2010_x86_64.whl',
+            ]
+        )
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages('cp37m', requirements_file, site_packages)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
     def test_can_use_abi3_whl_for_any_python3(self, tmpdir, pip_runner):
         reqs = ['foo', 'bar', 'baz', 'qux']
         pip, runner = pip_runner


### PR DESCRIPTION
This PR contains two fixes, one for Python 3.8.10 and one for manylinux tags.
I'm combining them into a single PR because you need both to get the tests passing
again.


## Python 3.8.10 fix

Due to Chalice using relative paths when importing an app,
in Python 3.8.10, we'll use a cached version of a previous test case's
sys.path location which will result in import errors, for example see:

https://github.com/jamesls/chalice/runs/2529906754

The GitHub action for 3.8 upgraded from 3.8.9 to 3.8.10 which triggered
this issue.  It looks like this issue has been resolved upstream
(https://bugs.python.org/issue44070) but we still need a fix in Chalice
until a new version of 3.8 is released.  Probably not a bad idea to
clear the cache anyways if we're removing stuff from sys.path.

## Manylinux tag fix

The packaging tests started failing because we couldn't package numpy.
This is because they started publishing wheels using the new perennial tag
for manylinux defined in [PEP 600](https://www.python.org/dev/peps/pep-0600/)
as well as using the compressed tag sets defined in [PEP 425](https://www.python.org/dev/peps/pep-0425/).

We technically only need the compressed tag set fix which requires us to iterate
through all the possible combinations of compatibility triples, but I'm guessing
the new manylinux tags will become more common so I've also added support
for the new tags without the older aliases.

See also:

https://github.com/aws/aws-lambda-builders/issues/233
https://github.com/numpy/numpy/issues/18988