### PR TITLE
Add RestAPI.Stage ref to ApiGatewayCustomDomainMapping

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -735,7 +735,7 @@ class SAMTemplateGenerator(TemplateGenerator):
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
                 'BasePath': domain_name.api_mapping.mount_path,
-                'Stage': resource.api_gateway_stage,
+                'Stage': {'Ref': 'RestAPI.Stage'},
             }
         }
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1646,7 +1646,7 @@ class TestSAMTemplate(TemplateTestBase):
             'Properties': {
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
-                'Stage': config.api_gateway_stage,
+                'Stage':  {'Ref': 'RestAPI.Stage'},
                 'BasePath': '(none)',
             }
         }
@@ -1680,7 +1680,7 @@ class TestSAMTemplate(TemplateTestBase):
             'Properties': {
                 'DomainName': {'Ref': 'ApiGatewayCustomDomain'},
                 'RestApiId': {'Ref': 'RestAPI'},
-                'Stage': config.api_gateway_stage,
+                'Stage':  {'Ref': 'RestAPI.Stage'},
                 'BasePath': '(none)',
             }
         }


### PR DESCRIPTION
This is intended to ensure that the mapping is created only after the stage exists.

*Issue #, if available:*

The problem is explained in #1735 (the issue originally proposed another solution using `DependsOn`, but that's less clean since it refers to a logical ID that's only created by the serverless transform (albeit documented), and this fix achieves the same without doing that.

*Description of changes:*

This implements the fix proposed in this [comment](https://github.com/aws/serverless-application-model/issues/192#issuecomment-520893111), which replaces the literal stage name by a reference to `RestAPI.Stage`. It also updates 2 unit tests.

It requires some documentation hunting to figure out why this should work, but basically the serverless transform substitutes 'RestAPI.Stage' by the logical id of the stage (e.g., `RestAPImystageStage`) as described [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-generated-resources-api.html), where it's documented as a Referenceable property (also confirmed by inspecting `sam validate --debug`). That results in delaying the creation of the custom domain mapping until after the stage resource is created (fixing the race condition). Then the `Ref RestAPImystageStage` resolves to the stage name as documented [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html). 

We've tested the PR in a Chalice API stack config that otherwise will pretty much always fail and roll back, and it resolves the issue, and generates a healthy API mapping (if the resolution chain was wrong it would fail with an "invalid stage identifier" error).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
