### PR TITLE
Fix missing ":" after def index() from doc's code

### DIFF
--- a/docs/source/topics/testing.rst
+++ b/docs/source/topics/testing.rst
@@ -179,7 +179,7 @@ You can test your REST API with the Chalice test client using the
    app = Chalice(app_name="testclient")
 
    @app.route('/')
-   def index()
+   def index():
        return {'hello': 'world'}
 
 


### PR DESCRIPTION
Missing ":" from line 182
```
def index()
return {'hello': 'world'}
```

Python error:
```
    def index()
              ^
SyntaxError: invalid syntax

```
*Issue #, if available:*

*Description of changes: Inserted the ":"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
