### PR TITLE
update terraform required_version to support 1.0

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -793,7 +793,7 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 0.16.0'
+                'required_version': '> 0.11.0, < 1.1.0'
             },
             'provider': {
                 'template': {'version': '~> 2'},


### PR DESCRIPTION
Issue:
Resolves #1757

Description of changes:
Bumps Terraform required_version to allow 1.0 since there are no major/breaking changes between 0.15 and 1.0 and nothing that should conflict with Chalice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.