### PR TITLE
add source_account to aws_lambda_permission for lambdas with s3 events

### DIFF
--- a/.changes/next-release/45694198875-enhancement-S3events-80788.json
+++ b/.changes/next-release/45694198875-enhancement-S3events-80788.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "S3 events",
+  "description": "Add source account to Lambda permissions when configuring S3 events (#1635)"
+}

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -877,7 +877,8 @@ class PlanStage(object):
             models.APICall(
                 method_name='add_permission_for_s3_event',
                 params={'bucket': resource.bucket,
-                        'function_arn': function_arn},
+                        'function_arn': function_arn,
+                        'account_id': Variable('account_id')},
             ),
             (models.APICall(
                 method_name='connect_s3_bucket_to_lambda',

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -873,7 +873,7 @@ class PlanStage(object):
         function_arn = Variable(
             '%s_lambda_arn' % resource.lambda_function.resource_name
         )
-        return [
+        return self._arn_parse_instructions(function_arn) + [
             models.APICall(
                 method_name='add_permission_for_s3_event',
                 params={'bucket': resource.bucket,

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -897,6 +897,7 @@ class TerraformGenerator(TemplateGenerator):
             'action': 'lambda:InvokeFunction',
             'function_name': self._fref(resource.lambda_function),
             'principal': self._options.service_principal('s3'),
+            'source_account': '${data.aws_caller_identity.chalice.account_id}',
             'source_arn': ('arn:${data.aws_partition.chalice.partition}:'
                            's3:::%s' % resource.bucket)
         }

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -819,6 +819,7 @@ class TestPlanS3Events(BasePlannerTests):
                 params={
                     'bucket': 'mybucket',
                     'function_arn': Variable('function_name_lambda_arn'),
+                    'account_id': Variable('account_id'),
                 },
             )
         )

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -642,6 +642,8 @@ class TestTerraformTemplate(TemplateTestBase):
                    'action': 'lambda:InvokeFunction',
                    'function_name': '${aws_lambda_function.handler.arn}',
                    'principal': 's3.amazonaws.com',
+                   'source_account': (
+                       '${data.aws_caller_identity.chalice.account_id}'),
                    'source_arn': (
                        'arn:${data.aws_partition.chalice.partition}:s3:::foo'),
                    'statement_id': 'handler-s3event'


### PR DESCRIPTION
Issue:
Resolves #1635

Description of changes:
Add `source_account` restriction for Lambda permissions with S3 events to meet AWS Foundational Security best practice:
[Lambda.1] Lambda function policies should prohibit public access
https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-lambda-1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.