### PR TITLE
Fix buildspec example in CD docs

### DIFF
--- a/docs/source/topics/cd.rst
+++ b/docs/source/topics/cd.rst
@@ -146,7 +146,7 @@ that does the following.
       - sudo pip install -r requirements.txt
       - chalice package /tmp/packaged
       - aws cloudformation package --template-file
-          tmp/packaged/sam.json --s3-bucket ${APP_S3_BUCKET}
+          /tmp/packaged/sam.json --s3-bucket ${APP_S3_BUCKET}
           --output-template-file transformed.yaml
   artifacts:
     type: zip


### PR DESCRIPTION
*Description of changes:*
Fix buildspec example in CD docs:
There was a missing "/" breaking cloudformation package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
