### PR TITLE
fix partition error when updating API Gateway in GovCloud region

### DIFF
--- a/.changes/next-release/22361029171-bugfix-GovCloud-55856.json
+++ b/.changes/next-release/22361029171-bugfix-GovCloud-55856.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "GovCloud",
+  "description": "Fix partition error when updating API Gateway in GovCloud region (#1770)"
+}

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -729,9 +729,10 @@ class TypedAWSClient(object):
             updated_domain_name = self._update_domain_name_v2(kwargs)
         else:
             raise ValueError('Unsupported protocol value.')
-        resource_arn = 'arn:aws:apigateway:{region_name}:' \
+        resource_arn = 'arn:{partition}:apigateway:{region_name}:' \
                        ':/domainnames/{domain_name}'\
             .format(
+                partition=self.partition_name,
                 region_name=self.region_name,
                 domain_name=domain_name
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes the following error when updating API Gateway in GovCloud:

```
chalice.deploy.deployer.ChaliceDeploymentError: ERROR - While deploying your chalice application, received the following error:

 An error occurred (BadRequestException) when calling the GetTags operation: 
 Invalid input resource arn: expected partition aws-us-gov

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
