### PR TITLE
Upgrade sphinx to latest version

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1824,9 +1824,9 @@ For more details on using the AWS CDK with Chalice, see :doc:`tutorials/cdk`.
 
 .. code-block:: python
 
-   from chalice.cdk import Chalice
+   from chalice import cdk
 
-.. class:: Chalice(scope, id, source_dir, stage_config=None, preserve_logical_ids=True, \*\*kwargs)
+.. class:: cdk.Chalice(scope, id, source_dir, stage_config=None, preserve_logical_ids=True, \*\*kwargs)
 
    A test client used to write tests for Chalice apps.  It allows you to
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,1 @@
-Sphinx==1.7.9
-guzzle_sphinx_theme>=0.7.10,<0.8
+Sphinx==4.1.2


### PR DESCRIPTION
The latest version of sphinx includes built-in
retries to the linkchecker, which has been failing our
CI builds recently.

The CDK related change was to fix a new error that
popped up with the new version of Sphinx.