### PR TITLE
Run CDK tests as part of the run-tests GitHub action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,29 @@ jobs:
           pip install -e .
       - name: Run PRCheck
         run: make prcheck
+  cdktests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: actions/setup-python@v2
+        name: Set up Python ${{ matrix.python-version }}
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install CDK
+        run: npm install -g aws-cdk
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt -r requirements-docs.txt
+          pip install -e .[cdk]
+      - name: Run CDK tests
+        run: python -m pytest tests/functional/cdk
 #  Chalice works on windows, but there's some differences between
 #  the GitHub actions windows environment and our windows dev
 #  laptops that are causing certain tests to fail.  Once these

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Run PRCheck
         run: make prcheck
   cdktests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2

--- a/tests/functional/cdk/test_construct.py
+++ b/tests/functional/cdk/test_construct.py
@@ -87,8 +87,6 @@ def test_can_package_as_cdk_app(runner):
         assert bucket_ref.startswith('AssetParameters')
 
 
-@pytest.mark.xfail(reason=("Expected fail due to invalid schema in "
-                           "CDK sam.json file."))
 def test_can_package_managed_layer(runner):
     with runner.isolated_filesystem():
         newproj.create_new_project_skeleton(


### PR DESCRIPTION
I've set this up as a separate job under this action to isolate
setting up node and the CDK to only the tests that need it.

Should prevent issues like #1786 from happening in the future.