### PR TITLE
Allow use of new lambda 3.9 runtime

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -163,7 +163,9 @@ class Config(object):
             return 'python3.6'
         elif (major, minor) <= (3, 7):
             return 'python3.7'
-        return 'python3.8'
+        elif (major, minor) <= (3, 8):
+            return 'python3.8'
+        return 'python3.9'
 
     @property
     def layers(self):

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -77,6 +77,7 @@ class BaseLambdaDeploymentPackager(object):
         'python3.6': 'cp36m',
         'python3.7': 'cp37m',
         'python3.8': 'cp38',
+        'python3.9': 'cp39'
     }
 
     def __init__(self, osutils, dependency_builder, ui):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -373,8 +373,10 @@ def test_can_load_python_version():
         expected_runtime = 'python3.6'
     elif minor <= 7:
         expected_runtime = 'python3.7'
-    else:
+    elif minor <= 8:
         expected_runtime = 'python3.8'
+    else:
+        expected_runtime = 'python3.9'
     assert c.lambda_python_version == expected_runtime
 
 


### PR DESCRIPTION
*Issue #, if available:* #1787

*Description of changes:*
Very short and naïve changes. Keeps all previous functionality, only that it also checks for 3.8 before 3.9. I tried deploying locally with a 3.9 runtime and I can confirm that the lambda elements are created with the correct version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #1787 
