### PR TITLE
Bump to 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ chalice.egg-info/
 .mypy_cache/
 *.pyc
 .vscode
+.gitattributes

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -163,7 +163,9 @@ class Config(object):
             return 'python3.6'
         elif (major, minor) <= (3, 7):
             return 'python3.7'
-        return 'python3.8'
+        elif (major, minor) <= (3, 8):
+            return 'python3.8'
+        return 'python3.9'
 
     @property
     def layers(self):

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -77,6 +77,7 @@ class BaseLambdaDeploymentPackager(object):
         'python3.6': 'cp36m',
         'python3.7': 'cp37m',
         'python3.8': 'cp38',
+        'python3.9': 'cp39'
     }
 
     def __init__(self, osutils, dependency_builder, ui):

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -413,6 +413,8 @@ def test_error_when_no_deployed_record(runner, mock_cli_factory):
                     reason="Cannot generate pipeline for python3.7.")
 @pytest.mark.skipif(sys.version_info[:2] == (3, 8),
                     reason="Cannot generate pipeline for python3.8.")
+@pytest.mark.skipif(sys.version_info[:2] == (3, 9),
+                    reason="Cannot generate pipeline for python3.9.")
 def test_can_generate_pipeline_for_all(runner):
     with runner.isolated_filesystem():
         newproj.create_new_project_skeleton('testproject')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -373,8 +373,10 @@ def test_can_load_python_version():
         expected_runtime = 'python3.6'
     elif minor <= 7:
         expected_runtime = 'python3.7'
-    else:
+    elif minor <= 8:
         expected_runtime = 'python3.8'
+    else:
+        expected_runtime = 'python3.9'
     assert c.lambda_python_version == expected_runtime
 
 


### PR DESCRIPTION
Issue #, if available: #1787

Description of changes:
Very short and naïve changes. Keeps all previous functionality, only that it also checks for 3.8 before 3.9. I tried deploying locally with a 3.9 runtime and I can confirm that the lambda elements are created with the correct version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #1787