### PR TITLE
Feature/issue 1176 add maximum batching window in seconds streams and sqs

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -721,7 +721,8 @@ class DecoratorAPI(object):
         )
 
     def on_sqs_message(self, queue=None, batch_size=1,
-                       name=None, queue_arn=None):
+                       name=None, queue_arn=None,
+                       maximum_batching_window_in_seconds=0):
         return self._create_registration_function(
             handler_type='on_sqs_message',
             name=name,
@@ -729,6 +730,7 @@ class DecoratorAPI(object):
                 'queue': queue,
                 'queue_arn': queue_arn,
                 'batch_size': batch_size,
+                'maximum_batching_window_in_seconds': maximum_batching_window_in_seconds
             }
         )
 
@@ -748,23 +750,27 @@ class DecoratorAPI(object):
         )
 
     def on_kinesis_record(self, stream, batch_size=100,
-                          starting_position='LATEST', name=None):
+                          starting_position='LATEST', name=None,
+                          maximum_batching_window_in_seconds=0):
         return self._create_registration_function(
             handler_type='on_kinesis_record',
             name=name,
             registration_kwargs={'stream': stream,
                                  'batch_size': batch_size,
-                                 'starting_position': starting_position},
+                                 'starting_position': starting_position,
+                                 'maximum_batching_window_in_seconds': maximum_batching_window_in_seconds},
         )
 
     def on_dynamodb_record(self, stream_arn, batch_size=100,
-                           starting_position='LATEST', name=None):
+                           starting_position='LATEST', name=None,
+                           maximum_batching_window_in_seconds=0):
         return self._create_registration_function(
             handler_type='on_dynamodb_record',
             name=name,
             registration_kwargs={'stream_arn': stream_arn,
                                  'batch_size': batch_size,
-                                 'starting_position': starting_position},
+                                 'starting_position': starting_position,
+                                 'maximum_batching_window_in_seconds': maximum_batching_window_in_seconds},
         )
 
     def route(self, path, **kwargs):
@@ -994,6 +1000,7 @@ class _HandlerRegistration(object):
             queue=queue,
             queue_arn=queue_arn,
             batch_size=kwargs['batch_size'],
+            maximum_batching_window_in_seconds=kwargs['maximum_batching_window_in_seconds'],
         )
         self.event_sources.append(sqs_config)
 
@@ -1005,6 +1012,7 @@ class _HandlerRegistration(object):
             stream=kwargs['stream'],
             batch_size=kwargs['batch_size'],
             starting_position=kwargs['starting_position'],
+            maximum_batching_window_in_seconds=kwargs['maximum_batching_window_in_seconds'],
         )
         self.event_sources.append(kinesis_config)
 
@@ -1016,6 +1024,7 @@ class _HandlerRegistration(object):
             stream_arn=kwargs['stream_arn'],
             batch_size=kwargs['batch_size'],
             starting_position=kwargs['starting_position'],
+            maximum_batching_window_in_seconds=kwargs['maximum_batching_window_in_seconds'],
         )
         self.event_sources.append(ddb_config)
 
@@ -1460,29 +1469,35 @@ class SNSEventConfig(BaseEventSourceConfig):
 
 
 class SQSEventConfig(BaseEventSourceConfig):
-    def __init__(self, name, handler_string, queue, queue_arn, batch_size):
+    def __init__(self, name, handler_string, queue, queue_arn, batch_size,
+                 maximum_batching_window_in_seconds):
         super(SQSEventConfig, self).__init__(name, handler_string)
         self.queue = queue
         self.queue_arn = queue_arn
         self.batch_size = batch_size
+        self.maximum_batching_window_in_seconds = maximum_batching_window_in_seconds
 
 
 class KinesisEventConfig(BaseEventSourceConfig):
     def __init__(self, name, handler_string, stream,
-                 batch_size, starting_position):
+                 batch_size, starting_position,
+                 maximum_batching_window_in_seconds):
         super(KinesisEventConfig, self).__init__(name, handler_string)
         self.stream = stream
         self.batch_size = batch_size
         self.starting_position = starting_position
+        self.maximum_batching_window_in_seconds = maximum_batching_window_in_seconds
 
 
 class DynamoDBEventConfig(BaseEventSourceConfig):
     def __init__(self, name, handler_string, stream_arn,
-                 batch_size, starting_position):
+                 batch_size, starting_position,
+                 maximum_batching_window_in_seconds):
         super(DynamoDBEventConfig, self).__init__(name, handler_string)
         self.stream_arn = stream_arn
         self.batch_size = batch_size
         self.starting_position = starting_position
+        self.maximum_batching_window_in_seconds = maximum_batching_window_in_seconds
 
 
 class WebsocketConnectConfig(BaseEventSourceConfig):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -354,13 +354,14 @@ class SNSEventConfig(BaseEventSourceConfig):
 
 
 class SQSEventConfig(BaseEventSourceConfig):
-    queue = ... # type: Optional[str]
-    queue_arn = ... # type: Optional[str]
-    batch_size = ... # type: int
+    queue = ...                              # type: Optional[str]
+    queue_arn = ...                          # type: Optional[str]
+    batch_size = ...                         # type: int
+    maximum_batching_window_in_seconds = ... # type: int
 
     def __init__(
         self, name: str, handler_string: str, queue: Optional[str],
-        queue_arn: Optional[str], batch_size: int
+        queue_arn: Optional[str], batch_size: int, maximum_batching_window_in_seconds: int,
     ) -> None: ...
 
 
@@ -374,15 +375,17 @@ class CloudWatchEventConfig(BaseEventSourceConfig):
 
 
 class KinesisEventConfig(BaseEventSourceConfig):
-    stream = ...             # type: str
-    batch_size = ...         # type: int
-    starting_position = ...  # type: str
+    stream = ...                             # type: str
+    batch_size = ...                         # type: int
+    starting_position = ...                  # type: str
+    maximum_batching_window_in_seconds = ... # type: int
 
 
 class DynamoDBEventConfig(BaseEventSourceConfig):
-    stream_arn = ...             # type: str
-    batch_size = ...             # type: int
-    starting_position = ...      # type: str
+    stream_arn = ...                         # type: str
+    batch_size = ...                         # type: int
+    starting_position = ...                  # type: str
+    maximum_batching_window_in_seconds = ... # type: int
 
 
 class Blueprint(DecoratorAPI):

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -570,6 +570,7 @@ class ApplicationGraphBuilder(object):
             queue=queue,
             batch_size=sqs_config.batch_size,
             lambda_function=lambda_function,
+            maximum_batching_window_in_seconds=sqs_config.maximum_batching_window_in_seconds,
         )
         return sqs_event_source
 
@@ -590,6 +591,7 @@ class ApplicationGraphBuilder(object):
             resource_name=resource_name,
             stream=kinesis_config.stream,
             batch_size=kinesis_config.batch_size,
+            maximum_batching_window_in_seconds=kinesis_config.maximum_batching_window_in_seconds,
             starting_position=kinesis_config.starting_position,
             lambda_function=lambda_function,
         )
@@ -612,6 +614,7 @@ class ApplicationGraphBuilder(object):
             resource_name=resource_name,
             stream_arn=ddb_config.stream_arn,
             batch_size=ddb_config.batch_size,
+            maximum_batching_window_in_seconds=ddb_config.maximum_batching_window_in_seconds,
             starting_position=ddb_config.starting_position,
             lambda_function=lambda_function,
         )

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -344,21 +344,24 @@ class QueueARN(object):
 @attrs
 class SQSEventSource(FunctionEventSubscriber):
     resource_type = 'sqs_event'
-    queue = attrib()            # type: Union[str, QueueARN]
-    batch_size = attrib()       # type: int
+    queue = attrib()                                # type: Union[str, QueueARN]
+    batch_size = attrib()                           # type: int
+    maximum_batching_window_in_seconds = attrib()   # type: int
 
 
 @attrs
 class KinesisEventSource(FunctionEventSubscriber):
     resource_type = 'kinesis_event'
-    stream = attrib()                # type: str
-    batch_size = attrib()            # type: int
-    starting_position = attrib()     # type: str
+    stream = attrib()                               # type: str
+    batch_size = attrib()                           # type: int
+    starting_position = attrib()                    # type: str
+    maximum_batching_window_in_seconds = attrib()   # type: int
 
 
 @attrs
 class DynamoDBEventSource(FunctionEventSubscriber):
     resource_type = 'dynamodb_event'
-    stream_arn = attrib()            # type: str
-    batch_size = attrib()            # type: int
-    starting_position = attrib()     # type: str
+    stream_arn = attrib()                           # type: str
+    batch_size = attrib()                           # type: int
+    starting_position = attrib()                    # type: str
+    maximum_batching_window_in_seconds = attrib()   # type: int

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -728,7 +728,8 @@ class PlanStage(object):
                 models.APICall(
                     method_name='update_lambda_event_source',
                     params={'event_uuid': uuid,
-                            'batch_size': resource.batch_size}
+                            'batch_size': resource.batch_size,
+                            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds}
                 )
             ] + self._batch_record_resource(
                 'sqs_event', resource.resource_name, {
@@ -743,6 +744,7 @@ class PlanStage(object):
                 method_name='create_lambda_event_source',
                 params={'event_source_arn': Variable(queue_arn_varname),
                         'batch_size': resource.batch_size,
+                        'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds,
                         'function_name': function_arn},
                 output_var=uuid_varname,
             ), 'Subscribing %s to SQS queue %s\n'
@@ -782,7 +784,8 @@ class PlanStage(object):
                 models.APICall(
                     method_name='update_lambda_event_source',
                     params={'event_uuid': uuid,
-                            'batch_size': resource.batch_size}
+                            'batch_size': resource.batch_size,
+                            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds}
                 )
             ] + self._batch_record_resource(
                 'kinesis_event', resource.resource_name, {
@@ -798,7 +801,8 @@ class PlanStage(object):
                 params={'event_source_arn': Variable(stream_arn_varname),
                         'batch_size': resource.batch_size,
                         'function_name': function_arn,
-                        'starting_position': resource.starting_position},
+                        'starting_position': resource.starting_position,
+                        'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds},
                 output_var=uuid_varname,
             ), 'Subscribing %s to Kinesis stream %s\n'
                 % (resource.lambda_function.function_name, resource.stream)
@@ -826,7 +830,8 @@ class PlanStage(object):
                 models.APICall(
                     method_name='update_lambda_event_source',
                     params={'event_uuid': uuid,
-                            'batch_size': resource.batch_size}
+                            'batch_size': resource.batch_size,
+                            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds}
                 )
             ] + self._batch_record_resource(
                 'dynamodb_event', resource.resource_name, {
@@ -841,7 +846,8 @@ class PlanStage(object):
                 params={'event_source_arn': resource.stream_arn,
                         'batch_size': resource.batch_size,
                         'function_name': function_arn,
-                        'starting_position': resource.starting_position},
+                        'starting_position': resource.starting_position,
+                        'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds},
                 output_var=uuid_varname,
             ), 'Subscribing %s to DynamoDB stream %s\n'
                 % (resource.lambda_function.function_name,

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -645,6 +645,7 @@ class SAMTemplateGenerator(TemplateGenerator):
                 'Properties': {
                     'Queue': queue,
                     'BatchSize': resource.batch_size,
+                    'MaximumBatchingWindowInSeconds': resource.maximum_batching_window_in_seconds,
                 }
             }
         }
@@ -666,6 +667,7 @@ class SAMTemplateGenerator(TemplateGenerator):
             },
             'BatchSize': resource.batch_size,
             'StartingPosition': resource.starting_position,
+            'MaximumBatchingWindowInSeconds': resource.maximum_batching_window_in_seconds,
         }
         function_cfn['Properties']['Events'] = {
             kinesis_cfn_name: {
@@ -685,6 +687,7 @@ class SAMTemplateGenerator(TemplateGenerator):
             'Stream': resource.stream_arn,
             'BatchSize': resource.batch_size,
             'StartingPosition': resource.starting_position,
+            'MaximumBatchingWindowInSeconds': resource.maximum_batching_window_in_seconds,
         }
         function_cfn['Properties']['Events'] = {
             ddb_cfn_name: {
@@ -916,6 +919,7 @@ class TerraformGenerator(TemplateGenerator):
             resource.resource_name] = {
             'event_source_arn': event_source_arn,
             'batch_size': resource.batch_size,
+            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds,
             'function_name': self._fref(resource.lambda_function)
         }
 
@@ -929,6 +933,7 @@ class TerraformGenerator(TemplateGenerator):
                 stream=resource.stream),
             'batch_size': resource.batch_size,
             'starting_position': resource.starting_position,
+            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds,
             'function_name': self._fref(resource.lambda_function)
         }
 
@@ -939,6 +944,7 @@ class TerraformGenerator(TemplateGenerator):
             'event_source_arn': resource.stream_arn,
             'batch_size': resource.batch_size,
             'starting_position': resource.starting_position,
+            'maximum_batching_window_in_seconds': resource.maximum_batching_window_in_seconds,
             'function_name': self._fref(resource.lambda_function),
         }
 

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1739,7 +1739,8 @@ class TestPlanSQSSubscription(BasePlannerTests):
             resource_name='function_name-sqs-event-source',
             queue='myqueue',
             batch_size=10,
-            lambda_function=function
+            lambda_function=function,
+            maximum_batching_window_in_seconds=60
         )
         plan = self.determine_plan(sqs_event_source)
         plan_parse_arn = plan[:5]
@@ -1779,6 +1780,7 @@ class TestPlanSQSSubscription(BasePlannerTests):
                     "function_name-sqs-event-source_queue_arn"
                 ),
                 'batch_size': 10,
+                'maximum_batching_window_in_seconds': 60,
                 'function_name': Variable("function_name_lambda_arn")
             },
             output_var='function_name-sqs-event-source_uuid'
@@ -1801,7 +1803,8 @@ class TestPlanSQSSubscription(BasePlannerTests):
             resource_name='function_name-sqs-event-source',
             queue=models.QueueARN(arn='arn:us-west-2:myqueue'),
             batch_size=10,
-            lambda_function=function
+            lambda_function=function,
+            maximum_batching_window_in_seconds=0
         )
         plan = self.determine_plan(sqs_event_source)
         assert plan[0] == models.StoreValue(
@@ -1815,6 +1818,7 @@ class TestPlanSQSSubscription(BasePlannerTests):
                     "function_name-sqs-event-source_queue_arn"
                 ),
                 'batch_size': 10,
+                'maximum_batching_window_in_seconds': 0,
                 'function_name': Variable("function_name_lambda_arn")
             },
             output_var='function_name-sqs-event-source_uuid'
@@ -1837,7 +1841,8 @@ class TestPlanSQSSubscription(BasePlannerTests):
             resource_name='function_name-sqs-event-source',
             queue=models.QueueARN(arn='arn:sqs:myqueue'),
             batch_size=10,
-            lambda_function=function
+            lambda_function=function,
+            maximum_batching_window_in_seconds=0
         )
         self.remote_state.declare_resource_exists(
             sqs_event_source,
@@ -1857,6 +1862,7 @@ class TestPlanSQSSubscription(BasePlannerTests):
             params={
                 'event_uuid': 'my-uuid',
                 'batch_size': 10,
+                'maximum_batching_window_in_seconds': 0,
             },
         )
         self.assert_recorded_values(
@@ -1874,7 +1880,8 @@ class TestPlanSQSSubscription(BasePlannerTests):
             resource_name='function_name-sqs-event-source',
             queue='myqueue',
             batch_size=10,
-            lambda_function=function
+            lambda_function=function,
+            maximum_batching_window_in_seconds=0
         )
         self.remote_state.declare_resource_exists(
             sqs_event_source,
@@ -1917,6 +1924,7 @@ class TestPlanSQSSubscription(BasePlannerTests):
             params={
                 'event_uuid': 'my-uuid',
                 'batch_size': 10,
+                'maximum_batching_window_in_seconds': 0,
             },
         )
         self.assert_recorded_values(
@@ -1972,6 +1980,7 @@ class TestPlanKinesisSubscription(BasePlannerTests):
             stream='mystream',
             batch_size=10,
             starting_position='LATEST',
+            maximum_batching_window_in_seconds=0,
             lambda_function=function
         )
         plan = self.determine_plan(kinesis_event_source)
@@ -2014,6 +2023,7 @@ class TestPlanKinesisSubscription(BasePlannerTests):
                 ),
                 'batch_size': 10,
                 'starting_position': 'LATEST',
+                'maximum_batching_window_in_seconds': 0,
                 'function_name': Variable("function_name_lambda_arn")
             },
             output_var='function_name-kinesis-event-source_uuid'
@@ -2037,6 +2047,7 @@ class TestPlanKinesisSubscription(BasePlannerTests):
             stream='mystream',
             batch_size=10,
             starting_position='LATEST',
+            maximum_batching_window_in_seconds=60,
             lambda_function=function
         )
         self.remote_state.declare_resource_exists(
@@ -2053,6 +2064,7 @@ class TestPlanKinesisSubscription(BasePlannerTests):
             params={
                 'event_uuid': 'my-uuid',
                 'batch_size': 10,
+                'maximum_batching_window_in_seconds': 60,
             }
         )
 
@@ -2063,6 +2075,7 @@ class TestPlanDynamoDBSubscription(BasePlannerTests):
         event_source = models.DynamoDBEventSource(
             resource_name='handler-dynamodb-event-source',
             stream_arn='arn:stream', batch_size=100,
+            maximum_batching_window_in_seconds=0,
             starting_position='LATEST', lambda_function=function)
         plan = self.determine_plan(event_source)
         assert plan[0] == models.APICall(
@@ -2072,6 +2085,7 @@ class TestPlanDynamoDBSubscription(BasePlannerTests):
                 'batch_size': 100,
                 'function_name': Variable('function_name_lambda_arn'),
                 'starting_position': 'LATEST',
+                'maximum_batching_window_in_seconds': 0,
             },
             output_var='handler-dynamodb-event-source_uuid',
         )
@@ -2081,6 +2095,7 @@ class TestPlanDynamoDBSubscription(BasePlannerTests):
         event_source = models.DynamoDBEventSource(
             resource_name='handler-dynamodb-event-source',
             stream_arn='arn:stream', batch_size=100,
+            maximum_batching_window_in_seconds=60,
             starting_position='LATEST', lambda_function=function)
         self.remote_state.declare_resource_exists(
             event_source,
@@ -2095,6 +2110,7 @@ class TestPlanDynamoDBSubscription(BasePlannerTests):
             params={
                 'event_uuid': 'my-uuid',
                 'batch_size': 100,
+                'maximum_batching_window_in_seconds': 60
             },
         )
 
@@ -2461,6 +2477,7 @@ class TestRemoteState(object):
                                      expected_result):
         event_source = models.SQSEventSource(
             resource_name='handler-sqs-event-source',
+            maximum_batching_window_in_seconds=0,
             queue=new_queue, batch_size=100, lambda_function=None
         )
         if deployed_queue is not None:
@@ -2494,6 +2511,7 @@ class TestRemoteState(object):
         event_source = models.KinesisEventSource(
             resource_name='handler-kinesis-event-source',
             stream='mystream', batch_size=100, starting_position='LATEST',
+            maximum_batching_window_in_seconds=0,
             lambda_function=None)
         deployed_resources = {'resources': []}
         remote_state = RemoteState(
@@ -2505,6 +2523,7 @@ class TestRemoteState(object):
         event_source = models.KinesisEventSource(
             resource_name='handler-kinesis-event-source',
             stream='mystream', batch_size=100, starting_position='LATEST',
+            maximum_batching_window_in_seconds=0,
             lambda_function=None)
         deployed_resources = {
             'resources': [{
@@ -2526,6 +2545,7 @@ class TestRemoteState(object):
         event_source = models.DynamoDBEventSource(
             resource_name='handler-dynamodb-event-source',
             stream_arn='arn:stream', batch_size=100,
+            maximum_batching_window_in_seconds=0,
             starting_position='LATEST', lambda_function=None)
         deployed_resources = {'resources': []}
         remote_state = RemoteState(
@@ -2537,6 +2557,7 @@ class TestRemoteState(object):
         event_source = models.KinesisEventSource(
             resource_name='handler-kinesis-event-source',
             stream='mystream', batch_size=100, starting_position='LATEST',
+            maximum_batching_window_in_seconds=0,
             lambda_function=None)
         deployed_resources = {
             'resources': [{
@@ -2943,7 +2964,8 @@ class TestUnreferencedResourcePlanner(BasePlannerTests):
                 resource_name='handler-sqs-event-source',
                 queue='my-queue',
                 batch_size=10,
-                lambda_function=create_function_resource('function_name')
+                lambda_function=create_function_resource('function_name'),
+                maximum_batching_window_in_seconds=0
             )
         )
         deployed = {
@@ -2995,7 +3017,8 @@ class TestUnreferencedResourcePlanner(BasePlannerTests):
                 resource_name='handler-sqs-event-source',
                 queue='my-new-queue',
                 batch_size=10,
-                lambda_function=create_function_resource('function_name')
+                lambda_function=create_function_resource('function_name'),
+                maximum_batching_window_in_seconds=0
             )
         )
         config = FakeConfig(deployed)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1986,6 +1986,7 @@ def test_can_create_sqs_handler(sample_app):
     event = sample_app.event_sources[0]
     assert event.queue == 'MyQueue'
     assert event.batch_size == 200
+    assert event.maximum_batching_window_in_seconds == 0
     assert event.handler_string == 'app.handler'
 
 
@@ -1997,6 +1998,16 @@ def test_can_set_sqs_handler_name(sample_app):
     assert len(sample_app.event_sources) == 1
     event = sample_app.event_sources[0]
     assert event.name == 'sqs_handler'
+
+
+def test_can_set_sqs_handler_maximum_batching_window_in_seconds(sample_app):
+    @sample_app.on_sqs_message(queue='MyQueue', maximum_batching_window_in_seconds=60)
+    def handler(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    event = sample_app.event_sources[0]
+    assert event.maximum_batching_window_in_seconds == 60
 
 
 def test_can_map_sqs_event(sample_app):
@@ -2044,6 +2055,20 @@ def test_can_create_kinesis_handler(sample_app):
     assert config.stream == 'MyStream'
     assert config.batch_size == 1
     assert config.starting_position == 'TRIM_HORIZON'
+    assert config.maximum_batching_window_in_seconds == 0
+
+
+def test_can_set_kinesis_handler_maximum_batching_window_in_seconds(sample_app):
+    @sample_app.on_kinesis_record(stream='MyStream',
+                                  batch_size=1,
+                                  starting_position='TRIM_HORIZON',
+                                  maximum_batching_window_in_seconds=60)
+    def handler(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    config = sample_app.event_sources[0]
+    assert config.maximum_batching_window_in_seconds == 60
 
 
 def test_can_map_kinesis_event(sample_app):
@@ -2115,6 +2140,20 @@ def test_can_create_ddb_handler(sample_app):
     assert config.stream_arn == 'arn:aws:dynamodb:...:stream'
     assert config.batch_size == 10
     assert config.starting_position == 'TRIM_HORIZON'
+    assert config.maximum_batching_window_in_seconds == 0
+
+
+def test_can_set_ddb_handler_maximum_batching_window_in_seconds(sample_app):
+    @sample_app.on_dynamodb_record(
+        stream_arn='arn:aws:dynamodb:...:stream', batch_size=10,
+        starting_position='TRIM_HORIZON',
+        maximum_batching_window_in_seconds=60)
+    def handler(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    config = sample_app.event_sources[0]
+    assert config.maximum_batching_window_in_seconds == 60
 
 
 def test_can_map_ddb_event(sample_app):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -728,8 +728,9 @@ class TestTerraformTemplate(TemplateTestBase):
                        ':${data.aws_region.chalice.name}:'
                        '${data.aws_caller_identity.chalice.account_id}:foo'),
                    'function_name': '${aws_lambda_function.handler.arn}',
-                   'batch_size': 5
-               }
+                   'batch_size': 5,
+                   'maximum_batching_window_in_seconds': 0
+        }
 
     def test_sqs_arn_does_not_use_fn_sub(self, sample_app):
         @sample_app.on_sqs_message(queue_arn='arn:foo:bar', batch_size=5)
@@ -747,7 +748,8 @@ class TestTerraformTemplate(TemplateTestBase):
                    'handler-sqs-event-source'] == {
                    'event_source_arn': 'arn:foo:bar',
                    'function_name': '${aws_lambda_function.handler.arn}',
-                   'batch_size': 5
+                   'batch_size': 5,
+                   'maximum_batching_window_in_seconds': 0
                }
 
     def test_can_package_kinesis_handler(self, sample_app):
@@ -772,7 +774,8 @@ class TestTerraformTemplate(TemplateTestBase):
                        ':stream/mystream'),
                    'function_name': '${aws_lambda_function.handler.arn}',
                    'starting_position': 'TRIM_HORIZON',
-                   'batch_size': 5
+                   'batch_size': 5,
+                   'maximum_batching_window_in_seconds': 0
                }
 
     def test_can_package_dynamodb_handler(self, sample_app):
@@ -794,7 +797,8 @@ class TestTerraformTemplate(TemplateTestBase):
                        'event_source_arn': 'arn:aws:...:stream',
                        'function_name': '${aws_lambda_function.handler.arn}',
                        'starting_position': 'TRIM_HORIZON',
-                       'batch_size': 5
+                       'batch_size': 5,
+                       'maximum_batching_window_in_seconds': 0
                    }
 
     def test_package_websocket_with_error_message(self, sample_websocket_app):
@@ -1538,6 +1542,7 @@ class TestSAMTemplate(TemplateTestBase):
                         )
                     },
                     'BatchSize': 5,
+                    'MaximumBatchingWindowInSeconds': 0,
                 },
             }
         }
@@ -1558,6 +1563,7 @@ class TestSAMTemplate(TemplateTestBase):
                 'Properties': {
                     'Queue': 'arn:foo:bar',
                     'BatchSize': 5,
+                    'MaximumBatchingWindowInSeconds': 0,
                 },
             }
         }
@@ -1584,6 +1590,7 @@ class TestSAMTemplate(TemplateTestBase):
                     },
                     'BatchSize': 5,
                     'StartingPosition': 'LATEST',
+                    'MaximumBatchingWindowInSeconds': 0,
                 },
             }
         }
@@ -1606,6 +1613,7 @@ class TestSAMTemplate(TemplateTestBase):
                     'Stream': 'arn:aws:...:stream',
                     'BatchSize': 5,
                     'StartingPosition': 'LATEST',
+                    'MaximumBatchingWindowInSeconds': 0,
                 },
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
Issue $1778

*Description of changes:*
Added MaximumBatchingWindowInSeconds to Stream (Kinesis, DynamoDb) and SQS handlers (defaulting to zero seconds). Updated necessary classes and along with Terrformform/Cloudformation generation scripts and all accompanying tests. Added new tests to validate setting of new attribute.

I have not updated documentation, but can once we have settled on the naming convention of the new field. I chose the verbose version so that it aligns with other documentation (AWS and Terraform).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
