### PR TITLE
Fix "chalice.Response" import in middleware docs

### DIFF
--- a/docs/source/topics/middleware.rst
+++ b/docs/source/topics/middleware.rst
@@ -233,7 +233,7 @@ want to register this handler for our ``http`` event type.
 
 .. code-block:: python
 
-   from chalice Response
+   from chalice import Response
 
    @app.middleware('http')
    def require_header(event, get_response):


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Just add `import` to code sample in middleware docs. The topic is "Short Circuiting a Request".


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
