### PR TITLE
Stop including tests in Python wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     author="James Saryerwinnie",
     author_email='js@jamesls.com',
     url='https://github.com/aws/chalice',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=install_requires,
     extras_require={
         'event-file-poller': ['watchdog==0.9.0'],


### PR DESCRIPTION
*Description of changes:*
The current Chalice wheel on PyPI contains tests that are installed as a separate "tests" site-package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
