### PR TITLE
Add HTTP Route Metadata Feature

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -14,7 +14,7 @@ import datetime
 from collections import defaultdict
 
 
-__version__ = '1.26.1'
+__version__ = '1.26.0'
 _PARAMS = re.compile(r'{\w+}')
 
 # Implementation note:  This file is intended to be a standalone file

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -117,6 +117,10 @@ Chalice
         you would like more control over how CORS is configured, you can provide
         an instance of :class:`CORSConfig`.
 
+      :param metadata: Allows you to register arbitrary data of any type to a
+        route. The data is accessible throughout the HTTP request lifecycle via
+        the Request object.
+
    .. method:: authorizer(name, \*\*options)
 
       Register a built-in authorizer.
@@ -647,6 +651,11 @@ Request
   .. attribute:: stage_vars
 
      A dict of configuration for the API Gateway stage.
+
+  .. attribute:: metadata
+
+     Metadata set on an HTTP Route. This is useful for passing route-specific
+     data to be used throughout the request lifecycle. Default value is None.
 
    .. attribute:: lambda_context
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -654,10 +654,10 @@ Request
 
   .. attribute:: metadata
 
-     Metadata set on an HTTP Route. This is useful for passing route-specific
-     data to be used throughout the request lifecycle. Default value is None.
+     Corresponds to the `metadata` parameter set on an HTTP Route. When present,
+     this data is added to the request, otherwise the default value is None.
 
-   .. attribute:: lambda_context
+  .. attribute:: lambda_context
 
      A Lambda context object that is passed to the invoked view by AWS
      Lambda. You can find out more about this object by reading the


### PR DESCRIPTION
*Issue #, if available:* 1818 kind of? I realized after posting the feature didn't exist so I closed/removed it to put up this PR.

*Description of changes:*
This commit/PR adds the ability to add arbitrary metadata to an HTTP route which is then passed down the call-chain to middleware(s) and the handler function. This allows more complex middleware to be created that needs
route-specific data!

This allows middleware to receive route-specific information and can be used in several ways such as:
- Defining "roles" on a per-route basis which is then used within a middleware.
- Conditionally skip middleware on specific HTTP endpoints using metadata to filter within the middleware

To do this the following was done:
-  Added some conditional code on HTTP requests in `RestAPIEventHandler` for looking up a route in order to get metadata
-  Added the ability to pass "metadata" parameter to route.
- `RestAPIEventHandler`'s call function now also looks at RouteEntry and
  also injects the metadata object into the request.
- Two unit tests were added that confirm that if no parameter is handed down, None metadata attribute exists. The second case is just to confirm if something is appended, it gets added and can be seen in middlewares & end response.

The data itself can be whatever you want since it is arbitrary and is default set to None.

An example: `@app.route("/", metadata={"some":"metadata"})`

PR Check was successful and API docs have been altered in the Chalice & Request Object sections. This should be ready to roll and with some review + feedback I'd really like to get this going since!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
