### PR TITLE
Allow pyyaml 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'pip>=9,<21.4',
     'attrs>=19.3.0,<21.3.0',
     'jmespath>=0.9.3,<1.0.0',
-    'pyyaml>=5.3.1,<6.0.0',
+    'pyyaml>=5.3.1,<7.0.0',
     'inquirer>=2.7.0,<3.0.0',
     'wheel',
     'setuptools'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

pyyaml 6.0 dropped almost 3 weeks ago. Chalice no longer supports legacy Python, so this update shouldn't break anything. 🤞 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
