### PR TITLE
Add CustomAuthorizer.__init__ args to app.pyi

### DIFF
--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -57,7 +57,14 @@ class CognitoUserPoolAuthorizer(Authorizer):
 
 class IAMAuthorizer(Authorizer): ...
 
-class CustomAuthorizer(Authorizer): ...
+class CustomAuthorizer(Authorizer):
+
+    def __init__(self, name: str=...,
+                 authorizer_uri: str=...,
+                 ttl_seconds: int=...,
+                 header: str=...,
+                 invoke_role_arn: Optional[str]=...,
+                 scopes: Optional[List[str]]=...) -> None: ...
 
 
 class CORSConfig:


### PR DESCRIPTION
*Issue #1831*

*Description of changes:*

Added `CustomAuthorizer.__init__` method arguments type hinting in `app.pyi` for fixing mypy error


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
