### PR TITLE
Fix: repeating Code in Message for ChaliceViewError and all it's subclasses

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -106,9 +106,6 @@ class WebsocketDisconnectedError(ChaliceError):
 class ChaliceViewError(ChaliceError):
     STATUS_CODE = 500
 
-    def __init__(self, msg=''):
-        super(ChaliceViewError, self).__init__(msg)
-
 
 class ChaliceUnhandledError(ChaliceError):
     """This error is not caught from a Chalice view function.

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -107,8 +107,7 @@ class ChaliceViewError(ChaliceError):
     STATUS_CODE = 500
 
     def __init__(self, msg=''):
-        super(ChaliceViewError, self).__init__(
-            self.__class__.__name__ + ': %s' % msg)
+        super(ChaliceViewError, self).__init__(msg)
 
 
 class ChaliceUnhandledError(ChaliceError):

--- a/docs/source/tutorials/basicrestapi.rst
+++ b/docs/source/tutorials/basicrestapi.rst
@@ -111,7 +111,7 @@ Notice what happens if we try to request a city that's not in our
 
     {
         "Code": "ChaliceViewError",
-        "Message": "ChaliceViewError: An internal server error occurred."
+        "Message": "An internal server error occurred."
     }
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3493,7 +3493,7 @@ class TestMiddleware:
             assert response.status_code == 404
             assert response.json_body == {
                 'Code': 'NotFoundError',
-                'Message': 'NotFoundError: resource not found'
+                'Message': 'resource not found'
             }
 
     def test_unhandled_error_not_caught(self):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -474,7 +474,7 @@ def test_errors_converted_to_json_response(handler):
     handler.do_GET()
     assert _get_body_from_response_stream(handler) == {
         'Code': 'BadRequestError',
-        'Message': 'BadRequestError: bad-request'
+        'Message': 'bad-request'
     }
 
 


### PR DESCRIPTION
*Description of changes:*

[According to docs](https://aws.github.io/chalice/topics/views.html#error-handling) the http response for a BadRequestError should look like:
```
{
    "Code": "BadRequestError",
    "Message": "This is a bad request"
}
```
> (Merging this PR will make this expectation match with actuality) 

But actually this is produced:
```
{
    "Code": "BadRequestError",
    "Message": "BadRequestError: This is a bad request"
}
```
> The Code is repeated in the Message string. This holds for all of ChaliceViewError it's subclasses

This PR fixes that. So basically when you merge this the docs are telling the truth.
Currently I am using a subclassed BadRequestError where I "fixed" this. I would like to use the chalice exceptions, instead of subclassing each time I want to use a different subclass, because I really need to have the  `Message` to not contain the `Code`.
I also think the way the docs put it, is the better way to go about this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
