### PR TITLE
Automatically associate VPC endpoint with Rest API

### DIFF
--- a/.changes/next-release/92815230962-enhancement-VPC-61341.json
+++ b/.changes/next-release/92815230962-enhancement-VPC-61341.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "VPC",
+  "description": "Associate VPC endpoint with Rest API (#1449)"
+}

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -168,6 +168,11 @@ class ApplicationGraphBuilder(object):
                 filename=os.path.join(
                     config.project_dir, '.chalice', policy_path))
 
+        vpce_ids = None
+        if config.api_gateway_endpoint_vpce:
+            vpce = config.api_gateway_endpoint_vpce
+            vpce_ids = [vpce] if isinstance(vpce, str) else vpce
+
         custom_domain_name = None
         if config.api_gateway_custom_domain:
             custom_domain_name = self._create_custom_domain_name(
@@ -188,6 +193,7 @@ class ApplicationGraphBuilder(object):
             policy=policy,
             domain_name=custom_domain_name,
             xray=config.xray_enabled,
+            vpce_ids=vpce_ids,
         )
 
     def _get_default_private_api_policy(self, config):

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -278,7 +278,8 @@ class RestAPI(ManagedModel):
     xray = attrib(default=False)                 # type: bool
     policy = attrib(default=None)                # type: Opt[IAMPolicy]
     authorizers = attrib(default=Factory(list))  # type: List[LambdaFunction]
-    domain_name = attrib(default=None)    # type: Opt[DomainName]
+    domain_name = attrib(default=None)           # type: Opt[DomainName]
+    vpce_ids = attrib(default=None)              # type: Opt[List[str]]
 
     def dependencies(self):
         # type: () -> List[Model]

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -40,12 +40,20 @@ class SwaggerGenerator(object):
         self._add_binary_types(api, app)
         self._add_route_paths(api, app)
         self._add_resource_policy(api, rest_api)
+        self._add_vpc_endpoint(api, rest_api)
         return api
 
     def _add_resource_policy(self, api, rest_api):
         # type: (Dict[str, Any], Optional[RestAPI]) -> None
         if rest_api and rest_api.policy:
             api['x-amazon-apigateway-policy'] = rest_api.policy.document
+
+    def _add_vpc_endpoint(self, api, rest_api):
+        # type: (Dict[str, Any], Optional[RestAPI]) -> None
+        if rest_api and rest_api.vpce_ids:
+            api['x-amazon-apigateway-endpoint-configuration'] = {
+                "vpcEndpointIds": rest_api.vpce_ids
+            }
 
     def _add_binary_types(self, api, app):
         # type: (Dict[str, Any], Chalice) -> None

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -865,6 +865,23 @@ def test_can_custom_resource_policy(sample_app, swagger_gen):
     }
 
 
+def test_can_vpce(sample_app, swagger_gen):
+    rest_api = RestAPI(
+        resource_name='dev',
+        swagger_doc={},
+        lambda_function=None,
+        minimum_compression="",
+        api_gateway_stage="xyz",
+        endpoint_type="PRIVATE",
+        vpce_ids=["vpce-12346", "vpce-abc123"],
+    )
+
+    doc = swagger_gen.generate_swagger(sample_app, rest_api)
+    assert doc['x-amazon-apigateway-endpoint-configuration'] == {
+        "vpcEndpointIds": ["vpce-12346", "vpce-abc123"]
+    }
+
+
 def test_can_auto_resource_policy_with_cfn(sample_app):
     swagger_gen = CFNSwaggerGenerator()
     rest_api = RestAPI(


### PR DESCRIPTION
This pulls in https://github.com/aws/chalice/pull/1744 and rebases it against the latest branch so we can verify the latest CI (couldn't push commits to the original PR).  Also added a changelog entry.

Fixes #1449 
Closes #1579 
