### PR TITLE
Update package.py

### DIFF
--- a/.changes/next-release/56921629897-bugfix-Terraform-8090.json
+++ b/.changes/next-release/56921629897-bugfix-Terraform-8090.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Terraform",
+  "description": "Use updated keywords for providing provider version contraints (#1717)"
+}

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -799,12 +799,12 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 1.1.0'
-            },
-            'provider': {
-                'template': {'version': '~> 2'},
-                'aws': {'version': '>= 2, < 4'},
-                'null': {'version': '>= 2, < 4'},
+                'required_version': '> 0.11.0, < 1.1.0',
+                'required_providers': {
+                    'aws': {'version': '>= 2, < 4'},
+                    'template': {'version': '~> 2'},
+                    'null': {'version': '>= 2, < 4'}
+                }
             },
             'data': {
                 'aws_caller_identity': {'chalice': {}},

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -799,7 +799,7 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 1.1.0',
+                'required_version': '>= 0.12.26, < 1.1.0',
                 'required_providers': {
                     'aws': {'version': '>= 2, < 4'},
                     'template': {'version': '~> 2'},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/chalice/issues/1717

*Description of changes:*
Depicting providers in this manner is deprecated and doesn't work in terraform 1.0 (default aws provider configuration cannot be inherited).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
