### PR TITLE
support terraform 1.1.x

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -799,7 +799,7 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 1.1.0'
+                'required_version': '> 0.11.0, < 1.2.0'
             },
             'provider': {
                 'template': {'version': '~> 2'},


### PR DESCRIPTION
I see no breaking change from 1.0 to 1.1.x in terraform changelogs, https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md

*Issue #, if available:*
terrafrom 1.1.x cannot init & apply

*Description of changes:*
bump supported terrafrom version in package.py

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
