### PR TITLE
Fixes #1879: Serializes Sets in Response

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -57,6 +57,9 @@ def handle_extra_types(obj):
     # to support that as well.
     if isinstance(obj, decimal.Decimal):
         return float(obj)
+    # DynamoDB responses might contain sets
+    if isinstance(obj, set):
+        return list(obj)
     # This is added for backwards compatibility.
     # It will keep only the last value for every key as it used to.
     if isinstance(obj, MultiDict):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1816,6 +1816,17 @@ def test_http_response_to_dict(body, headers, status_code):
     assert isinstance(serialized['body'], six.string_types)
 
 
+@given(headers=STR_MAP,
+       status_code=st.integers(min_value=200, max_value=599))
+def test_http_response_with_set_to_dict(headers, status_code):
+    r = Response(body={'example': set([1, 2, 3])}, headers=headers, status_code=status_code)
+    serialized = r.to_dict()
+    assert 'headers' in serialized
+    assert 'statusCode' in serialized
+    assert 'body' in serialized
+    assert isinstance(serialized['body'], six.string_types)
+
+
 @given(body=st.binary(), content_type=st.sampled_from(BINARY_TYPES))
 def test_handles_binary_responses(body, content_type):
     r = Response(body=body, headers={'Content-Type': content_type})


### PR DESCRIPTION
I'm getting an item from a DynamoDB Table that has a set attribute.
Simply returning the item at the end of the request through Chalice
raises this error:

> TypeError: Object of type set is not JSON serializable

Issue #1879

It handles set as an "extra" type during JSON Serialization.

___

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
