### PR TITLE
Support pip v22.x

### DIFF
--- a/.changes/next-release/20023496171-bugfix-pip-84022.json
+++ b/.changes/next-release/20023496171-bugfix-pip-84022.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "pip",
+  "description": "Fix RuntimeError with pip v22.x (#1887)"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt -r requirements-docs.txt
-          pip install -e .
+          pip install --upgrade --upgrade-strategy eager -e .
       - name: Run PRCheck
         run: make prcheck
   cdktests:

--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -28,8 +28,13 @@ def pip_import_string():
         return 'from pip._internal import main'
     elif (19, 3) <= pip_major_minor < (20, 0):
         return 'from pip._internal.main import main'
-    elif (20, 0) <= pip_major_minor < (22, 0):
+    elif pip_major_minor >= (20, 0):
         # More changes! https://github.com/pypa/pip/issues/7498
+        # We'll assume that anything >= v20.0 will use this import
+        # string.  We're already specifying our supported versions of
+        # pip as a dependency so assuming this stays the same, pip
+        # upgrades will just require bumping our dependency range in
+        # setup.py.
         return 'from pip._internal.cli.main import main'
     raise RuntimeError("Unknown import string for pip version: %s"
                        % str(pip_major_minor))


### PR DESCRIPTION
Two changes here:

1. Update our github action to always pull in the latest versions of our dependencies.  We previously pulled in a version bump to pip 22.x but our CI didn't fail because pip was already in our supported version range and didn't pull in the latest version we wanted to test.  Verified the tests fail with this change.

2. Update the import string to assume the latest import string will work with the latest versions of pip.


Fixes #1887.