### PR TITLE
Update template requirements-dev.txt

### DIFF
--- a/chalice/templates/0000-rest-api/requirements-dev.txt
+++ b/chalice/templates/0000-rest-api/requirements-dev.txt
@@ -1,2 +1,2 @@
 chalice=={{chalice_version}}
-py.test
+pytest

--- a/chalice/templates/0002-s3-event-handler/requirements-dev.txt
+++ b/chalice/templates/0002-s3-event-handler/requirements-dev.txt
@@ -1,2 +1,2 @@
 chalice
-py.test
+pytest

--- a/chalice/templates/0007-lambda-only/requirements-dev.txt
+++ b/chalice/templates/0007-lambda-only/requirements-dev.txt
@@ -1,2 +1,2 @@
 chalice
-py.test
+pytest


### PR DESCRIPTION
The `py.test` package on PyPI raises a ValueError in its setup.py when pip installed
> ValueError: please use 'pytest' pypi package instead of 'py.test'

*Issue #, if available:*

*Description of changes:*
Template files that list `py.test` as a dependency have been switched to use `pytest`. The `py.test` command still works (as would `pytest`) so this PR only modifies the dependency name not existing uses of `py.test` command.

`pytest` used to be part of the package `py`, but was split out to its own package in `pytest` 2.0.0. From [the release notes](https://docs.pytest.org/en/latest/announce/release-2.0.0.html):
> A note on packaging: pytest used to part of the “py” distribution up until version py-1.3.4 but this has changed now: pytest-2.0.0 only contains py.test related code and is expected to be backward-compatible to existing test code.

Hence the `py.test` command still works, but the package on PyPI is really `pytest` not `py.test`. Anticipating the confusion, the maintainer of `pytest` also keeps a package on PyPI [named `py.test`](https://pypi.org/project/py.test/) consisting of a very short `setup.py` file that raises a `ValueError` on package installation.
```
import sys
from distutils.core import setup

if __name__ == "__main__":
    if "sdist" not in sys.argv[1:]:
        raise ValueError("please use 'pytest' pypi package instead of 'py.test'")
    setup(
        name="py.test",
        version="0.0",
        description="please use 'pytest' for installation",
    )
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
