### PR TITLE
Set a default timeout in local

### DIFF
--- a/.changes/next-release/30122944134-bugfix-Local-93796.json
+++ b/.changes/next-release/30122944134-bugfix-Local-93796.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Local",
+  "description": "Set a default timeout when creating the local LambdaContext instance (#1896)"
+}

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -462,7 +462,8 @@ class LocalGateway(object):
     def _generate_lambda_context(self):
         # type: () -> LambdaContext
         if self._config.lambda_timeout is None:
-            timeout = None
+            # AWS Lambda max timeout is 15 minutes
+            timeout = 900 * 1000
         else:
             timeout = self._config.lambda_timeout * 1000
         return LambdaContext(

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -449,6 +449,9 @@ class LocalGatewayAuthorizer(object):
 
 class LocalGateway(object):
     """A class for faking the behavior of API Gateway."""
+
+    MAX_LAMBDA_EXECUTION_TIME = 900
+
     def __init__(self, app_object, config):
         # type: (Chalice, Config) -> None
         self._app_object = app_object
@@ -462,8 +465,7 @@ class LocalGateway(object):
     def _generate_lambda_context(self):
         # type: () -> LambdaContext
         if self._config.lambda_timeout is None:
-            # AWS Lambda max timeout is 15 minutes
-            timeout = 900 * 1000
+            timeout = self.MAX_LAMBDA_EXECUTION_TIME * 1000
         else:
             timeout = self._config.lambda_timeout * 1000
         return LambdaContext(


### PR DESCRIPTION
Downstream code (namely `LambdaContext.get_remaining_time_in_millis()` [see here](https://github.com/aws/chalice/blob/91bcfa20ae423c92a94f2043a28828287281b7ee/chalice/local.py#L293-L296)) does not expect a `None` value for `timeout`.

In particular `LambdaContext.get_remaining_time_in_millis()` is called by the Sentry integration [here](https://github.com/getsentry/sentry-python/blob/4c09f3203d6d19789c6fa729a2e46557ad4ea913/sentry_sdk/integrations/chalice.py#L40) and [here](https://github.com/getsentry/sentry-python/blob/4c09f3203d6d19789c6fa729a2e46557ad4ea913/sentry_sdk/integrations/chalice.py#L67) and it provokes a completely silent failure.

As the AWS Lambda max timeout is 15min I think the change is pretty safe.