### PR TITLE
Add support for CDK Version 2

### DIFF
--- a/.changes/next-release/51683855307-feature-CDK-82568.json
+++ b/.changes/next-release/51683855307-feature-CDK-82568.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CDK",
+  "description": "Add support for CDK v2 (#1742)"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
+        cdk-version: [cdk, cdkv2]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -43,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt -r requirements-docs.txt
-          pip install -e .[cdk]
+          pip install -e .[${{ matrix.cdk-version }}]
       - name: Run CDK tests
         run: python -m pytest tests/functional/cdk
 #  Chalice works on windows, but there's some differences between

--- a/chalice/cdk/construct.py
+++ b/chalice/cdk/construct.py
@@ -8,13 +8,19 @@ from aws_cdk import (
     cloudformation_include,
     aws_iam as iam,
     aws_lambda as lambda_,
-    core as cdk
 )
+
+try:
+    from aws_cdk.core import Construct
+    from aws_cdk import core as cdk
+except ImportError:
+    import aws_cdk as cdk
+    from constructs import Construct
 
 from chalice import api
 
 
-class Chalice(cdk.Construct):
+class Chalice(Construct):
     """Chalice construct for CDK.
 
     Packages the application into AWS SAM format and imports the resulting
@@ -24,7 +30,7 @@ class Chalice(cdk.Construct):
     # pylint: disable=redefined-builtin
     # The 'id' parameter name is CDK convention.
     def __init__(self,
-                 scope,                       # type: cdk.Construct
+                 scope,                       # type: Construct
                  id,                          # type: str
                  source_dir,                  # type: str
                  stage_config=None,           # type: Optional[Dict[str, Any]]

--- a/chalice/templates/6001-cdk-ddb/infrastructure/app.py
+++ b/chalice/templates/6001-cdk-ddb/infrastructure/app.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-from aws_cdk import core as cdk
+try:
+    from aws_cdk import core as cdk
+except ImportError:
+    import aws_cdk as cdk
 from stacks.chaliceapp import ChaliceApp
 
 app = cdk.App()

--- a/chalice/templates/6001-cdk-ddb/infrastructure/cdk.json
+++ b/chalice/templates/6001-cdk-ddb/infrastructure/cdk.json
@@ -1,7 +1,6 @@
 {
   "app": "python3 app.py",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true"
   }

--- a/chalice/templates/6001-cdk-ddb/infrastructure/requirements.txt
+++ b/chalice/templates/6001-cdk-ddb/infrastructure/requirements.txt
@@ -1,2 +1,1 @@
-aws_cdk.core>=1.85.0,<2.0
-aws_cdk.aws_dynamodb>=1.85.0,<2.0
+aws-cdk-lib>2.0,<3.0

--- a/chalice/templates/6001-cdk-ddb/infrastructure/stacks/chaliceapp.py
+++ b/chalice/templates/6001-cdk-ddb/infrastructure/stacks/chaliceapp.py
@@ -1,9 +1,12 @@
 import os
 
-from aws_cdk import (
-    aws_dynamodb as dynamodb,
-    core as cdk
-)
+from aws_cdk import aws_dynamodb as dynamodb
+
+try:
+    from aws_cdk import core as cdk
+except ImportError:
+    import aws_cdk as cdk
+
 from chalice.cdk import Chalice
 
 

--- a/docs/source/tutorials/cdk.rst
+++ b/docs/source/tutorials/cdk.rst
@@ -55,7 +55,8 @@ To install the necessary dependencies run the following command:
 
   $ python3 -m pip install "chalice[cdkv2]"
 
-**Note:** Although cdk version 2 is recommended, you can still use cdk version 1 the following way:
+**Note:** Although cdk version 2 is recommended, you can still use cdk
+version 1 the following way:
 
 ::
 

--- a/docs/source/tutorials/cdk.rst
+++ b/docs/source/tutorials/cdk.rst
@@ -53,6 +53,12 @@ To install the necessary dependencies run the following command:
 
 ::
 
+  $ python3 -m pip install "chalice[cdkv2]"
+
+**Note:** Although cdk version 2 is recommended, you can still use cdk version 1 the following way:
+
+::
+
   $ python3 -m pip install "chalice[cdk]"
 
 You're now ready to create your first Chalice and CDK application.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
             'aws_cdk.aws-s3-assets>=1.85.0,<2.0',
             'aws_cdk.cloudformation-include>=1.85.0,<2.0',
             'aws_cdk.core>=1.85.0,<2.0',
-        ]
+        ],
+        'cdkv2': ["aws-cdk-lib>2.0,<3.0"]
     },
     license="Apache License 2.0",
     package_data={'chalice': [

--- a/tests/functional/cdk/test_construct.py
+++ b/tests/functional/cdk/test_construct.py
@@ -10,9 +10,11 @@ from chalice.cli import newproj
 
 try:
     from aws_cdk import core as cdk
+    CDK_VERSION = 1
 except ImportError:
     try:
         import aws_cdk as cdk
+        CDK_VERSION = 2
     except ImportError:
         pytestmark = pytest.mark.skip(
             "aws_cdk package needed to run CDK tests.")
@@ -21,6 +23,26 @@ except ImportError:
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+def verify_code_asset_exists_v1(uri_props):
+    bucket_ref = uri_props['Bucket']['Ref']
+    assert bucket_ref.startswith('AssetParameters')
+
+
+def verify_code_asset_exists_v2(uri_props):
+    bucket_ref = uri_props['Bucket']['Fn::Sub']
+    # Actual sub value will look something like this:
+    # 'cdk-abcdefghi-assets-${AWS::AccountId}-${AWS::Region}'},
+    assert bucket_ref.startswith('cdk-')
+
+
+@pytest.fixture
+def verify_code_asset_exists():
+    if CDK_VERSION == 1:
+        return verify_code_asset_exists_v1
+    elif CDK_VERSION == 2:
+        return verify_code_asset_exists_v2
 
 
 def load_chalice_construct(dirname, stack_name='testcdk'):
@@ -59,7 +81,7 @@ def test_cdk_construct_api(runner):
         assert hasattr(role, 'role_name')
 
 
-def test_can_package_as_cdk_app(runner):
+def test_can_package_as_cdk_app(runner, verify_code_asset_exists):
     # The CDK loading/synth can take a while so we're testing the
     # various APIs out in one test to cut down on test time.
     with runner.isolated_filesystem():
@@ -86,11 +108,10 @@ def test_can_package_as_cdk_app(runner):
         # CDK specific assets.
         functions = filter_resources(
             cfn_template, 'AWS::Serverless::Function')[0]
-        bucket_ref = functions[1]['Properties']['CodeUri']['Bucket']['Ref']
-        assert bucket_ref.startswith('AssetParameters')
+        verify_code_asset_exists(functions[1]['Properties']['CodeUri'])
 
 
-def test_can_package_managed_layer(runner):
+def test_can_package_managed_layer(runner, verify_code_asset_exists):
     with runner.isolated_filesystem():
         newproj.create_new_project_skeleton(
             'testcdklayers', project_type='cdk-ddb')
@@ -111,5 +132,4 @@ def test_can_package_managed_layer(runner):
         cfn_template = stack.template
         layers = filter_resources(
             cfn_template, 'AWS::Serverless::LayerVersion')[0]
-        bucket_ref = layers[1]['Properties']['ContentUri']['Bucket']['Ref']
-        assert bucket_ref.startswith('AssetParameters')
+        verify_code_asset_exists(layers[1]['Properties']['ContentUri'])

--- a/tests/functional/cdk/test_construct.py
+++ b/tests/functional/cdk/test_construct.py
@@ -10,9 +10,12 @@ from chalice.cli import newproj
 
 try:
     from aws_cdk import core as cdk
-except Exception:
-    pytestmark = pytest.mark.skip(
-        "aws_cdk package needed to run CDK tests.")
+except ImportError:
+    try:
+        import aws_cdk as cdk
+    except ImportError:
+        pytestmark = pytest.mark.skip(
+            "aws_cdk package needed to run CDK tests.")
 
 
 @pytest.fixture


### PR DESCRIPTION
*Issue #, if available:*

Addresses #1742 

*Description of changes:*

* updates the `cdk-ddb` template to support cdk version 2
* tested against both cdk version 2 and version 1
* to use cdk version 2: `pip install 'chalice[cdkv2]'`
* documentation has been updated to reflect this change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
