### PR TITLE
Update git clone to use https

### DIFF
--- a/scripts/gh-page-docs
+++ b/scripts/gh-page-docs
@@ -40,7 +40,7 @@ make clean && make html
 echo
 echo "Copy docs to local checkout"
 rm -rf "${CHECKOUT_DIR}"
-git clone git://github.com/aws/chalice --branch gh-pages \
+git clone https://github.com/aws/chalice.git --branch gh-pages \
 	--single-branch ${CHECKOUT_DIR}
 cp -r build/html/* ${CHECKOUT_DIR}/
 # Add a .nojekyll file so make sure we don't ignore _static


### PR DESCRIPTION
The `git://` protocol is no longer supported by GitHub.