### PR TITLE
Add support for WebSockets API Terraform packaging

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -18,7 +18,7 @@ from chalice.deploy.swagger import (
 from chalice.utils import (
     OSUtils, UI, serialize_to_json, to_cfn_resource_name
 )
-from chalice.awsclient import TypedAWSClient # noqa
+from chalice.awsclient import TypedAWSClient  # noqa
 from chalice.config import Config  # noqa
 from chalice.deploy import models
 from chalice.deploy.appgraph import ApplicationGraphBuilder, DependencyBuilder
@@ -101,8 +101,8 @@ class PackageOptions(object):
 class ResourceBuilder(object):
     def __init__(self,
                  application_builder,  # type: ApplicationGraphBuilder
-                 deps_builder,         # type: DependencyBuilder
-                 build_stage,          # type: BuildStage
+                 deps_builder,  # type: DependencyBuilder
+                 build_stage,  # type: BuildStage
                  ):
         # type: (...) -> None
         self._application_builder = application_builder
@@ -122,7 +122,6 @@ class ResourceBuilder(object):
 
 
 class TemplateGenerator(object):
-
     template_file = None  # type: str
 
     def __init__(self, config, options):
@@ -861,7 +860,8 @@ class TerraformGenerator(TemplateGenerator):
     def _add_websocket_lambda_integration(
             self, websocket_api_id, websocket_handler, template):
         # type: (str, str, Dict[str, Any]) -> None
-        websocket_handler_function_name = "${aws_lambda_function.%s.function_name}" % websocket_handler
+        websocket_handler_function_name = \
+            "${aws_lambda_function.%s.function_name}" % websocket_handler
         resource_definition = {
             'api_id': websocket_api_id,
             'connection_type': 'INTERNET',
@@ -883,7 +883,8 @@ class TerraformGenerator(TemplateGenerator):
     def _add_websocket_lambda_invoke_permission(
             self, websocket_api_id, websocket_handler, template):
         # type: (str, str, Dict[str, Any]) -> None
-        websocket_handler_function_name = "${aws_lambda_function.%s.function_name}" % websocket_handler
+        websocket_handler_function_name = \
+            "${aws_lambda_function.%s.function_name}" % websocket_handler
         resource_definition = {
             "function_name": websocket_handler_function_name,
             "action": "lambda:InvokeFunction",
@@ -902,9 +903,13 @@ class TerraformGenerator(TemplateGenerator):
     def _add_websockets_route(self, websocket_api_id, route_key, template):
         # type: (str, str, Dict[str, Any]) -> str
         integration_target = {
-            '$connect': 'integrations/${aws_apigatewayv2_integration.websocket_connect_api_integration.id}',
-            '$disconnect': 'integrations/${aws_apigatewayv2_integration.websocket_disconnect_api_integration.id}',
-        }.get(route_key, 'integrations/${aws_apigatewayv2_integration.websocket_message_api_integration.id}')
+            '$connect': 'integrations/${aws_apigatewayv2_integration'
+                        '.websocket_connect_api_integration.id}',
+            '$disconnect': 'integrations/${aws_apigatewayv2_integration'
+                           '.websocket_disconnect_api_integration.id}',
+        }.get(route_key,
+              'integrations/${aws_apigatewayv2_integration'
+              '.websocket_message_api_integration.id}')
 
         route_resource_name = {
             '$connect': 'websocket_connect_route',
@@ -946,33 +951,49 @@ class TerraformGenerator(TemplateGenerator):
             'aws_apigatewayv2_api_mapping', {}
         )[domain_name.resource_name + '_mapping'] = {
             "api_id": websocket_api_id,
-            "domain_name": "${aws_apigatewayv2_domain_name.%s.id}" % domain_name.resource_name,
+            "domain_name": "${aws_apigatewayv2_domain_name.%s.id}" %
+                           domain_name.resource_name,
             "stage": "${aws_apigatewayv2_stage.websocket_api_stage.id}",
         }
 
     def _inject_websocketapi_outputs(self, websocket_api_id, template):
         # type: (str, Dict[str, Any]) -> None
         aws_lambda_functions = template['resource']['aws_lambda_function']
-        stage_name = template['resource']['aws_apigatewayv2_stage']['websocket_api_stage']['name']
+        stage_name = \
+            template['resource']['aws_apigatewayv2_stage'][
+                'websocket_api_stage'][
+                'name']
         output = template.setdefault('output', {})
         output['WebsocketAPIId'] = {"value": websocket_api_id}
 
         if 'websocket_connect' in aws_lambda_functions:
-            output['WebsocketConnectHandlerArn'] = {"value": "${aws_lambda_function.websocket_connect.arn}"}
-            output['WebsocketConnectHandlerName'] = {"value": "${aws_lambda_function.websocket_connect}"}
+            output['WebsocketConnectHandlerArn'] = {
+                "value": "${aws_lambda_function.websocket_connect.arn}"}
+            output['WebsocketConnectHandlerName'] = {
+                "value": "${aws_lambda_function.websocket_connect}"}
         if 'websocket_message' in aws_lambda_functions:
-            output['WebsocketMessageHandlerArn'] = {"value": "${aws_lambda_function.websocket_message.arn}"}
-            output['WebsocketMessageHandlerName'] = {"value": "${aws_lambda_function.websocket_message}"}
+            output['WebsocketMessageHandlerArn'] = {
+                "value": "${aws_lambda_function.websocket_message.arn}"}
+            output['WebsocketMessageHandlerName'] = {
+                "value": "${aws_lambda_function.websocket_message}"}
         if 'websocket_disconnect' in aws_lambda_functions:
-            output['WebsocketDisconnectHandlerArn'] = {"value": "${aws_lambda_function.websocket_disconnect.arn}"}
-            output['WebsocketDisconnectHandlerName'] = {"value": "${aws_lambda_function.websocket_disconnect}"}
+            output['WebsocketDisconnectHandlerArn'] = {
+                "value": "${aws_lambda_function.websocket_disconnect.arn}"}
+            output['WebsocketDisconnectHandlerName'] = {
+                "value": "${aws_lambda_function.websocket_disconnect}"}
 
-        output['WebsocketConnectEndpointURL'] = {"value": (
-                    'wss://%(websocket_api_id)s.execute-api'
-                    # The api_gateway_stage is filled in when
-                    # the template is built.
-                    '.${data.aws_region.chalice.name}.amazonaws.com/%(stage_name)s/'
-                ) % {"stage_name": stage_name, "websocket_api_id": websocket_api_id}}
+        output['WebsocketConnectEndpointURL'] = {
+            "value": (
+                'wss://%(websocket_api_id)s.execute-api'
+                # The api_gateway_stage is filled in when
+                # the template is built.
+                '.${data.aws_region.chalice.name}'
+                '.amazonaws.com/%(stage_name)s/'
+            ) % {
+                "stage_name": stage_name,
+                "websocket_api_id": websocket_api_id
+            }
+        }
 
     def _generate_websocketapi(self, resource, template):
         # type: (models.WebsocketAPI, Dict[str, Any]) -> None
@@ -986,7 +1007,8 @@ class TerraformGenerator(TemplateGenerator):
         template['resource'].setdefault('aws_apigatewayv2_api', {})[
             resource.resource_name] = ws_definition
 
-        websocket_api_id = "${aws_apigatewayv2_api.%s.id}" % resource.resource_name
+        websocket_api_id = "${aws_apigatewayv2_api.%s.id}" % \
+                           resource.resource_name
 
         websocket_handlers = [
             'websocket_connect',
@@ -996,26 +1018,32 @@ class TerraformGenerator(TemplateGenerator):
 
         for handler in websocket_handlers:
             if handler in template['resource']['aws_lambda_function']:
-                self._add_websocket_lambda_integration(websocket_api_id, handler, template)
-                self._add_websocket_lambda_invoke_permission(websocket_api_id, handler, template)
+                self._add_websocket_lambda_integration(websocket_api_id,
+                                                       handler, template)
+                self._add_websocket_lambda_invoke_permission(websocket_api_id,
+                                                             handler, template)
 
         route_resource_names = []
         for route_key in resource.routes:
-            route_resource_name = self._add_websockets_route(websocket_api_id, route_key, template)
+            route_resource_name = self._add_websockets_route(websocket_api_id,
+                                                             route_key,
+                                                             template)
             route_resource_names.append(route_resource_name)
 
         template['resource'].setdefault(
             'aws_apigatewayv2_deployment', {}
         )['websocket_api_deployment'] = {
             "api_id": websocket_api_id,
-            "depends_on": ["aws_apigatewayv2_route.%s" % name for name in route_resource_names]
+            "depends_on": ["aws_apigatewayv2_route.%s" % name for name in
+                           route_resource_names]
         }
 
         template['resource'].setdefault(
             'aws_apigatewayv2_stage', {}
         )['websocket_api_stage'] = {
             "api_id": websocket_api_id,
-            "deployment_id": "${aws_apigatewayv2_deployment.websocket_api_deployment.id}",
+            "deployment_id": ("${aws_apigatewayv2_deployment"
+                              ".websocket_api_deployment.id}"),
             "name": resource.api_gateway_stage
         }
 
@@ -1177,10 +1205,10 @@ class TerraformGenerator(TemplateGenerator):
         # type: (models.LambdaLayer, Dict[str, Any]) -> None
         template['resource'].setdefault(
             "aws_lambda_layer_version", {})[
-                resource.resource_name] = {
-                'layer_name': resource.layer_name,
-                'compatible_runtimes': [resource.runtime],
-                'filename': resource.deployment_package.filename,
+            resource.resource_name] = {
+            'layer_name': resource.layer_name,
+            'compatible_runtimes': [resource.runtime],
+            'filename': resource.deployment_package.filename,
         }
         self._chalice_layer = resource.resource_name
 
@@ -1309,7 +1337,8 @@ class TerraformGenerator(TemplateGenerator):
                 'principal': self._options.service_principal('apigateway'),
                 'source_arn': (
                     "${aws_api_gateway_rest_api.%s.execution_arn}" % (
-                        resource.resource_name) + "/*"
+                        resource.resource_name
+                    ) + "/*"
                 )
             }
         self._add_domain_name(resource, template)

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -954,8 +954,8 @@ class TerraformGenerator(TemplateGenerator):
         # type: (str, Dict[str, Any]) -> None
         aws_lambda_functions = template['resource']['aws_lambda_function']
         stage_name = template['resource']['aws_apigatewayv2_stage']['websocket_api_stage']['name']
-        output = template['output']
-        output['websocket_api_id'] = {"value": websocket_api_id}
+        output = template.setdefault('output', {})
+        output['WebsocketAPIId'] = {"value": websocket_api_id}
 
         if 'websocket_connect' in aws_lambda_functions:
             output['WebsocketConnectHandlerArn'] = {"value": "${aws_lambda_function.websocket_connect.arn}"}

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -952,15 +952,6 @@ class TerraformGenerator(TemplateGenerator):
 
     def _inject_websocketapi_outputs(self, websocket_api_id, template):
         # type: (str, Dict[str, Any]) -> None
-        # The 'Outputs' of the SAM template are considered
-        # part of the public API of chalice and therefore
-        # need to maintain backwards compatibility.  This
-        # method uses the same output key names as the old
-        # deployer.
-        # For now, we aren't adding any of the new resources
-        # to the Outputs section until we can figure out
-        # a consist naming scheme.  Ideally we don't use
-        # the autogen'd names that contain the md5 suffixes.
         aws_lambda_functions = template['resource']['aws_lambda_function']
         stage_name = template['resource']['aws_apigatewayv2_stage']['websocket_api_stage']['name']
         output = template['output']

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -861,7 +861,7 @@ class TerraformGenerator(TemplateGenerator):
     def _add_websocket_lambda_integration(
             self, websocket_api_id, websocket_handler, template):
         # type: (str, str, Dict[str, Any]) -> None
-
+        websocket_handler_function_name = "${aws_lambda_function.%s.function_name}" % websocket_handler
         resource_definition = {
             'api_id': websocket_api_id,
             'connection_type': 'INTERNET',
@@ -872,8 +872,8 @@ class TerraformGenerator(TemplateGenerator):
                 ":lambda:path/2015-03-31/functions/arn"
                 ":%(partition)s:lambda:%(region)s"
                 ":%(account_id)s:function"
-                ":${aws_lambda_function.%(websocket_handler)s.function_name}/invocations",
-                websocket_handler=websocket_handler
+                ":%(websocket_handler_function_name)s/invocations",
+                websocket_handler_function_name=websocket_handler_function_name
             )
         }
         template['resource'].setdefault(
@@ -883,9 +883,9 @@ class TerraformGenerator(TemplateGenerator):
     def _add_websocket_lambda_invoke_permission(
             self, websocket_api_id, websocket_handler, template):
         # type: (str, str, Dict[str, Any]) -> None
-
+        websocket_handler_function_name = "${aws_lambda_function.%s.function_name}" % websocket_handler
         resource_definition = {
-            "function_name": "${aws_lambda_function.%s.arn}" % websocket_handler,
+            "function_name": websocket_handler_function_name,
             "action": "lambda:InvokeFunction",
             "principal": self._options.service_principal('apigateway'),
             "source_arn": self._arnref(

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -831,7 +831,9 @@ class TestTerraformTemplate(TemplateTestBase):
                 'value': '${aws_lambda_function.websocket_disconnect}'
             },
             'WebsocketConnectEndpointURL': {
-                'value': 'wss://${aws_apigatewayv2_api.websocket_api.id}.execute-api.${data.aws_region.chalice.name}.amazonaws.com/api/'
+                'value': 'wss://${aws_apigatewayv2_api.websocket_api.id}'
+                         '.execute-api.${data.aws_region.chalice.name}'
+                         '.amazonaws.com/api/'
             }
         }
 
@@ -849,42 +851,82 @@ class TestTerraformTemplate(TemplateTestBase):
                 'connection_type': 'INTERNET',
                 'content_handling_strategy': 'CONVERT_TO_TEXT',
                 'integration_type': 'AWS_PROXY',
-                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_connect.function_name}/invocations'
+                'integration_uri': 'arn:${data.aws_partition.chalice'
+                                   '.partition}:apigateway:'
+                                   '${data.aws_region.chalice.name}'
+                                   ':lambda:path/2015-03-31/functions/arn'
+                                   ':${data.aws_partition.chalice.partition}'
+                                   ':lambda:${data.aws_region.chalice.name}'
+                                   ':${data.aws_caller_identity'
+                                   '.chalice.account_id}:function'
+                                   ':${aws_lambda_function.websocket_connect'
+                                   '.function_name}/invocations'
             },
             'websocket_message_api_integration': {
                 'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
                 'connection_type': 'INTERNET',
                 'content_handling_strategy': 'CONVERT_TO_TEXT',
                 'integration_type': 'AWS_PROXY',
-                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_message.function_name}/invocations'
+                'integration_uri': 'arn:${data.aws_partition.chalice'
+                                   '.partition}:apigateway'
+                                   ':${data.aws_region.chalice.name}'
+                                   ':lambda:path/2015-03-31/functions/arn'
+                                   ':${data.aws_partition.chalice.partition}'
+                                   ':lambda:${data.aws_region.chalice.name}'
+                                   ':${data.aws_caller_identity.chalice'
+                                   '.account_id}:function'
+                                   ':${aws_lambda_function.websocket_message'
+                                   '.function_name}/invocations'
             },
             'websocket_disconnect_api_integration': {
                 'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
                 'connection_type': 'INTERNET',
                 'content_handling_strategy': 'CONVERT_TO_TEXT',
                 'integration_type': 'AWS_PROXY',
-                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_disconnect.function_name}/invocations'
+                'integration_uri': 'arn:${data.aws_partition'
+                                   '.chalice.partition}:apigateway'
+                                   ':${data.aws_region.chalice.name}'
+                                   ':lambda:path/2015-03-31/functions/arn'
+                                   ':${data.aws_partition.chalice.partition}'
+                                   ':lambda:${data.aws_region.chalice.name}'
+                                   ':${data.aws_caller_identity'
+                                   '.chalice.account_id}:function'
+                                   ':${aws_lambda_function'
+                                   '.websocket_disconnect.function_name}'
+                                   '/invocations'
             }
         }
 
         assert template['resource']['aws_lambda_permission'] == {
             'websocket_connect_invoke_permission': {
-                'function_name': '${aws_lambda_function.websocket_connect.function_name}',
+                'function_name': '${aws_lambda_function.websocket_connect'
+                                 '.function_name}',
                 'action': 'lambda:InvokeFunction',
                 'principal': 'apigateway.amazonaws.com',
-                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}'
+                              ':execute-api:${data.aws_region.chalice.name}'
+                              ':${data.aws_caller_identity.chalice.account_id}'
+                              ':${aws_apigatewayv2_api.websocket_api.id}/*'
             },
             'websocket_message_invoke_permission': {
-                'function_name': '${aws_lambda_function.websocket_message.function_name}',
+                'function_name': '${aws_lambda_function.websocket_message'
+                                 '.function_name}',
                 'action': 'lambda:InvokeFunction',
                 'principal': 'apigateway.amazonaws.com',
-                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}'
+                              ':execute-api:${data.aws_region.chalice.name}'
+                              ':${data.aws_caller_identity.chalice.account_id}'
+                              ':${aws_apigatewayv2_api.websocket_api.id}/*'
             },
             'websocket_disconnect_invoke_permission': {
-                'function_name': '${aws_lambda_function.websocket_disconnect.function_name}',
+                'function_name': '${aws_lambda_function.websocket_disconnect'
+                                 '.function_name}',
                 'action': 'lambda:InvokeFunction',
                 'principal': 'apigateway.amazonaws.com',
-                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}'
+                              ':execute-api:${data.aws_region.chalice.name}'
+                              ':${data.aws_caller_identity.chalice.account_id}'
+                              ':${aws_apigatewayv2_api.websocket_api.id}/*'
             }
         }
 
@@ -892,31 +934,40 @@ class TestTerraformTemplate(TemplateTestBase):
             'websocket_connect_route': {
                 'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
                 'route_key': '$connect',
-                'target': 'integrations/${aws_apigatewayv2_integration.websocket_connect_api_integration.id}'
+                'target': 'integrations/${aws_apigatewayv2_integration'
+                          '.websocket_connect_api_integration.id}'
             },
             'websocket_message_route': {
                 'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
                 'route_key': '$default',
-                'target': 'integrations/${aws_apigatewayv2_integration.websocket_message_api_integration.id}'
+                'target': 'integrations/${aws_apigatewayv2_integration'
+                          '.websocket_message_api_integration.id}'
             },
             'websocket_disconnect_route': {
                 'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
                 'route_key': '$disconnect',
-                'target': 'integrations/${aws_apigatewayv2_integration.websocket_disconnect_api_integration.id}'
+                'target': 'integrations/${aws_apigatewayv2_integration'
+                          '.websocket_disconnect_api_integration.id}'
             }
         }
 
         assert template['resource']['aws_apigatewayv2_deployment'] == {
-            'websocket_api_deployment': {'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
-                                         'depends_on': ['aws_apigatewayv2_route.websocket_connect_route',
-                                                        'aws_apigatewayv2_route.websocket_message_route',
-                                                        'aws_apigatewayv2_route.websocket_disconnect_route']}}
+            'websocket_api_deployment': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'depends_on': [
+                    'aws_apigatewayv2_route.websocket_connect_route',
+                    'aws_apigatewayv2_route.websocket_message_route',
+                    'aws_apigatewayv2_route.websocket_disconnect_route'
+                ]}}
 
         assert template['resource']['aws_apigatewayv2_stage'] == {
-            'websocket_api_stage': {'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
-                                    'deployment_id': '${aws_apigatewayv2_deployment.websocket_api_deployment.id}',
-                                    'name': 'api'}}
-
+            'websocket_api_stage': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'deployment_id': '${aws_apigatewayv2_deployment'
+                                 '.websocket_api_deployment.id}',
+                'name': 'api'
+            }
+        }
 
     def test_can_generate_custom_domain_name(self, sample_app):
         config = Config.create(

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -801,18 +801,122 @@ class TestTerraformTemplate(TemplateTestBase):
                        'maximum_batching_window_in_seconds': 0
                    }
 
-    def test_package_websocket_with_error_message(self, sample_websocket_app):
+    def test_can_generate_websockets_api(self, sample_websocket_app):
         config = Config.create(chalice_app=sample_websocket_app,
                                project_dir='.',
                                app_name='sample_app',
                                api_gateway_stage='api')
-        with pytest.raises(NotImplementedError) as excinfo:
-            self.generate_template(config)
+        template = self.generate_template(config)
 
-        # Should mention the decorator name.
-        assert 'Websocket decorators' in str(excinfo.value)
-        # Should mention you can use `chalice deploy`.
-        assert 'chalice deploy' in str(excinfo.value)
+        assert template['output'] == {
+            'WebsocketAPIId': {
+                'value': '${aws_apigatewayv2_api.websocket_api.id}'
+            },
+            'WebsocketConnectHandlerArn': {
+                'value': '${aws_lambda_function.websocket_connect.arn}'
+            },
+            'WebsocketConnectHandlerName': {
+                'value': '${aws_lambda_function.websocket_connect}'
+            },
+            'WebsocketMessageHandlerArn': {
+                'value': '${aws_lambda_function.websocket_message.arn}'
+            },
+            'WebsocketMessageHandlerName': {
+                'value': '${aws_lambda_function.websocket_message}'
+            },
+            'WebsocketDisconnectHandlerArn': {
+                'value': '${aws_lambda_function.websocket_disconnect.arn}'
+            },
+            'WebsocketDisconnectHandlerName': {
+                'value': '${aws_lambda_function.websocket_disconnect}'
+            },
+            'WebsocketConnectEndpointURL': {
+                'value': 'wss://${aws_apigatewayv2_api.websocket_api.id}.execute-api.${data.aws_region.chalice.name}.amazonaws.com/api/'
+            }
+        }
+
+        assert template['resource']['aws_apigatewayv2_api'] == {
+            'websocket_api': {
+                'name': 'sample_app-dev-websocket-api',
+                'route_selection_expression': '$request.body.action',
+                'protocol_type': 'WEBSOCKET'
+            }
+        }
+
+        assert template['resource']['aws_apigatewayv2_integration'] == {
+            'websocket_connect_api_integration': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'connection_type': 'INTERNET',
+                'content_handling_strategy': 'CONVERT_TO_TEXT',
+                'integration_type': 'AWS_PROXY',
+                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_connect.function_name}/invocations'
+            },
+            'websocket_message_api_integration': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'connection_type': 'INTERNET',
+                'content_handling_strategy': 'CONVERT_TO_TEXT',
+                'integration_type': 'AWS_PROXY',
+                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_message.function_name}/invocations'
+            },
+            'websocket_disconnect_api_integration': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'connection_type': 'INTERNET',
+                'content_handling_strategy': 'CONVERT_TO_TEXT',
+                'integration_type': 'AWS_PROXY',
+                'integration_uri': 'arn:${data.aws_partition.chalice.partition}:apigateway:${data.aws_region.chalice.name}:lambda:path/2015-03-31/functions/arn:${data.aws_partition.chalice.partition}:lambda:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:function:${aws_lambda_function.websocket_disconnect.function_name}/invocations'
+            }
+        }
+
+        assert template['resource']['aws_lambda_permission'] == {
+            'websocket_connect_invoke_permission': {
+                'function_name': '${aws_lambda_function.websocket_connect.function_name}',
+                'action': 'lambda:InvokeFunction',
+                'principal': 'apigateway.amazonaws.com',
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+            },
+            'websocket_message_invoke_permission': {
+                'function_name': '${aws_lambda_function.websocket_message.function_name}',
+                'action': 'lambda:InvokeFunction',
+                'principal': 'apigateway.amazonaws.com',
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+            },
+            'websocket_disconnect_invoke_permission': {
+                'function_name': '${aws_lambda_function.websocket_disconnect.function_name}',
+                'action': 'lambda:InvokeFunction',
+                'principal': 'apigateway.amazonaws.com',
+                'source_arn': 'arn:${data.aws_partition.chalice.partition}:execute-api:${data.aws_region.chalice.name}:${data.aws_caller_identity.chalice.account_id}:${aws_apigatewayv2_api.websocket_api.id}/*'
+            }
+        }
+
+        assert template['resource']['aws_apigatewayv2_route'] == {
+            'websocket_connect_route': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'route_key': '$connect',
+                'target': 'integrations/${aws_apigatewayv2_integration.websocket_connect_api_integration.id}'
+            },
+            'websocket_message_route': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'route_key': '$default',
+                'target': 'integrations/${aws_apigatewayv2_integration.websocket_message_api_integration.id}'
+            },
+            'websocket_disconnect_route': {
+                'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                'route_key': '$disconnect',
+                'target': 'integrations/${aws_apigatewayv2_integration.websocket_disconnect_api_integration.id}'
+            }
+        }
+
+        assert template['resource']['aws_apigatewayv2_deployment'] == {
+            'websocket_api_deployment': {'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                                         'depends_on': ['aws_apigatewayv2_route.websocket_connect_route',
+                                                        'aws_apigatewayv2_route.websocket_message_route',
+                                                        'aws_apigatewayv2_route.websocket_disconnect_route']}}
+
+        assert template['resource']['aws_apigatewayv2_stage'] == {
+            'websocket_api_stage': {'api_id': '${aws_apigatewayv2_api.websocket_api.id}',
+                                    'deployment_id': '${aws_apigatewayv2_deployment.websocket_api_deployment.id}',
+                                    'name': 'api'}}
+
 
     def test_can_generate_custom_domain_name(self, sample_app):
         config = Config.create(
@@ -829,19 +933,19 @@ class TestTerraformTemplate(TemplateTestBase):
         )
         template = self.generate_template(config)
         assert template['resource']['aws_api_gateway_domain_name'][
-            'api_gateway_custom_domain'] == {
-                'domain_name': 'example.com',
-                'certificate_arn': 'my_cert_arn',
-                'security_policy': 'TLS_1_2',
-                'endpoint_configuration': {'types': ['EDGE']},
-                'tags': {'foo': 'bar'},
-        }
+                   'api_gateway_custom_domain'] == {
+                   'domain_name': 'example.com',
+                   'certificate_arn': 'my_cert_arn',
+                   'security_policy': 'TLS_1_2',
+                   'endpoint_configuration': {'types': ['EDGE']},
+                   'tags': {'foo': 'bar'},
+               }
         assert template['resource']['aws_api_gateway_base_path_mapping'][
-            'api_gateway_custom_domain_mapping'] == {
-                'api_id': '${aws_api_gateway_rest_api.rest_api.id}',
-                'stage_name': 'api',
-                'domain_name': 'example.com',
-        }
+                   'api_gateway_custom_domain_mapping'] == {
+                   'api_id': '${aws_api_gateway_rest_api.rest_api.id}',
+                   'stage_name': 'api',
+                   'domain_name': 'example.com',
+               }
         outputs = template['output']
         assert outputs['AliasDomainName']['value'] == (
             '${aws_api_gateway_domain_name.api_gateway_custom_domain'
@@ -865,17 +969,17 @@ class TestTerraformTemplate(TemplateTestBase):
         )
         template = self.generate_template(config)
         assert template['resource']['aws_api_gateway_domain_name'][
-            'api_gateway_custom_domain'] == {
-                'domain_name': 'example.com',
-                'regional_certificate_arn': 'my_cert_arn',
-                'endpoint_configuration': {'types': ['REGIONAL']},
-        }
+                   'api_gateway_custom_domain'] == {
+                   'domain_name': 'example.com',
+                   'regional_certificate_arn': 'my_cert_arn',
+                   'endpoint_configuration': {'types': ['REGIONAL']},
+               }
         assert template['resource']['aws_api_gateway_base_path_mapping'][
-            'api_gateway_custom_domain_mapping'] == {
-                'api_id': '${aws_api_gateway_rest_api.rest_api.id}',
-                'stage_name': 'api',
-                'domain_name': 'example.com',
-        }
+                   'api_gateway_custom_domain_mapping'] == {
+                   'api_id': '${aws_api_gateway_rest_api.rest_api.id}',
+                   'stage_name': 'api',
+                   'domain_name': 'example.com',
+               }
         outputs = template['output']
         assert outputs['AliasDomainName']['value'] == (
             '${aws_api_gateway_domain_name.api_gateway_custom_domain'


### PR DESCRIPTION
*Issue https://github.com/aws/chalice/issues/1670

*Description of changes:*

Adds terraform packaging support for WebSockets API with its unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
