### PR TITLE
Access to sns message attributes in SNSEvent and generated test events

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1875,6 +1875,7 @@ class SNSEvent(BaseLambdaEvent):
         first_record = event_dict['Records'][0]
         self.message = first_record['Sns']['Message']
         self.subject = first_record['Sns']['Subject']
+        self.message_attributes = first_record['Sns']['MessageAttributes']
 
 
 class S3Event(BaseLambdaEvent):

--- a/chalice/test.py
+++ b/chalice/test.py
@@ -196,20 +196,22 @@ class TestEventsClient(BaseClient):
         # type: (Chalice) -> None
         self._app = app
 
-    def generate_sns_event(self, message, subject=''):
-        # type: (str, str) -> Dict[str, Any]
+    def generate_sns_event(self, message, subject='', message_attributes=None):
+        # type: (str, str, Dict[str, Any]) -> Dict[str, Any]
+        if message_attributes is None:
+            message_attributes = {
+                'AttributeKey': {
+                    'Type': 'String',
+                    'Value': 'AttributeValue'
+                }
+            }
         sns_event = {'Records': [{
             'EventSource': 'aws:sns',
             'EventSubscriptionArn': 'arn:subscription-arn',
             'EventVersion': '1.0',
             'Sns': {
                 'Message': message,
-                'MessageAttributes': {
-                    'AttributeKey': {
-                        'Type': 'String',
-                        'Value': 'AttributeValue'
-                    }
-                },
+                'MessageAttributes': message_attributes,
                 'MessageId': 'abcdefgh-51e4-5ae2-9964-b296c8d65d1a',
                 'Signature': 'signature',
                 'SignatureVersion': '1',

--- a/tests/unit/test_test.py
+++ b/tests/unit/test_test.py
@@ -228,14 +228,27 @@ def test_can_invoke_event_handler():
     @app.on_sns_message(topic='mytopic')
     def foo(event):
         return {'message': event.message,
-                'subject': event.subject}
+                'subject': event.subject,
+                'message_attributes': event.message_attributes}
 
     with Client(app) as client:
         event = client.events.generate_sns_event(message='my message',
-                                                 subject='hello')
+                                                 subject='hello',
+                                                 message_attributes={
+                                                     "my_attr": {
+                                                         'Type': 'String',
+                                                         'Value': 'some_attr'
+                                                     }
+                                                 })
         response = client.lambda_.invoke('foo', event)
         assert response.payload == {'message': 'my message',
-                                    'subject': 'hello'}
+                                    'subject': 'hello',
+                                    'message_attributes': {
+                                        "my_attr": {
+                                            'Type': 'String',
+                                            'Value': 'some_attr'
+                                        }
+                                    }}
 
 
 def test_can_generate_s3_event():


### PR DESCRIPTION
*Description of changes:*
This adds SNS message attributes as extracted attributes to the `SNSEvent`. Additionally, this change adds message attributes as an optional key word argument to the `generate_sns_event` method.

Use case: We use and examine message attributes to handle certain messages differently. Testing this behavior with the chalice test client will become more convenient with this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
