### PR TITLE
Change AWS Terraform provider constraint to allow versions 4.x

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -801,7 +801,7 @@ class TerraformGenerator(TemplateGenerator):
             'terraform': {
                 'required_version': '>= 0.12.26, < 1.2.0',
                 'required_providers': {
-                    'aws': {'version': '>= 2, < 4'},
+                    'aws': {'version': '>= 2, < 5'},
                     'null': {'version': '>= 2, < 4'}
                 }
             },


### PR DESCRIPTION
*Issue #, if available:*
#1951

*Description of changes:*
Change the AWS Terraform provider constraint to allow versions 4.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
