### PR TITLE
Add python3.9 to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,8 @@ Quickstart
 In this tutorial, you'll use the ``chalice`` command line utility
 to create and deploy a basic REST API.  This quickstart uses Python 3.7,
 but AWS Chalice supports all versions of python supported by AWS Lambda,
-which includes python2.7, python3.6, python3.7, python3.8.  We recommend
-you use a version of Python 3.
+which includes python2.7, python3.6, python3.7, python3.8, python3.9.
+We recommend you use a version of Python 3.
 You can find the latest versions of python on the
 `Python download page <https://www.python.org/downloads/>`_.
 


### PR DESCRIPTION
AWS Lambda and this project support python3.9.
But the README didn't mention that.