### PR TITLE
Remove 3.6 testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
As of July 18, 2022 you can no longer creating new Lambda functions
with Python 3.6
As of August 17, 2022 you can no longer update new Lambda functions
with Python 3.6.