### PR TITLE
Enable stale issue github action

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -44,4 +44,4 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
-        dry-run: true
+        dry-run: false


### PR DESCRIPTION
After several dry run outputs, it's performing the expected
actions so we can enable this workflow.

[Dry run output](https://github.com/aws/chalice/runs/7997994808?check_suite_focus=true#step:3:20)