### PR TITLE
Fix local authorizer not respecting `header` argument passed to it

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -223,6 +223,7 @@ class CaseInsensitiveMapping(Mapping):
 class Authorizer(object):
     name: str = ''
     scopes: List[str] = []
+    config: Optional['BuiltinAuthConfig'] = None
 
     def to_swagger(self) -> Dict[str, Any]:
         raise NotImplementedError("to_swagger")


### PR DESCRIPTION
Adds the ability to locally use the authorizer `header` argument by using the `BuiltInAuthConfig` attribute in the wrapped authorizer.

*Issue #, if available:*
#1976 

*Description of changes:*
Just changes the code to use the existing `config: BuiltInAuthConfig` attribute on the built-in local authorizer wrapped function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
