### PR TITLE
Read _user_provided_params for function specific config

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -206,6 +206,9 @@ class Config(object):
             search_dicts.append(
                 self._config_from_disk.get('lambda_functions', {}).get(
                     self.function_name, {}))
+            search_dicts.append(
+                self._user_provided_params.get('lambda_functions', {}).get(
+                    self.function_name, {}))
         search_dicts.extend([self._config_from_disk, self._default_params])
         for cfg_dict in search_dicts:
             if isinstance(cfg_dict, dict) and cfg_dict.get(name) is not None:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/chalice/issues/1998

*Description of changes:*
`_user_provided_params` is added to read _user_provided_params for lambda specific configuration because with CDK the lambda specific configuration does not work properly.

ref: https://github.com/aws/chalice/issues/1998

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
