### PR TITLE
Add support for greedy catch-all path variables

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -30,7 +30,9 @@ from typing import List, Dict, Any, Optional, Sequence, Union, Callable, Set, \
 if TYPE_CHECKING:
     from chalice.local import LambdaContext
 
-_PARAMS = re.compile(r'{\w+}')
+# the optional + at the end is for supporting the special greedy parameter in
+# API Gateway (ie. "{proxy+}")
+_PARAMS = re.compile(r'{(\w+)\+?}')
 MiddlewareFuncType = Callable[[Any, Callable[[Any], Any]], Any]
 UserHandlerFuncType = Callable[..., Any]
 
@@ -577,9 +579,7 @@ class RouteEntry(object):
     def _parse_view_args(self) -> List[str]:
         if '{' not in self.uri_pattern:
             return []
-        # The [1:-1] slice is to remove the braces
-        # e.g {foobar} -> foobar
-        results = [r[1:-1] for r in _PARAMS.findall(self.uri_pattern)]
+        results = _PARAMS.findall(self.uri_pattern)
         return results
 
     def __eq__(self, other: object) -> bool:

--- a/tests/aws/test_features.py
+++ b/tests/aws/test_features.py
@@ -265,6 +265,10 @@ def test_supports_path_params(smoke_test_app):
     assert smoke_test_app.get_json('/path/bar') == {'path': 'bar'}
 
 
+def test_supports_catch_all_param(smoke_test_app):
+    assert smoke_test_app.get_json('/catch-all/foo/bar') == {'proxy': 'foo/bar'}
+
+
 def test_path_params_mapped_in_api(smoke_test_app, apig_client):
     # Use the API Gateway API to ensure that path parameters
     # are modeled as such.  Otherwise this will break

--- a/tests/aws/testapp/app.py
+++ b/tests/aws/testapp/app.py
@@ -227,6 +227,11 @@ def repr_raw_body():
     return {'repr-raw-body': app.current_request.raw_body.decode('utf-8')}
 
 
+@app.route('/catch-all/{proxy+}', methods=['GET'])
+def catch_all(proxy):
+    return {'proxy': proxy}
+
+
 SOCKET_MESSAGES = []
 
 

--- a/tests/functional/test_local.py
+++ b/tests/functional/test_local.py
@@ -318,3 +318,17 @@ def test_can_reload_server(unused_tcp_port, basic_app, http_session):
             assert http_session.json_get(url) == {'version': 'reloaded'}
         finally:
             p.terminate()
+
+
+def test_can_parse_proxy_catch_all_route(
+        config, local_server_factory):
+    demo = app.Chalice('app-name')
+
+    @demo.route('/{proxy+}')
+    def proxy_view(proxy):
+        return proxy
+
+    local_server, port = local_server_factory(demo, config)
+    response = local_server.make_call(requests.get, '/any/thing', port)
+    assert response.status_code == 200
+    assert response.text == 'any/thing'

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -463,6 +463,12 @@ def test_can_parse_route_view_args():
     assert entry.view_args == ['bar', 'qux']
 
 
+def test_can_parse_catch_all_route_view_args():
+    entry = app.RouteEntry(lambda: {"foo": "bar"}, 'view-name',
+                           '/foo/{proxy+}', method='GET')
+    assert entry.view_args == ['proxy']
+
+
 def test_can_route_single_view():
     demo = app.Chalice('app-name')
 

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -595,12 +595,18 @@ def test_multi_value_header(handler):
     ('/names/bar/wrong', None),
     ('/a/z/c', '/a/{capture}/c'),
     ('/a/b/c', '/a/b/c'),
+    ('/x', None),
+    ('/x/foo', '/x/{proxy+}'),
+    ('/x/foo/bar', '/x/{proxy+}'),
+    ('/y/foo/bar', '/y/{capture}/{proxy+}'),
+    ('/y/foo/bar/baz', '/y/{capture}/{proxy+}'),
 ])
 def test_can_match_exact_route(actual_url, matched_url):
     matcher = local.RouteMatcher([
         '/foo', '/foo/{capture}', '/foo/bar',
         '/names/{capture}',
-        '/a/{capture}/c', '/a/b/c'
+        '/a/{capture}/c', '/a/b/c',
+        '/x/{proxy+}', '/y/{capture}/{proxy+}'
     ])
     if matched_url is not None:
         assert matcher.match_route(actual_url).route == matched_url


### PR DESCRIPTION
This was attempted/discussed in #140, but here is a more complete and also tested implementation.

API Gateway has support for ["greedy" path parameters](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-routes.html#http-api-develop-routes.evaluation) in APIs routes, but that is not fully supported in Chalice. We have run into several use cases for such a feature in our company:
* Varying callback URLs from 3rd party providers that all need to go to one handler
* Static asset mapping

Currently, if you specify a `{proxy+}` path variable in an `@app.route`, it will actually work, but there are a few things lacking:
1. It's not possible to map the value to an actual parameter in the function. I'd expect to be able to get the proxied portion of the path through a parameter named "proxy".
2. The catch-all parameter does not work for local development (`chalice local`)

Those gaps are implemented in this PR. Usage would be as follows:

```python
@app.route('/foo/{proxy+}', methods=['GET'])
def example(proxy):
    return proxy
```

This will match any url under `/foo` (although not `/foo` itself), returning the proxied portion of the path:

```
GET /foo/test
=> test

GET /foo/test/bar
=> test/bar
```

The PR also adds support local development (`chalice local`) so that the matching also works locally just as it does in API Gateway.