### PR TITLE
Fixup github actions for faster feedback

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,13 @@
 name: Run PR Checks
 on:
   push:
+    branches:
+      - master
+      - "feature/**"
   pull_request:
+    branches:
+      - master
+      - "feature/**"
 jobs:
   prcheck:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -r requirements-dev.txt --upgrade --upgrade-strategy eager -e .
+          make install-dev-deps
       - name: Run PRCheck
         run: make prcheck
   testsonly:

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,6 @@ doccheck:
 	$(MAKE) -C docs html
 
 prcheck: check pylint coverage doccheck typecheck
+
+install-dev-deps:
+	pip install -r requirements-dev.txt --upgrade --upgrade-strategy eager -e .


### PR DESCRIPTION
* Add a makefile target to install deps the same way that the github action installs deps.
* Avoid duplicate/wasted jobs for PRs.