### PR TITLE
update terraform required_version to support 1.3

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -799,7 +799,7 @@ class TerraformGenerator(TemplateGenerator):
             'resource': {},
             'locals': {},
             'terraform': {
-                'required_version': '>= 0.12.26, < 1.2.0',
+                'required_version': '>= 0.12.26, < 1.4.0',
                 'required_providers': {
                     'aws': {'version': '>= 2, < 5'},
                     'null': {'version': '>= 2, < 4'}


### PR DESCRIPTION
*Issue #, if available:*
resolves #2014 

*Description of changes:*
Bumps Terraform required_version to allow 1.3 since there are no major/breaking changes between 1.x and 1.3 and nothing that should conflict with Chalice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
