### PR TITLE
Remove attrs from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
   allow:
   - dependency-name: pip
   - dependency-name: click
-  - dependency-name: attrs


### PR DESCRIPTION
We no longer rely on attrs in our code, we've switched to dataclasses.