### PR TITLE
Fix type of Response.headers

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 _PARAMS = re.compile(r'{\w+}')
 MiddlewareFuncType = Callable[[Any, Callable[[Any], Any]], Any]
 UserHandlerFuncType = Callable[..., Any]
+HeadersType = Dict[str, Union[str, List[str]]]
 
 # In python 3 string and bytes are different so we explicitly check
 # for both.
@@ -54,8 +55,10 @@ def handle_extra_types(
                     % obj.__class__.__name__)
 
 
-def error_response(message: str, error_code: str, http_status_code: int,
-                   headers: Optional[Dict[str, str]] = None) -> 'Response':
+def error_response(
+    message: str, error_code: str, http_status_code: int,
+    headers: Optional[HeadersType] = None
+) -> 'Response':
     body = {'Code': error_code, 'Message': message}
     response = Response(body=body, status_code=http_status_code,
                         headers=headers)
@@ -469,13 +472,13 @@ class Response(object):
 
     def __init__(
             self, body: Any,
-            headers: Optional[Dict[str, str]] = None,
+            headers: Optional[HeadersType] = None,
             status_code: int = 200
     ):
         self.body: Any = body
         if headers is None:
             headers = {}
-        self.headers: Dict[str, str] = headers
+        self.headers: HeadersType = headers
         self.status_code = status_code
 
     def to_dict(
@@ -498,7 +501,7 @@ class Response(object):
         return response
 
     def _sort_headers(
-            self, all_headers: Dict[str, str]
+            self, all_headers: HeadersType
     ) -> Tuple[Dict[str, Any], Dict[str, List]]:
         multi_headers: Dict[str, List] = {}
         single_headers: Dict[str, Any] = {}
@@ -1930,7 +1933,7 @@ class RestAPIEventHandler(BaseLambdaHandler):
         return response
 
     def _unhandled_exception_to_response(self) -> Response:
-        headers = {}
+        headers: HeadersType = {}
         path = getattr(self.current_request, 'path', 'unknown')
         self.log.error("Caught exception for path %s", path, exc_info=True)
         if self.debug:


### PR DESCRIPTION
The type for `Response.headers` was previously typed as `Dict[str, str]`, but that is not completely correct. Header values can also be a list of strings, e.g. for multiple `Set-Cookie` headers. See #1214 when this feature was introduced. 

The wrong type definition was introduced in afd23d7d729f8383033fe3851bc1de5effd1f22f.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
