### PR TITLE
(Easy merge ⭐️) Upgrade Sample Todo App to Use Latest 3rd Party Python Dependencies

### DIFF
--- a/docs/source/samples/todo-app/code/chalicelib/auth.py
+++ b/docs/source/samples/todo-app/code/chalicelib/auth.py
@@ -12,7 +12,7 @@ def get_jwt_token(username, password, record, secret):
         record['hash'],
         password.encode('utf-8'),
         record['salt'].value,
-        record['rounds']
+        int(record['rounds'])
     )
     expected = record['hashed'].value
     if hmac.compare_digest(actual, expected):
@@ -25,7 +25,7 @@ def get_jwt_token(username, password, record, secret):
             'jti': unique_id,
             # NOTE: We can also add 'exp' if we want tokens to expire.
         }
-        return jwt.encode(payload, secret, algorithm='HS256').decode('utf-8')
+        return jwt.encode(payload, secret, algorithm='HS256')
     raise UnauthorizedError('Invalid password')
 
 

--- a/docs/source/samples/todo-app/code/requirements-dev.txt
+++ b/docs/source/samples/todo-app/code/requirements-dev.txt
@@ -1,2 +1,2 @@
-chalice==1.15.1
-pytest==5.4.3
+chalice==1.29.0
+pytest==7.4.0

--- a/docs/source/samples/todo-app/code/requirements.txt
+++ b/docs/source/samples/todo-app/code/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.14.18
-botocore==1.17.18
-PyJWT==2.4.0
+boto3==1.27.0
+botocore==1.30.0
+PyJWT==2.7.0


### PR DESCRIPTION
Upgrading the dependencies doesn't work by itself as there was an issue with jwt token. This resolves that problem.

*Description of changes:*

1. Upgrading the 3rd-party Python dependencies 
2. Step 1 above doesn't work by itself, as there was an issue with jwt token code in chalicelib/auth.py. Two simple adjustments to that file has everything working with the latest versions.