### PR TITLE
Partial fix for #1753: Add TracingEnabled to RestAPI during SAM package when xray enabled in config

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -334,6 +334,9 @@ class SAMTemplateGenerator(TemplateGenerator):
             properties = resources['RestAPI']['Properties']
             properties['MinimumCompressionSize'] = \
                 int(resource.minimum_compression)
+        if self._config.xray_enabled:
+            properties = resources['RestAPI']['Properties']
+            properties['TracingEnabled'] = True
 
         handler_cfn_name = to_cfn_resource_name(
             resource.lambda_function.resource_name)

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1335,6 +1335,17 @@ class TestSAMTemplate(TemplateTestBase):
             },
         }
 
+    def test_can_generate_rest_api_with_xray(
+            self, sample_app_with_auth):
+        config = Config.create(chalice_app=sample_app_with_auth,
+                               project_dir='.',
+                               api_gateway_stage='api',
+                               xray=True
+                               )
+        template = self.generate_template(config)
+        resources = template['Resources']
+        assert resources['RestAPI']['Properties']['TracingEnabled'] is True
+
     def test_can_generate_rest_api_without_compression(
             self, sample_app_with_auth):
         config = Config.create(chalice_app=sample_app_with_auth,
@@ -1372,6 +1383,7 @@ class TestSAMTemplate(TemplateTestBase):
         assert resources['RestAPI']['Type'] == 'AWS::Serverless::Api'
         assert resources['RestAPI']['Properties']['MinimumCompressionSize'] \
             == 100
+        assert 'TracingEnabled' not in resources['RestAPI']['Properties']
         # We should also create the auth lambda function.
         assert resources['Myauth']['Type'] == 'AWS::Serverless::Function'
         # Along with permission to invoke from API Gateway.


### PR DESCRIPTION
*Issue #, if available:*
#1753 

*Description of changes:*

Add TracingEnabled to RestAPI when creating a SAM package and XRay is enabled in config. This makes it consistent with the deploy workflow.
Added unit test to confirm.
Validated it in my own project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
