### PR TITLE
Use unittest.mock instead of mock if available

### DIFF
--- a/requirements-test.in
+++ b/requirements-test.in
@@ -5,4 +5,3 @@ coverage
 websocket-client<2.0.0
 pytest-cov
 requests
-mock

--- a/tests/aws/test_features.py
+++ b/tests/aws/test_features.py
@@ -3,11 +3,8 @@ import os
 import time
 import shutil
 import uuid
+from unittest import mock
 
-try:
-    from unittest import mock
-except:
-    import mock
 import botocore.session
 import pytest
 import requests

--- a/tests/aws/test_features.py
+++ b/tests/aws/test_features.py
@@ -4,7 +4,10 @@ import time
 import shutil
 import uuid
 
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import botocore.session
 import pytest
 import requests

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -6,7 +6,10 @@ import re
 
 import pytest
 from click.testing import CliRunner
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 from botocore.exceptions import ClientError
 
 from chalice import cli

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -3,13 +3,10 @@ import zipfile
 import os
 import sys
 import re
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
-try:
-    from unittest import mock
-except:
-    import mock
 from botocore.exceptions import ClientError
 
 from chalice import cli

--- a/tests/functional/cli/test_reloader.py
+++ b/tests/functional/cli/test_reloader.py
@@ -1,8 +1,5 @@
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 import threading
 import os
 import unittest

--- a/tests/functional/cli/test_reloader.py
+++ b/tests/functional/cli/test_reloader.py
@@ -1,5 +1,8 @@
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import threading
 import os
 import unittest

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -3,7 +3,10 @@ import datetime
 import time
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import botocore.exceptions
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -1,12 +1,9 @@
 import json
 import datetime
 import time
+from unittest import mock
 
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
 import botocore.exceptions
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -1,10 +1,7 @@
 import os
 import zipfile
 import json
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 import hashlib
 
 from pytest import fixture

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -1,7 +1,10 @@
 import os
 import zipfile
 import json
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import hashlib
 
 from pytest import fixture

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -2,13 +2,10 @@ import os
 import zipfile
 import tarfile
 import io
+from unittest import mock
 from collections import defaultdict, namedtuple
 
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
 
 from chalice.awsclient import TypedAWSClient
 from chalice.config import Config

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -5,7 +5,10 @@ import io
 from collections import defaultdict, namedtuple
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 
 from chalice.awsclient import TypedAWSClient
 from chalice.config import Config

--- a/tests/unit/cli/filewatch/test_eventbased.py
+++ b/tests/unit/cli/filewatch/test_eventbased.py
@@ -1,10 +1,7 @@
 import threading
 from subprocess import Popen
+from unittest import mock
 
-try:
-    from unittest import mock
-except:
-    import mock
 import pytest
 
 try:

--- a/tests/unit/cli/filewatch/test_eventbased.py
+++ b/tests/unit/cli/filewatch/test_eventbased.py
@@ -1,7 +1,10 @@
 import threading
 from subprocess import Popen
 
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import pytest
 
 try:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import pytest
 import re
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 import pytest
 import re
 

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -6,10 +6,7 @@ import socket
 import botocore.session
 
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 from botocore.stub import Stubber
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -6,7 +6,10 @@ import socket
 import botocore.session
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 from botocore.stub import Stubber
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError

--- a/tests/unit/deploy/test_executor.py
+++ b/tests/unit/deploy/test_executor.py
@@ -1,5 +1,8 @@
 import re
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import pytest
 
 from chalice.awsclient import TypedAWSClient

--- a/tests/unit/deploy/test_executor.py
+++ b/tests/unit/deploy/test_executor.py
@@ -1,8 +1,5 @@
 import re
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 import pytest
 
 from chalice.awsclient import TypedAWSClient

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 
 import pytest
 from dataclasses import replace, dataclass

--- a/tests/unit/deploy/test_planner.py
+++ b/tests/unit/deploy/test_planner.py
@@ -1,11 +1,8 @@
-try:
-    from unittest import mock
-except:
-    import mock
-
-import pytest
+from unittest import mock
 from dataclasses import replace, dataclass
 from typing import Tuple
+
+import pytest
 
 from chalice.awsclient import TypedAWSClient, ResourceDoesNotExistError
 from chalice.deploy import models

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -4,7 +4,10 @@ from chalice import CORSConfig
 from chalice.app import CustomAuthorizer, CognitoUserPoolAuthorizer
 from chalice.app import IAMAuthorizer, Chalice
 from chalice.deploy.models import RestAPI, IAMPolicy
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 from pytest import fixture
 
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -1,13 +1,11 @@
+from unittest import mock
+
 from chalice.deploy.swagger import (
     SwaggerGenerator, CFNSwaggerGenerator, TerraformSwaggerGenerator)
 from chalice import CORSConfig
 from chalice.app import CustomAuthorizer, CognitoUserPoolAuthorizer
 from chalice.app import IAMAuthorizer, Chalice
 from chalice.deploy.models import RestAPI, IAMPolicy
-try:
-    from unittest import mock
-except:
-    import mock
 from pytest import fixture
 
 

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -1,8 +1,5 @@
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 
 from chalice.app import Chalice
 from chalice.config import Config

--- a/tests/unit/deploy/test_validate.py
+++ b/tests/unit/deploy/test_validate.py
@@ -1,5 +1,8 @@
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 
 from chalice.app import Chalice
 from chalice.config import Config

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -2,7 +2,10 @@ import re
 import json
 import decimal
 import pytest
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 from pytest import fixture
 from six import BytesIO
 from six.moves.BaseHTTPServer import HTTPServer

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,11 +1,9 @@
 import re
 import json
 import decimal
+from unittest import mock
+
 import pytest
-try:
-    from unittest import mock
-except:
-    import mock
 from pytest import fixture
 from six import BytesIO
 from six.moves.BaseHTTPServer import HTTPServer

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -1,8 +1,5 @@
 import time
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 from datetime import datetime, timedelta
 
 from chalice import logs

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -1,5 +1,8 @@
 import time
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 from datetime import datetime, timedelta
 
 from chalice import logs

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1,6 +1,9 @@
 import os
 import json
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 
 import pytest
 from chalice.config import Config

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1,9 +1,6 @@
 import os
 import json
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 
 import pytest
 from chalice.config import Config

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,9 @@
 import os
 import re
-import mock
+try:
+    from unittest import mock
+except:
+    import mock
 import sys
 
 import click

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,9 +1,6 @@
 import os
 import re
-try:
-    from unittest import mock
-except:
-    import mock
+from unittest import mock
 import sys
 
 import click


### PR DESCRIPTION
*Description of changes:*
`mock` is deprecated and has been replaced by `unittest.mock` in recent Python versions, so use that instead if it's available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
