### PR TITLE
python 3.11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
         cdk-version: [cdk, cdkv2]
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Quickstart
 In this tutorial, you'll use the ``chalice`` command line utility
 to create and deploy a basic REST API.  This quickstart uses Python 3.7,
 but AWS Chalice supports all versions of python supported by AWS Lambda,
-which includes python3.6, python3.7, python3.8, python3.9, python3.10.
+which includes python3.6, python3.7, python3.8, python3.9, python3.10, python3.11.
 You can find the latest versions of python on the
 `Python download page <https://www.python.org/downloads/>`_.
 

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -160,7 +160,9 @@ class Config(object):
             return 'python3.8'
         elif (major, minor) <= (3, 9):
             return 'python3.9'
-        return 'python3.10'
+        elif (major, minor) <= (3, 10):
+            return 'python3.10'
+        return 'python3.11'
 
     @property
     def log_retention_in_days(self) -> int:

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -151,17 +151,12 @@ class Config(object):
         if major == 2:
             return 'python2.7'
         # Python 3 for backwards compatibility needs to select python3.6
-        # for python versions 3.0-3.6. 3.7 and higher will use python3.7.
+        # for python versions 3.0-3.6. 3.7-3.10 will use their version.
+        # 3.11 and higher will use 3.11
         elif (major, minor) <= (3, 6):
             return 'python3.6'
-        elif (major, minor) <= (3, 7):
-            return 'python3.7'
-        elif (major, minor) <= (3, 8):
-            return 'python3.8'
-        elif (major, minor) <= (3, 9):
-            return 'python3.9'
         elif (major, minor) <= (3, 10):
-            return 'python3.10'
+            return 'python%s.%s' % (major, minor)
         return 'python3.11'
 
     @property

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -82,6 +82,7 @@ class BaseLambdaDeploymentPackager(object):
         'python3.8': 'cp38',
         'python3.9': 'cp39',
         'python3.10': 'cp310',
+        'python3.11': 'cp311',
     }
 
     def __init__(
@@ -498,7 +499,8 @@ class DependencyBuilder(object):
         'cp36m': (2, 17),
         'cp37m': (2, 17),
         'cp38': (2, 26),
-        'cp310': (2, 26)
+        'cp310': (2, 26),
+        'cp311': (2, 26),
     }
     # Fallback version if we're on an unknown python version
     # not in _RUNTIME_GLIBC.

--- a/docs/source/topics/middleware.rst
+++ b/docs/source/topics/middleware.rst
@@ -271,15 +271,15 @@ Integrating with AWS Lambda Powertools
 --------------------------------------
 
 `AWS Lambda Powertools
-<https://awslabs.github.io/aws-lambda-powertools-python/latest/>`__ is a suite of
+<https://docs.powertools.aws.dev/lambda/python/latest/>`__ is a suite of
 utilities for AWS Lambda functions that makes tracing with AWS X-Ray,
 structured logging and creating custom metrics asynchronously easier.
 
 You can use Chalice middleware to easily integrate Lambda Powertools with
 your Chalice apps.  In this example, we'll use the
 `Logger
-<https://awslabs.github.io/aws-lambda-powertools-python/latest/core/logger/>`__
-and `Tracer <https://awslabs.github.io/aws-lambda-powertools-python/latest/core/tracer/>`__
+<https://docs.powertools.aws.dev/lambda/python/latest/core/logger/>`__
+and `Tracer <https://docs.powertools.aws.dev/lambda/python/latest/core/tracer/>`__
 and convert them to Chalice middleware so they will be automatically applied
 to all Lambda functions in our application.
 

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 )

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -417,6 +417,8 @@ def test_error_when_no_deployed_record(runner, mock_cli_factory):
                     reason="Cannot generate pipeline for python3.9.")
 @pytest.mark.skipif(sys.version_info[:2] == (3, 10),
                     reason="Cannot generate pipeline for python3.10.")
+@pytest.mark.skipif(sys.version_info[:2] == (3, 11),
+                    reason="Cannot generate pipeline for python3.11.")
 def test_can_generate_pipeline_for_all(runner):
     with runner.isolated_filesystem():
         newproj.create_new_project_skeleton('testproject')

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -45,7 +45,7 @@ PACKAGES_TO_TEST = {
         ],
     },
     'numpy': {
-        'version': '1.21.6',
+        'version': '1.23.3',
         'legacy_version': '1.19.4',
         'contents': [
             'numpy/__init__.py',
@@ -76,7 +76,7 @@ PACKAGES_TO_TEST = {
         'contents': ['markupsafe/__init__.py'],
     },
     'scipy': {
-        'version': '1.7.3',
+        'version': '1.10.1',
         'legacy_version': '1.5.4',
         'contents': [
             'scipy/__init__.py',

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -377,8 +377,10 @@ def test_can_load_python_version():
         expected_runtime = 'python3.8'
     elif minor <= 9:
         expected_runtime = 'python3.9'
-    else:
+    elif minor <= 10:
         expected_runtime = 'python3.10'
+    else:
+        expected_runtime = 'python3.11'
     assert c.lambda_python_version == expected_runtime
 
 


### PR DESCRIPTION
*Issue #, if available:* #2053


*Description of changes:*

Python 3.11 support
https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
