### PR TITLE
Replace null resource in terraform template with locals to fix warning

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -817,26 +817,20 @@ class TerraformGenerator(TemplateGenerator):
         # type: (List[models.Model]) -> Dict[str, Any]
         template = {
             'resource': {},
-            'locals': {},
+            'locals': {
+                'chalice_app': self._config.app_name,
+                'chalice_stage': self._config.chalice_stage
+            },
             'terraform': {
                 'required_version': '>= 0.12.26, < 1.4.0',
                 'required_providers': {
                     'aws': {'version': '>= 2, < 5'},
-                    'null': {'version': '>= 2, < 4'}
                 }
             },
             'data': {
                 'aws_caller_identity': {'chalice': {}},
                 'aws_partition': {'chalice': {}},
                 'aws_region': {'chalice': {}},
-                'null_data_source': {
-                    'chalice': {
-                        'inputs': {
-                            'app': self._config.app_name,
-                            'stage': self._config.chalice_stage
-                        }
-                    }
-                }
             }
         }
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -616,10 +616,14 @@ class TestTerraformTemplate(TemplateTestBase):
                                app_name='myfoo',
                                api_gateway_stage='dev')
         template = self.generate_template(config)
-        assert template['data']['null_data_source']['chalice']['inputs'] == {
-            'app': 'myfoo',
-            'stage': 'dev'
-        }
+        assert 'chalice_app' in template['locals']
+        assert 'chalice_stage' in template['locals']
+        assert 'chalice_api_swagger' in template['locals']
+        assert template['locals']['chalice_app'] == 'myfoo'
+        assert template['locals']['chalice_stage'] == 'dev'
+        assert template['locals']['chalice_api_swagger'] == (
+            '{"info": {"title": "some-app"}, "x-amazon-apigateway-binary-media-types": []}'
+        )
 
     def test_can_package_s3_event_handler_sans_filters(self, sample_app):
         @sample_app.on_s3_event(bucket='foo')


### PR DESCRIPTION
Fixes #1874 

This replaces the null_data_source used in the terraform template with locals.

It is a breaking change for anyone who was using the old values in their templates. I can change this to just the addition of the locals if we prefer to avoid the API change for now, that would at least give people an alternative although it would not resolve the warning yet.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
