### PR TITLE
chore: relax stale issue timings

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -31,8 +31,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 2
+        days-before-stale: 10
+        days-before-close: 4
         days-before-ancient: 2190
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
We received customer feedback that our stale issue timings are too tight. This doubles what we had previously.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
