### PR TITLE
Update the AWS provider & required versions of terraform

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -819,9 +819,9 @@ class TerraformGenerator(TemplateGenerator):
             'resource': {},
             'locals': {},
             'terraform': {
-                'required_version': '>= 0.12.26, < 1.4.0',
+                'required_version': '>= 0.12.26, < 1.8.0',
                 'required_providers': {
-                    'aws': {'version': '>= 2, < 5'},
+                    'aws': {'version': '>= 2, < 6'},
                     'null': {'version': '>= 2, < 4'}
                 }
             },


### PR DESCRIPTION
This update allows terraform -package to support python 3.11 chalice.  Currently wouldn't work


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
