### PR TITLE
Set APIGateway tracing based on xray settings

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -328,6 +328,7 @@ class SAMTemplateGenerator(TemplateGenerator):
             'Properties': {
                 'EndpointConfiguration': resource.endpoint_type,
                 'StageName': resource.api_gateway_stage,
+                'TracingEnabled': resource.xray,
                 'DefinitionBody': resource.swagger_doc,
             }
         }


### PR DESCRIPTION
Fixes X-Ray tracing in API Gateway when using SAM template or CDK
