### PR TITLE
Bump AWS provider version to support Python 3.12

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -822,7 +822,7 @@ class TerraformGenerator(TemplateGenerator):
             'terraform': {
                 'required_version': '>= 0.12.26, < 1.4.0',
                 'required_providers': {
-                    'aws': {'version': '>= 2, < 5'},
+                    'aws': {'version': '>= 2, < 5.43.0'},
                     'null': {'version': '>= 2, < 4'}
                 }
             },


### PR DESCRIPTION
Fixes Issue #2097.

Bump AWS provider version to support Python 3.12. I've tested this with a few lambdas, and everything looks good. The Terraform plan also generated a reasonable output.