### PR TITLE
feat: maximum_concurrency option in on_sqs_message 

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -768,7 +768,8 @@ class DecoratorAPI(object):
     def on_sqs_message(self, queue: Optional[str] = None, batch_size: int = 1,
                        name: Optional[str] = None,
                        queue_arn: Optional[str] = None,
-                       maximum_batching_window_in_seconds: int = 0
+                       maximum_batching_window_in_seconds: int = 0,
+                       maximum_concurrency: Optional[int] = None,
                        ) -> Callable[..., Any]:
         return self._create_registration_function(
             handler_type='on_sqs_message',
@@ -778,7 +779,8 @@ class DecoratorAPI(object):
                 'queue_arn': queue_arn,
                 'batch_size': batch_size,
                 'maximum_batching_window_in_seconds':
-                    maximum_batching_window_in_seconds
+                    maximum_batching_window_in_seconds,
+                'maximum_concurrency': maximum_concurrency,
             }
         )
 
@@ -1101,6 +1103,8 @@ class _HandlerRegistration(object):
             batch_size=kwargs['batch_size'],
             maximum_batching_window_in_seconds=kwargs[
                 'maximum_batching_window_in_seconds'],
+            maximum_concurrency=kwargs[
+                'maximum_concurrency'],
         )
         self.event_sources.append(sqs_config)
 
@@ -1625,13 +1629,15 @@ class SNSEventConfig(BaseEventSourceConfig):
 class SQSEventConfig(BaseEventSourceConfig):
     def __init__(self, name: str, handler_string: str, queue: Optional[str],
                  queue_arn: Optional[str], batch_size: int,
-                 maximum_batching_window_in_seconds: int):
+                 maximum_batching_window_in_seconds: int,
+                 maximum_concurrency: Optional[int]):
         super(SQSEventConfig, self).__init__(name, handler_string)
         self.queue: Optional[str] = queue
         self.queue_arn: Optional[str] = queue_arn
         self.batch_size: int = batch_size
         self.maximum_batching_window_in_seconds: int = \
             maximum_batching_window_in_seconds
+        self.maximum_concurrency: Optional[int] = maximum_concurrency
 
 
 class KinesisEventConfig(BaseEventSourceConfig):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1826,6 +1826,7 @@ class TypedAWSClient(object):
         batch_size: int,
         starting_position: Optional[str] = None,
         maximum_batching_window_in_seconds: Optional[int] = 0,
+        maximum_concurrency: Optional[int] = None,
     ) -> None:
         lambda_client = self._client('lambda')
         batch_window = maximum_batching_window_in_seconds
@@ -1835,6 +1836,10 @@ class TypedAWSClient(object):
             'BatchSize': batch_size,
             'MaximumBatchingWindowInSeconds': batch_window,
         }
+        if maximum_concurrency:
+            kwargs['ScalingConfig'] = {
+                'MaximumConcurrency': maximum_concurrency
+            }
         if starting_position is not None:
             kwargs['StartingPosition'] = starting_position
         return self._call_client_method_with_retries(
@@ -1848,6 +1853,7 @@ class TypedAWSClient(object):
         event_uuid: str,
         batch_size: int,
         maximum_batching_window_in_seconds: Optional[int] = 0,
+        maximum_concurrency: Optional[int] = None,
     ) -> None:
         lambda_client = self._client('lambda')
         batch_window = maximum_batching_window_in_seconds
@@ -1856,6 +1862,10 @@ class TypedAWSClient(object):
             'BatchSize': batch_size,
             'MaximumBatchingWindowInSeconds': batch_window,
         }
+        if maximum_concurrency:
+            kwargs['ScalingConfig'] = {
+                'MaximumConcurrency': maximum_concurrency
+            }
         self._call_client_method_with_retries(
             lambda_client.update_event_source_mapping,
             kwargs,

--- a/chalice/deploy/appgraph.py
+++ b/chalice/deploy/appgraph.py
@@ -664,6 +664,7 @@ class ApplicationGraphBuilder(object):
             batch_size=sqs_config.batch_size,
             lambda_function=lambda_function,
             maximum_batching_window_in_seconds=batch_window,
+            maximum_concurrency=sqs_config.maximum_concurrency
         )
         return sqs_event_source
 

--- a/chalice/deploy/models.py
+++ b/chalice/deploy/models.py
@@ -348,6 +348,7 @@ class SQSEventSource(FunctionEventSubscriber):
     queue: Union[str, QueueARN]
     batch_size: int
     maximum_batching_window_in_seconds: int
+    maximum_concurrency: Opt[int] = None
 
 
 @dataclass

--- a/chalice/deploy/planner.py
+++ b/chalice/deploy/planner.py
@@ -731,10 +731,13 @@ class PlanStage(object):
             return instruction_for_queue_arn + [
                 models.APICall(
                     method_name='update_lambda_event_source',
-                    params={'event_uuid': uuid,
-                            'batch_size': resource.batch_size,
-                            'maximum_batching_window_in_seconds':
-                                resource.maximum_batching_window_in_seconds}
+                    params={
+                        'event_uuid': uuid,
+                        'batch_size': resource.batch_size,
+                        'maximum_batching_window_in_seconds':
+                            resource.maximum_batching_window_in_seconds,
+                        'maximum_concurrency': resource.maximum_concurrency
+                    }
                 )
             ] + self._batch_record_resource(
                 'sqs_event', resource.resource_name, {
@@ -751,6 +754,7 @@ class PlanStage(object):
                         'batch_size': resource.batch_size,
                         'maximum_batching_window_in_seconds':
                             resource.maximum_batching_window_in_seconds,
+                        'maximum_concurrency': resource.maximum_concurrency,
                         'function_name': function_arn},
                 output_var=uuid_varname,
             ), 'Subscribing %s to SQS queue %s\n'

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -282,7 +282,7 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
-   .. method:: on_sqs_message(queue, batch_size=1, name=None, queue_arn=None, maximum_batching_window_in_seconds=0)
+   .. method:: on_sqs_message(queue, batch_size=1, name=None, queue_arn=None, maximum_batching_window_in_seconds=0, maximum_concurrency=None)
 
       Create a lambda function and configure it to be automatically invoked
       whenever a message is published to the specified SQS queue.
@@ -336,6 +336,9 @@ Chalice
 
       :param maximum_batching_window_in_seconds: The maximum amount of time,
         in seconds, to gather records before invoking the function.
+
+      :param maximum_concurrency: The maximum number of concurrent functions
+        that the event source can invoke.
 
    .. method:: on_kinesis_record(stream, batch_size=100, starting_position='LATEST', name=None, maximum_batching_window_in_seconds=0)
 


### PR DESCRIPTION
Issue https://github.com/aws/chalice/issues/2031

*Description of changes:*

This PR adds option to configure [MaximumConcurrency](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-max-concurrency) value for sqs event source lambdas. 

The option can be used like following:

```python
@app.on_sqs_message(queue='my-queue', batch_size=1, maximum_concurrency=20)
def handle_sqs_message(event):
    ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
