### PR TITLE
Fix distutils warning when packaging/deploying apps

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1421,8 +1421,7 @@ class TypedAWSClient(object):
             logGroupName=log_group_name, interleaved=True
         )
         try:
-            for log_message in self._iter_log_messages(pages):
-                yield log_message
+            yield from self._iter_log_messages(pages)
         except logs.exceptions.ResourceNotFoundException:
             # If the lambda function exists but has not been invoked yet,
             # it's possible that the log group does not exist and we'll get

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -176,8 +176,7 @@ class BaseLambdaDeploymentPackager(object):
             chalice_init = chalice_init[:-1]
         yield (chalice_init, 'chalice/__init__.py')
         yield (self._osutils.joinpath(project_dir, 'app.py'), 'app.py')
-        for filename in self._iter_chalice_lib_if_needed(project_dir):
-            yield filename
+        yield from self._iter_chalice_lib_if_needed(project_dir)
 
     def _hash_project_dir(
         self, requirements_filename: str, vendor_dir: str, project_dir: str

--- a/chalice/logs.py
+++ b/chalice/logs.py
@@ -169,8 +169,7 @@ class LogEventGenerator(BaseLogEventGenerator):
         logs = self._client.iter_log_events(
             log_group_name=log_group_name, start_time=options.start_time
         )
-        for log_message in logs:
-            yield log_message
+        yield from logs
 
 
 class FollowLogEventGenerator(BaseLogEventGenerator):
@@ -193,12 +192,11 @@ class FollowLogEventGenerator(BaseLogEventGenerator):
     ) -> Iterator[CWLogEvent]:
         start_time = options.start_time
         try:
-            for event in self._loop_on_filter_log_events(
+            yield from self._loop_on_filter_log_events(
                 log_group_name, start_time
-            ):
-                yield event
+            )
         except KeyboardInterrupt:
-            return
+            pass
 
     def _loop_on_filter_log_events(
         self, log_group_name: str, start_time: Optional[datetime]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,27 +6,27 @@
 #
 alabaster==0.7.13
     # via sphinx
-astroid==3.0.3
+astroid==3.2.4
     # via pylint
-attrs==23.2.0
+attrs==24.2.0
     # via hypothesis
-babel==2.14.0
+babel==2.16.0
     # via sphinx
-boto3==1.34.46
+boto3==1.35.66
     # via -r requirements-test.in
-botocore==1.34.46
+botocore==1.35.66
     # via
     #   boto3
     #   s3transfer
-certifi==2024.2.2
+certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage[toml]==7.4.2
+coverage[toml]==7.6.1
     # via
     #   -r requirements-test.in
     #   pytest-cov
-dill==0.3.8
+dill==0.3.9
     # via pylint
 doc8==0.11.2
     # via -r requirements-dev.in
@@ -36,15 +36,15 @@ docutils==0.17.1
     #   doc8
     #   restructuredtext-lint
     #   sphinx
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   hypothesis
     #   pytest
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements-dev.in
-hypothesis==6.98.9
+hypothesis==6.113.0
     # via -r requirements-test.in
-idna==3.6
+idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -52,7 +52,7 @@ iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via pylint
-jinja2==3.1.3
+jinja2==3.1.4
     # via sphinx
 jmespath==1.0.1
     # via
@@ -64,50 +64,50 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.8.0
+mypy==1.13.0
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via mypy
-packaging==23.2
+packaging==24.2
     # via
     #   pytest
     #   sphinx
-pbr==6.0.0
+pbr==6.1.0
     # via stevedore
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via pylint
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pydocstyle==6.3.0
     # via -r requirements-dev.in
 pyflakes==3.2.0
     # via flake8
-pygments==2.17.2
+pygments==2.18.0
     # via
     #   -r requirements-dev.in
     #   doc8
     #   sphinx
-pylint==3.0.3
+pylint==3.2.7
     # via -r requirements-dev.in
-pytest==8.0.1
+pytest==8.3.3
     # via
     #   -r requirements-test.in
     #   pytest-cov
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via -r requirements-test.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via botocore
-pytz==2024.1
+pytz==2024.2
     # via babel
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements-test.in
     #   sphinx
 restructuredtext-lint==1.4.0
     # via doc8
-s3transfer==0.10.0
+s3transfer==0.10.4
     # via boto3
 six==1.16.0
     # via python-dateutil
@@ -131,34 +131,34 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==5.1.0
+stevedore==5.3.0
     # via doc8
-tomli==2.0.1
+tomli==2.1.0
     # via
     #   coverage
     #   mypy
     #   pylint
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.13.2
     # via pylint
-types-python-dateutil==2.8.19.20240106
+types-python-dateutil==2.9.0.20241003
     # via -r requirements-dev.in
-types-pyyaml==6.0.12.12
+types-pyyaml==6.0.12.20240917
     # via -r requirements-dev.in
-types-six==1.16.21.20240106
+types-six==1.16.21.20241105
     # via -r requirements-dev.in
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   astroid
     #   mypy
     #   pylint
-urllib3==1.26.18
+urllib3==1.26.20
     # via
     #   botocore
     #   requests
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via -r requirements-test.in
-wheel==0.42.0
+wheel==0.45.0
     # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'pip>=9,<24.1',
     'jmespath>=0.9.3,<2.0.0',
     'pyyaml>=5.3.1,<7.0.0',
-    'inquirer>=2.7.0,<3.0.0',
+    'inquirer>=3.0.0,<4.0.0',
     'wheel',
     'setuptools'
 ]


### PR DESCRIPTION
If distutils is imported before pip outside of a `setup.py`, you see a deprecation warning about distutils.  This warning was being triggered whenever you run `chalice package/deploy`:

```
$ chalice package out
./site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils. Support for replacing an already imported distutils is deprecated. In the future, this condition will fail. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
  warnings.warn(
```

This was caused by a depdency we use, `inquirer`, using a dependency that used distutils. Upgrading to the latest major version of `inquirer` fixes this issue, which no longer depends on the affected package.  As a result, we no longer see this warning message when running `chalice package` or `chalice deploy`.

This triggered several other dependencies that needed to be updated, which resulted in a few cosmetic code tweaks to make pylint happy.