### PR TITLE
bumping readme suggested python version from 3.7 to 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Quickstart
 .. quick-start-begin
 
 In this tutorial, you'll use the ``chalice`` command line utility
-to create and deploy a basic REST API.  This quickstart uses Python 3.7,
+to create and deploy a basic REST API.  This quickstart uses Python 3.12,
 but AWS Chalice supports all versions of python supported by AWS Lambda,
 which includes Python 3.7 through python 3.12.
 
@@ -117,12 +117,12 @@ You can find the latest versions of python on the
 `Python download page <https://www.python.org/downloads/>`_.
 
 To install Chalice, we'll first create and activate a virtual environment
-in python3.7::
+in python3.12::
 
     $ python3 --version
-    Python 3.7.3
-    $ python3 -m venv venv37
-    $ . venv37/bin/activate
+    Python 3.12.3
+    $ python3 -m venv venv312
+    $ . venv312/bin/activate
 
 Next we'll install Chalice using ``pip``::
 


### PR DESCRIPTION
Documentation update only (Readme).

Even though Chalice supports 3.7, it seems wrong to suggest using obsolete 3.7 in Readme and Quickstart
I updated it to 3.12 with 2028-10 end of support.