### PR TITLE
Add ARM runtime support for Lambda functions

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -173,8 +173,8 @@ class TypedAWSClient(object):
 
         This allows the an endpoint to be discerned based on an ARN.  This
         is a convenience method due to the need to parse multiple ARNs
-        throughout the project. If the service and region combination
-        is not found the None will be returned.
+        throughout the project. If the service and region
+        combination is not found the None will be returned.
         """
         arn_split = arn.split(':')
         return self.resolve_endpoint(arn_split[2], arn_split[3])
@@ -403,6 +403,7 @@ class TypedAWSClient(object):
         security_group_ids: OptStrList = None,
         subnet_ids: OptStrList = None,
         layers: OptStrList = None,
+        architecture: OptStr = None,
     ) -> str:
         # pylint: disable=too-many-locals
         kwargs: Dict[str, Any] = {
@@ -429,6 +430,8 @@ class TypedAWSClient(object):
             )
         if layers is not None:
             kwargs['Layers'] = layers
+        if architecture is not None:
+            kwargs['Architectures'] = [architecture]
         arn, state = self._create_lambda_function(kwargs)
         # Avoid the GetFunctionConfiguration call unless
         # we're not immediately active.
@@ -909,6 +912,7 @@ class TypedAWSClient(object):
         subnet_ids: OptStrList = None,
         security_group_ids: OptStrList = None,
         layers: OptStrList = None,
+        architecture: OptStr = None,
     ) -> Dict[str, Any]:
         """Update a Lambda function's code and configuration.
 
@@ -930,6 +934,7 @@ class TypedAWSClient(object):
             security_group_ids=security_group_ids,
             function_name=function_name,
             layers=layers,
+            architecture=architecture,
         )
         if tags is not None:
             self._update_function_tags(return_value['FunctionArn'], tags)
@@ -982,6 +987,7 @@ class TypedAWSClient(object):
         function_name: str,
         layers: OptStrList,
         xray: Optional[bool],
+        architecture: OptStr,
     ) -> None:
         kwargs: Dict[str, Any] = {}
         if environment_variables is not None:
@@ -1002,6 +1008,8 @@ class TypedAWSClient(object):
             )
         if layers is not None:
             kwargs['Layers'] = layers
+        if architecture is not None:
+            kwargs['Architectures'] = [architecture]
         if kwargs:
             self._do_update_function_config(function_name, kwargs)
 

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -343,6 +343,12 @@ class Config(object):
                                   varies_per_chalice_stage=True,
                                   varies_per_function=True)
 
+    @property
+    def lambda_architecture(self) -> str:
+        return self._chain_lookup('lambda_architecture',
+                                  varies_per_chalice_stage=True,
+                                  varies_per_function=True)
+
     def scope(self, chalice_stage: str, function_name: str) -> Config:
         # Used to create a new config object that's scoped to a different
         # stage and/or function.  This creates a completely separate copy.

--- a/chalice/deploy/validate.py
+++ b/chalice/deploy/validate.py
@@ -50,6 +50,7 @@ def validate_configuration(config):
     validate_resource_policy(config)
     validate_sqs_configuration(config.chalice_app)
     validate_environment_variables_type(config)
+    validate_lambda_architecture(config)
 
 
 def validate_resource_policy(config):
@@ -277,3 +278,12 @@ def _validate_environment_variables(environment_variables):
             raise ValueError("Environment variable values must be strings, "
                              "got 'type' %s for key '%s'" % (
                                  type(value).__name__, key))
+
+
+def validate_lambda_architecture(config):
+    # type: (Config) -> None
+    valid_architectures = ['x86_64', 'arm64']
+    if config.lambda_architecture and config.lambda_architecture not in valid_architectures:
+        raise ValueError(
+            "Invalid lambda architecture '%s'. Valid options are: %s" % (
+                config.lambda_architecture, ", ".join(valid_architectures)))

--- a/chalice/templates/0000-rest-api/.chalice/config.json
+++ b/chalice/templates/0000-rest-api/.chalice/config.json
@@ -3,7 +3,8 @@
   "app_name": "{{app_name}}",
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64"
     }
   }
 }

--- a/chalice/templates/0002-s3-event-handler/.chalice/config.json
+++ b/chalice/templates/0002-s3-event-handler/.chalice/config.json
@@ -3,7 +3,8 @@
   "app_name": "{{app_name}}",
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64"
     }
   }
 }

--- a/chalice/templates/0007-lambda-only/.chalice/config.json
+++ b/chalice/templates/0007-lambda-only/.chalice/config.json
@@ -3,7 +3,8 @@
   "app_name": "{{app_name}}",
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64"
     }
   }
 }

--- a/chalice/templates/0009-legacy/.chalice/config.json
+++ b/chalice/templates/0009-legacy/.chalice/config.json
@@ -3,7 +3,8 @@
   "app_name": "{{app_name}}",
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64"
     }
   }
 }

--- a/chalice/templates/6001-cdk-ddb/runtime/.chalice/config.json
+++ b/chalice/templates/6001-cdk-ddb/runtime/.chalice/config.json
@@ -4,6 +4,7 @@
   "stages": {
     "dev": {
       "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64",
       "lambda_functions": {
         "api_handler": {
           "environment_variables": {

--- a/tests/aws/testapp/.chalice/config.json
+++ b/tests/aws/testapp/.chalice/config.json
@@ -4,7 +4,8 @@
       "api_gateway_stage": "api",
       "environment_variables": {
         "APP_NAME": "replaceme"
-      }
+      },
+      "lambda_architecture": "x86_64"
     }
   },
   "version": "2.0",

--- a/tests/aws/testwebsocketapp/.chalice/config.json
+++ b/tests/aws/testwebsocketapp/.chalice/config.json
@@ -4,7 +4,8 @@
   "stages": {
     "dev": {
 	"api_gateway_stage": "api",
-	"environment_variables": {}
+	"environment_variables": {},
+	"lambda_architecture": "x86_64"
     }
   }
 }

--- a/tests/functional/basicapp/.chalice/config.json
+++ b/tests/functional/basicapp/.chalice/config.json
@@ -3,7 +3,8 @@
   "app_name": "basicapp",
   "stages": {
     "dev": {
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "lambda_architecture": "x86_64"
     }
   }
 }

--- a/tests/functional/envapp/.chalice/config.json
+++ b/tests/functional/envapp/.chalice/config.json
@@ -2,7 +2,8 @@
   "stages": {
     "dev": {
       "api_gateway_stage": "api",
-      "environment_variables": {"FOO": "bar"}
+      "environment_variables": {"FOO": "bar"},
+      "lambda_architecture": "x86_64"
     }
   },
   "version": "2.0",


### PR DESCRIPTION
Add support for deployment to the Lambda Python ARM runtime.

* **AWS Client**: Add support for ARM architecture in `create_function` and `update_function` methods in `chalice/awsclient.py`.
* **Configuration**: Add `lambda_architecture` property to `Config` class in `chalice/config.py`.
* **Validation**: Validate `lambda_architecture` parameter in `validate_configuration` function in `chalice/deploy/validate.py`.
* **Templates**: Add `lambda_architecture` parameter to `config.json` in the following templates:
  - `chalice/templates/0000-rest-api/.chalice/config.json`
  - `chalice/templates/0002-s3-event-handler/.chalice/config.json`
  - `chalice/templates/0007-lambda-only/.chalice/config.json`
  - `chalice/templates/0009-legacy/.chalice/config.json`
  - `chalice/templates/6001-cdk-ddb/runtime/.chalice/config.json`
* **Tests**: Add `lambda_architecture` parameter to `config.json` in the following test files:
  - `tests/aws/testapp/.chalice/config.json`
  - `tests/aws/testwebsocketapp/.chalice/config.json`
  - `tests/functional/basicapp/.chalice/config.json`
  - `tests/functional/envapp/.chalice/config.json`

