### PR TITLE
UsageIdentifierKeys added into AuthResponse for use in Built-In Authorizers

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1436,7 +1436,8 @@ class AuthResponse(object):
                                    'PATCH', 'POST', 'PUT', 'GET']
 
     def __init__(self, routes: List[Union[str, 'AuthRoute']],
-                 principal_id: str, context: Optional[Dict[str, str]] = None):
+                 principal_id: str, context: Optional[Dict[str, str]] = None,
+                 usage_identifier_key: Optional[str] = None):
         self.routes: List[Union[str, 'AuthRoute']] = routes
         self.principal_id: str = principal_id
         # The request is used to generate full qualified ARNs
@@ -1445,13 +1446,17 @@ class AuthResponse(object):
         if context is None:
             context = {}
         self.context: Dict[str, str] = context
+        self.usage_identifier_key: Optional[str] = usage_identifier_key
 
     def to_dict(self, request: AuthRequest) -> Dict[str, Any]:
-        return {
+        response = {
             'context': self.context,
             'principalId': self.principal_id,
             'policyDocument': self._generate_policy(request),
         }
+        if self.usage_identifier_key:
+            response['usageIdentifierKey'] = self.usage_identifier_key
+        return response
 
     def _generate_policy(self, request: AuthRequest) -> Dict[str, Any]:
         allowed_resources = self._generate_allowed_resources(request)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -194,6 +194,7 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -194,7 +194,6 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -812,6 +812,11 @@ These classes are used when defining built-in authorizers in Chalice.
       will be accessible in the ``app.current_request.context``
       in all subsequent authorized requests for this user.
 
+   .. attribute:: usage_identifier_key
+
+      An optional string value that represents a usage plan's api
+      key if the ``apiKeySource`` for that plan is set to ``AUTHORIZER``.
+
 .. class:: AuthRoute(path, methods)
 
    This class be used in the ``routes`` attribute of a

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1507,6 +1507,39 @@ def test_root_resource(auth_request):
     }
 
 
+def test_auth_response_with_usage_identifier_key(auth_request):
+    event = {
+        'type': 'TOKEN',
+        'authorizationToken': 'authtoken',
+        'methodArn': 'arn:aws:execute-api:us-west-2:1:id/dev/GET/a',
+    }
+    auth_app = app.Chalice('builtin-auth')
+
+    response = {
+        'context': {},
+        'principalId': 'principal',
+        'policyDocument': {
+            'Version': '2012-10-17',
+            'Statement': [
+                {'Action': 'execute-api:Invoke',
+                 'Effect': 'Allow',
+                 'Resource': [
+                     'arn:aws:execute-api:us-west-2:1:id/dev/*/a'
+                 ]}
+            ]
+        },
+        'usageIdentifierKey': 'api-key'
+    }
+
+    @auth_app.authorizer()
+    def builtin_auth(auth_request):
+        return app.AuthResponse(['/a'], 'principal',
+                                usage_identifier_key='api-key')
+
+    actual = builtin_auth(event, None)
+    assert actual == response
+
+
 def test_can_register_scheduled_event_with_str(sample_app):
     @sample_app.schedule('rate(1 minute)')
     def foo(event):


### PR DESCRIPTION
I added in a `usageIdentifierKey` attribute into the `AuthResponse` class and modified the `to_dict` method to serialize it if it exists. This allows my built-in authorizer to inject API Key values for tracking in Usage Plans. My use case involves translating existing header values into API Keys, instead of forcing my clients to provide an additional header and key.

*Issue #, if available:*

*Description of changes:*
app.py AuthResponse class updated to add the attribute in the contstructor and serialize in the to_dict method.
tests/test_app.py updated to include test case where usageIdentifierKey attribute is used.
docs/api.rst updated to reflect the new attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
