### PR TITLE
Update docs generation script

### DIFF
--- a/scripts/gh-page-docs
+++ b/scripts/gh-page-docs
@@ -41,7 +41,7 @@ echo "Copy docs to local checkout"
 rm -rf "${CHECKOUT_DIR}"
 git clone https://github.com/aws/chalice.git --branch gh-pages \
 	--single-branch ${CHECKOUT_DIR}
-cp -r build/html/* ${CHECKOUT_DIR}/
+rsync -av --delete --exclude '.git' build/html/ ${CHECKOUT_DIR}/
 # Add a .nojekyll file so make sure we don't ignore _static
 # paths.
 touch ${CHECKOUT_DIR}/.nojekyll


### PR DESCRIPTION
The current docs generation script uses cp instead of rsync, so old files that are no longer generated by more recent versions of sphinx remain on the github pages site.  

This updates the command to use rsync instead to remove those old unused files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
