### PR TITLE
docs: remove broken icon link from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,12 +9,6 @@ AWS Chalice
    :target: http://aws.github.io/chalice/?badge=latest
    :alt: Documentation Status
 
-
-.. image:: https://aws.github.io/chalice/_images/chalice-logo-whitespace.png
-   :target: https://aws.github.io/chalice/
-   :alt: Chalice Logo
-
-
 Chalice is a framework for writing serverless apps in python. It allows
 you to quickly create and deploy applications that use AWS Lambda.  It provides:
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removes broken icon link from README. The documentation is still linked below in L98 for users.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
