### PR TITLE
ci: bump stale bot action to latest version

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v4
+    - uses: aws-actions/stale-issue-cleanup@v7.1.0
       with:
         issue-types: issues
         ancient-issue-message: ""


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Stale bot action is set on a fairly old version - update to the latest one made available in March

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
