### PR TITLE
fix: link to chalice logo in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ AWS Chalice
    :alt: Documentation Status
 
 
-.. image:: https://aws.github.io/chalice/_images/chalice-logo-whitespace.png
+.. image:: https://aws.github.io/chalice/_static/img/chalice-logo-whitespace.png
    :target: https://aws.github.io/chalice/
    :alt: Chalice Logo
 


### PR DESCRIPTION
*Description of changes:*

This fixes the link to the logo asset in the README. 

Found https://github.com/aws/chalice/blob/gh-pages/_static/img/chalice-logo-whitespace.png

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
