### PR TITLE
fix: handle broken symlinks in filewatcher initial scan

### DIFF
--- a/chalice/cli/filewatch/stat.py
+++ b/chalice/cli/filewatch/stat.py
@@ -56,7 +56,12 @@ class StatFileWatcher(FileWatcher):
         for rootdir, _, filenames in self._osutils.walk(root_dir):
             for filename in filenames:
                 path = self._osutils.joinpath(rootdir, filename)
-                self._mtime_cache[path] = self._osutils.mtime(path)
+                try:
+                    self._mtime_cache[path] = self._osutils.mtime(path)
+                except (OSError, IOError):
+                    # This can happen with broken symlinks or files that
+                    # disappear between walk() and mtime().
+                    LOGGER.debug("Unable to stat file: %s, skipping.", path)
 
     def _single_pass_poll(self, root_dir, callback):
         # type: (str, Callable[[], None]) -> None

--- a/tests/unit/cli/filewatch/test_stat.py
+++ b/tests/unit/cli/filewatch/test_stat.py
@@ -38,3 +38,42 @@ def test_can_ignore_stat_errors():
         time.sleep(0.2)
     else:
         raise AssertionError("Expected callback to be invoked but was not.")
+
+
+class FakeOSUtilsWithBrokenSymlink(object):
+    """Simulates a broken symlink that fails os.stat during initial cache seed.
+
+    This can happen with symlinks pointing to non-existent files, such as
+    Emacs lock files (.#app.py) or other temporary symlinks.
+    """
+    def __init__(self):
+        self.scan_count = 0
+
+    def walk(self, rootdir):
+        self.scan_count += 1
+        yield 'rootdir', [], ['broken-symlink', 'good-file']
+
+    def joinpath(self, *parts):
+        return os.path.join(*parts)
+
+    def mtime(self, path):
+        if path.endswith('broken-symlink'):
+            raise FileNotFoundError("No such file or directory")
+        return 1
+
+
+def test_can_handle_broken_symlink_during_initial_scan():
+    """Test that broken symlinks during initial cache seeding are handled.
+
+    This is a regression test for issue #997 where symlinks to non-existent
+    files (like Emacs .#app.py files) would crash the file watcher during
+    the initial _seed_mtime_cache call.
+    """
+    osutils = FakeOSUtilsWithBrokenSymlink()
+    watcher = stat.StatFileWatcher(osutils)
+    # This should not raise an exception
+    watcher._seed_mtime_cache('rootdir')
+    # The good file should be in the cache, the broken symlink should not
+    assert len(watcher._mtime_cache) == 1
+    assert 'rootdir/good-file' in watcher._mtime_cache or \
+           os.path.join('rootdir', 'good-file') in watcher._mtime_cache


### PR DESCRIPTION
## Summary

This PR fixes the file watcher crash when encountering broken symlinks during the initial cache seeding phase.

**Problem:** When a directory contains a symlink pointing to a non-existent file (such as Emacs lock files like `.#app.py`), the `_seed_mtime_cache` method would crash with a `FileNotFoundError`, making the file watcher unusable and preventing hot-reloading during development.

**Solution:** Add exception handling to `_seed_mtime_cache` to catch `(OSError, IOError)` when calling `mtime()`, consistent with the existing error handling in `_is_changed_file`. Files that cannot be stat'd are skipped with a debug log message.

## Changes

- `chalice/cli/filewatch/stat.py`: Added try/except block in `_seed_mtime_cache` to handle broken symlinks
- `tests/unit/cli/filewatch/test_stat.py`: Added regression test `test_can_handle_broken_symlink_during_initial_scan`

## Reproduction

```bash
# Create a broken symlink (like Emacs creates)
ln -s /nonexistent/path .#app.py
# Run chalice local - this would crash before this fix
chalice local
```

## Test Plan

- [x] Unit tests pass (`pytest tests/unit/cli/filewatch/test_stat.py`)
- [x] New regression test added that specifically tests broken symlink handling during initial scan
- [x] Manual reproduction confirmed - broken symlinks are now skipped gracefully
- [x] Flake8 passes
- [x] Mypy passes with project configuration
- [x] Pylint score: 10.00/10

Fixes #997

---
*Generated with assistance from Claude Code*