### PR TITLE
Refresh README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ AWS Chalice
    :alt: Documentation Status
 
 
-.. image:: https://aws.github.io/chalice/_images/chalice-logo-whitespace.png
+.. image:: https://aws.github.io/chalice/_static/img/chalice-logo-whitespace.png
    :target: https://aws.github.io/chalice/
    :alt: Chalice Logo
 

--- a/README.rst
+++ b/README.rst
@@ -69,10 +69,11 @@ You can connect a lambda function to an S3 event:
     # Whenever an object is uploaded to 'mybucket'
     # this lambda function will be invoked.
 
-    @app.on_s3_event(bucket='mybucket')
+    @app.on_s3_event(bucket="mybucket")
     def handler(event):
-        print("Object uploaded for bucket: %s, key: %s"
-              % (event.bucket, event.key))
+        print(
+            f"Object uploaded for bucket: {event.bucket}, key: {event.key}"
+        )
 
 As well as an SQS queue:
 
@@ -85,10 +86,10 @@ As well as an SQS queue:
     # Invoke this lambda function whenever a message
     # is sent to the ``my-queue-name`` SQS queue.
 
-    @app.on_sqs_message(queue='my-queue-name')
+    @app.on_sqs_message(queue="my-queue-name")
     def handler(event):
         for record in event:
-            print("Message body: %s" % record.body)
+            print(f"Message body: {record.body}")
 
 
 And several other AWS resources.
@@ -161,7 +162,7 @@ can follow these steps to quickly get started::
 If you want more information on all the supported methods for
 configuring credentials, see the
 `boto3 docs
-<http://boto3.readthedocs.io/en/latest/guide/configuration.html>`__.
+<https://docs.aws.amazon.com/boto3/latest/guide/configuration.html>`__.
 
 
 Creating Your Project
@@ -190,12 +191,12 @@ Let's take a look at the ``app.py`` file:
 
     from chalice import Chalice
 
-    app = Chalice(app_name='helloworld')
+    app = Chalice(app_name="helloworld")
 
 
-    @app.route('/')
+    @app.route("/")
     def index():
-        return {'hello': 'world'}
+        return {"hello": "world"}
 
 
 The ``new-project`` command created a sample app that defines a

--- a/README.rst
+++ b/README.rst
@@ -191,12 +191,12 @@ Let's take a look at the ``app.py`` file:
 
     from chalice import Chalice
 
-    app = Chalice(app_name="helloworld")
+    app = Chalice(app_name='helloworld')
 
 
-    @app.route("/")
+    @app.route('/')
     def index():
-        return {"hello": "world"}
+        return {'hello': 'world'}
 
 
 The ``new-project`` command created a sample app that defines a

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,21 @@
 AWS Chalice
 ===========
 
-.. image:: https://badges.gitter.im/awslabs/chalice.svg
-   :target: https://gitter.im/awslabs/chalice?utm_source=badge&utm_medium=badge
-   :alt: Gitter
+.. image:: http://img.shields.io/pypi/v/chalice.svg?style=flat
+   :target: https://pypi.python.org/pypi/chalice/
+   :alt: Package Version
+
+.. image:: https://img.shields.io/pypi/pyversions/chalice.svg?style=flat
+   :target: https://pypi.python.org/pypi/chalice/
+   :alt: Python Versions
+
 .. image:: https://readthedocs.org/projects/chalice/badge/?version=latest
    :target: http://aws.github.io/chalice/?badge=latest
    :alt: Documentation Status
 
+.. image:: http://img.shields.io/pypi/l/chalice.svg?style=flat
+   :target: https://github.com/aws/chalice/blob/master/LICENSE
+   :alt: License
 
 .. image:: https://aws.github.io/chalice/_static/img/chalice-logo-whitespace.png
    :target: https://aws.github.io/chalice/
@@ -256,5 +264,4 @@ Feedback
 
 We'd also love to hear from you.  Please create any Github issues for
 additional features you'd like to see over at
-https://github.com/aws/chalice/issues.  You can also chat with us
-on gitter: https://gitter.im/awslabs/chalice
+https://github.com/aws/chalice/issues.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 AWS Chalice
 ===========
 
-.. image:: http://img.shields.io/pypi/v/chalice.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/chalice.svg?style=flat
    :target: https://pypi.python.org/pypi/chalice/
    :alt: Package Version
 
@@ -11,10 +11,10 @@ AWS Chalice
    :alt: Python Versions
 
 .. image:: https://readthedocs.org/projects/chalice/badge/?version=latest
-   :target: http://aws.github.io/chalice/?badge=latest
+   :target: https://aws.github.io/chalice/?badge=latest
    :alt: Documentation Status
 
-.. image:: http://img.shields.io/pypi/l/chalice.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/chalice.svg?style=flat
    :target: https://github.com/aws/chalice/blob/master/LICENSE
    :alt: License
 
@@ -23,7 +23,7 @@ AWS Chalice
    :alt: Chalice Logo
 
 
-Chalice is a framework for writing serverless apps in python. It allows
+Chalice is a framework for writing serverless apps in Python. It allows
 you to quickly create and deploy applications that use AWS Lambda.  It provides:
 
 * A command line tool for creating, deploying, and managing your app
@@ -66,7 +66,7 @@ You can connect a lambda function to an S3 event:
 
     app = Chalice(app_name="helloworld")
 
-    # Whenever an object is uploaded to 'mybucket'
+    # Whenever an object is uploaded to "mybucket"
     # this lambda function will be invoked.
 
     @app.on_s3_event(bucket="mybucket")
@@ -101,16 +101,16 @@ and Chalice takes care of deploying your app.
 
     $ chalice deploy
     ...
-    https://endpoint/dev
+    https://endpoint/api
 
     $ curl https://endpoint/api
     {"hello": "world"}
 
 Up and running in less than 30 seconds.
-Give this project a try and share your feedback with us here on Github.
+Give this project a try and share your feedback with us here on GitHub.
 
 The documentation is available
-`here <http://aws.github.io/chalice/>`__.
+`here <https://aws.github.io/chalice/>`__.
 
 Quickstart
 ==========
@@ -119,8 +119,8 @@ Quickstart
 
 In this tutorial, you'll use the ``chalice`` command line utility
 to create and deploy a basic REST API.  This quickstart uses Python 3.10,
-but AWS Chalice supports all versions of python supported by AWS Lambda,
-which includes Python 3.10 through python 3.14.
+but AWS Chalice supports all versions of Python supported by AWS Lambda,
+which includes Python 3.10 through Python 3.14.
 
 To install Chalice, we'll first create and activate a virtual environment
 in python3.10::
@@ -216,12 +216,12 @@ directory and run ``chalice deploy``::
     Creating lambda function: helloworld-dev
     Creating Rest API
     Resources deployed:
-      - Lambda ARN: arn:aws:lambda:us-west-2:12345:function:helloworld-dev
+      - Lambda ARN: arn:aws:lambda:us-west-2:123456789012:function:helloworld-dev
       - Rest API URL: https://abcd.execute-api.us-west-2.amazonaws.com/api/
 
 You now have an API up and running using API Gateway and Lambda::
 
-    $ curl https://qxea58oupc.execute-api.us-west-2.amazonaws.com/api/
+    $ curl https://abcd.execute-api.us-west-2.amazonaws.com/api/
     {"hello": "world"}
 
 Try making a change to the returned dictionary from the ``index()``
@@ -256,13 +256,13 @@ it created when running the ``chalice deploy`` command.
 
     $ chalice delete
     Deleting Rest API: abcd4kwyl4
-    Deleting function aws:arn:lambda:region:123456789:helloworld-dev
+    Deleting function arn:aws:lambda:region:123456789012:function:helloworld-dev
     Deleting IAM Role helloworld-dev
 
 
 Feedback
 ========
 
-We'd also love to hear from you.  Please create any Github issues for
+We'd also love to hear from you.  Please create any GitHub issues for
 additional features you'd like to see over at
 https://github.com/aws/chalice/issues.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -16,7 +16,7 @@ it created when running the ``chalice deploy`` command.
 
     $ chalice delete
     Deleting Rest API: abcd4kwyl4
-    Deleting function aws:arn:lambda:region:123456789:helloworld-dev
+    Deleting function arn:aws:lambda:region:123456789012:function:helloworld-dev
     Deleting IAM Role helloworld-dev
 
 


### PR DESCRIPTION
> [!NOTE]
> This PR builds on top of and conflicts with https://github.com/aws/chalice/pull/2162 and https://github.com/aws/chalice/pull/2163 so it should be merged after. This diff will minimize after they are merged. 

Addresses https://github.com/aws/chalice/pull/2151 and https://github.com/aws/chalice/pull/2142

## Summary
Quick refresh of `README.rst`:

- **Badges**: drop dead Gitter badge; add PyPI version, supported Python versions, and license badges
- **Logo**: fix broken logo image link
- **Links**: switch to HTTPS for shields.io badges, the docs link, and the readthedocs target; update the boto3 configuration docs link to its current home on docs.aws.amazon.com
- **Examples**: normalize illustrative code snippets to double quotes and f-strings; keep the "Let's take a look at the `app.py` file" block on single quotes so it matches what `chalice new-project` actually writes
- **Walkthrough fixes**: repair malformed ARN in the `chalice delete` example, use a 12-digit placeholder account ID, align the deploy-output stage name with the rest of the doc (`/api`), and reuse the `abcd...` placeholder host instead of a hardcoded one

## Testing
- [x] Render `README.rst` on GitHub and confirm badges, logo, and external links resolve
<img width="915" height="555" alt="Screenshot 2026-05-02 at 5 37 49 PM" src="https://github.com/user-attachments/assets/b28a9fc8-b942-4b2e-a45d-e16f6bf35fa7" />

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
