### PR TITLE
Harden and update GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
   allow:
   - dependency-name: pip
   - dependency-name: click
+  cooldown:
+    default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,30 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/."
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-name: pip
-  - dependency-name: click
-  cooldown:
-    default-days: 7
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    allow:
+      - dependency-name: "pip"
+      - dependency-name: "click"
+    groups:
+      python:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
       - "feature/**"
+permissions:
+  contents: read
 jobs:
   prcheck:
     runs-on: ${{ matrix.os }}
@@ -19,8 +21,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Set up Python ${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}
@@ -35,11 +39,13 @@ jobs:
       matrix:
         python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Set up Python ${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -2,14 +2,16 @@ name: "Close stale issues"
 
 on:
   schedule:
-    - cron: "*/60 * * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v4
+    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440 # v7.1.1
       with:
         issue-types: issues
         ancient-issue-message: ""


### PR DESCRIPTION
## Overview

This PR updates GitHub Actions dependencies to their latest versions, hardens workflow security, and tightens the Dependabot update cadence.

## Changes

- Update and pin actions to commit SHAs: All actions are upgraded to their latest versions and pinned to exact commit hashes, preventing supply chain attacks via tag mutation:
  - actions/checkout: v2 → v6.0.2
  - actions/setup-python: v6 → v6.2.0
  - actions/setup-node: v6 → v6.4.0
  - aws-actions/stale-issue-cleanup: v4 → v7.1.1
- Add `persist-credentials: false`: Checkout steps no longer persist Git credentials in the workspace, reducing the blast radius of a compromised step.
- Scope workflow permissions: `run-tests.yml` now declares `permissions: contents: read` at the workflow level; `stale-issue.yml` scopes the job to `issues: write only`.
- Fix stale-issue cron schedule: Corrected the schedule from `*/60 * * * *` (every hour) to 0 0 * * * (daily).
- Add Dependabot 7-day cooldown: New updates won't be proposed until a dependency has been available for at least 7 days, reducing noise from short-lived or yanked releases.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
