### PR TITLE
Fix logs --since for non-follow mode

### DIFF
--- a/.changes/next-release/1968449060970458-bugfix-logs-80150.json
+++ b/.changes/next-release/1968449060970458-bugfix-logs-80150.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "logs",
+  "description": "Respect the `--since` option when retrieving logs without `--follow`."
+}

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -1414,9 +1414,13 @@ class TypedAWSClient(object):
     ) -> Iterator[CWLogEvent]:
         logs = self._client('logs')
         paginator = logs.get_paginator('filter_log_events')
-        pages = paginator.paginate(
-            logGroupName=log_group_name, interleaved=True
-        )
+        kwargs = {
+            'logGroupName': log_group_name,
+            'interleaved': interleaved,
+        }
+        if start_time is not None:
+            kwargs['startTime'] = int(datetime2timestamp(start_time) * 1000)
+        pages = paginator.paginate(**kwargs)
         try:
             yield from self._iter_log_messages(pages)
         except logs.exceptions.ResourceNotFoundException:

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -157,7 +157,8 @@ def test_can_provide_optional_start_time_iter_logs(stubbed_session):
     # because the loss of precision in sub ms time.
     datetime_now = datetime.datetime.utcfromtimestamp(timestamp / 1000.0)
     stubbed_session.stub('logs').filter_log_events(
-        logGroupName='loggroup', interleaved=True).returns({
+        logGroupName='loggroup', interleaved=True,
+        startTime=timestamp).returns({
             "events": [{
                 "logStreamName": "logStreamName",
                 "timestamp": timestamp,


### PR DESCRIPTION
Fixes https://github.com/aws/chalice/issues/2144

## Overview
This PR fixes `chalice logs --since` when running without `--follow`.

Previously, `--since` was parsed correctly but ignored by the non-follow log retrieval path, causing `chalice logs --since ...` to return older CloudWatch log events. The follow path worked because it already passed `startTime` to CloudWatch.

## Summary
* Pass `startTime` through the `iter_log_events()` CloudWatch paginator call.
* Add regression coverage to verify `startTime` is sent for non-follow log retrieval.
* Add a jmeslog bugfix entry.

## Testing
* `python -m pytest tests/functional/test_awsclient.py -k log tests/unit/test_logs.py`


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
