### PR TITLE
Upgrade doc8 to fix release infra failures on Python 3.12+

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,6 @@
 -r requirements-test.in
 pylint<4.0.0
-doc8<1.0.0
+doc8<2.0.0
 pydocstyle
 flake8
 Sphinx==8.1.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ coverage[toml]==7.6.1
     #   pytest-cov
 dill==0.3.9
     # via pylint
-doc8==0.11.2
+doc8==1.1.2
     # via -r requirements-dev.in
 docutils==0.21.2
     # via
@@ -72,8 +72,6 @@ packaging==24.2
     # via
     #   pytest
     #   sphinx
-pbr==6.1.0
-    # via stevedore
 platformdirs==4.3.6
     # via pylint
 pluggy==1.5.0
@@ -131,11 +129,12 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 standard-imghdr==3.13.0
     # via -r requirements-dev.in
-stevedore==5.3.0
+stevedore==5.7.0
     # via doc8
 tomli==2.1.0
     # via
     #   coverage
+    #   doc8
     #   mypy
     #   pylint
     #   pytest


### PR DESCRIPTION
## Problem

Certain Python 3.12+ environments will fail with the following failure:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

The root cause is `pbr`, a transitive dev dependency pulled in via `doc8`  -> `stevedore`. `pbr` registers a setuptools `egg_info.writers` entry point that unconditionally imports `pkg_resources`, which was removed in setuptools 82+. ([src](https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals))When chalice's packager tests invoke `setup.py egg_info` in a subprocess, this entry point fires and crashes the process before metadata is written.

The issue does not reproduce in all environments. On some platforms setuptools writes PKG-INFO before the entry point executes, masking the failure.

## Fix

Upgrade `doc8` from 0.11.2 to 1.1.2. The newer versions have dropped their dependency on pbr ([ref](https://github.com/PyCQA/doc8/pull/119/changes))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
