### PR TITLE
Refresh test dependencies to fix coverage OOM

### DIFF
--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -165,7 +165,7 @@ class Boto3ClientMethodCallType(Boto3ClientMethodType):
 
 class TypedSymbol(symtable.Symbol):
     inferred_type = None  # type: Any
-    ast_node = None  # type: ast.AST
+    ast_node = None  # type: Optional[ast.AST]
 
 
 class FunctionType(BaseType):
@@ -308,11 +308,11 @@ class ChainedSymbolTable(object):
         symbol = self._local_table.lookup(name)
         if symbol.is_global():
             symbol = self._global_table.lookup(name)
-        try:
-            return cast(TypedSymbol, symbol).ast_node
-        except AttributeError:
+        ast_node = getattr(cast(TypedSymbol, symbol), 'ast_node', None)
+        if ast_node is None:
             raise ValueError(
                 "No AST node registered for symbol: %s" % name)
+        return ast_node
 
     def has_ast_node_for_symbol(self, name):
         # type: (str) -> bool

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -123,7 +123,7 @@ class ResourceBuilder(object):
 
 
 class TemplateGenerator(object):
-    template_file = None  # type: str
+    template_file = None  # type: Optional[str]
 
     def __init__(self, config, options):
         # type: (Config, PackageOptions) -> None
@@ -1488,8 +1488,11 @@ class AppPackager(object):
             template, config, outdir, chalice_stage_name)
         contents = self._template_serializer.serialize_template(template)
         extension = self._template_serializer.file_extension
+        template_file = self._templater.template_file
+        if template_file is None:
+            raise RuntimeError("No template file configured for packager.")
         filename = os.path.join(
-            outdir, self._templater.template_file) + '.' + extension
+            outdir, template_file) + '.' + extension
         self._osutils.set_file_contents(
             filename=filename,
             contents=contents,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,27 +6,27 @@
 #
 alabaster==1.0.0
     # via sphinx
-astroid==3.3.10
+ast-serialize==0.3.0
+    # via mypy
+astroid==3.3.11
     # via pylint
-attrs==24.2.0
-    # via hypothesis
-babel==2.16.0
+babel==2.18.0
     # via sphinx
-boto3==1.35.66
+boto3==1.43.5
     # via -r requirements-test.in
-botocore==1.35.66
+botocore==1.43.5
     # via
     #   boto3
     #   s3transfer
-certifi==2024.8.30
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.7
     # via requests
-coverage[toml]==7.6.1
+coverage[toml]==7.13.5
     # via
     #   -r requirements-test.in
     #   pytest-cov
-dill==0.3.9
+dill==0.4.1
     # via pylint
 doc8==1.1.2
     # via -r requirements-dev.in
@@ -36,78 +36,86 @@ docutils==0.21.2
     #   doc8
     #   restructuredtext-lint
     #   sphinx
-exceptiongroup==1.2.2
+exceptiongroup==1.3.1
     # via
     #   hypothesis
     #   pytest
-flake8==7.1.1
+flake8==7.3.0
     # via -r requirements-dev.in
-hypothesis==6.113.0
+hypothesis==6.152.4
     # via -r requirements-test.in
-idna==3.10
+idna==3.13
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-isort==5.13.2
+isort==6.1.0
     # via pylint
-jinja2==3.1.4
+jinja2==3.1.6
     # via sphinx
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-markupsafe==2.1.5
+librt==0.10.0
+    # via mypy
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.13.0
+mypy==2.0.0
     # via -r requirements-dev.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
-packaging==24.2
+packaging==26.2
     # via
     #   pytest
     #   sphinx
-platformdirs==4.3.6
+    #   wheel
+pathspec==1.1.1
+    # via mypy
+platformdirs==4.9.6
     # via pylint
-pluggy==1.5.0
-    # via pytest
-pycodestyle==2.12.1
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+pycodestyle==2.14.0
     # via flake8
 pydocstyle==6.3.0
     # via -r requirements-dev.in
-pyflakes==3.2.0
+pyflakes==3.4.0
     # via flake8
-pygments==2.18.0
+pygments==2.20.0
     # via
     #   -r requirements-dev.in
     #   doc8
+    #   pytest
     #   sphinx
-pylint==3.3.7
+pylint==3.3.9
     # via -r requirements-dev.in
-pytest==8.3.3
+pytest==9.0.3
     # via
     #   -r requirements-test.in
     #   pytest-cov
-pytest-cov==5.0.0
+pytest-cov==7.1.0
     # via -r requirements-test.in
 python-dateutil==2.9.0.post0
     # via botocore
-requests==2.32.3
+requests==2.33.1
     # via
     #   -r requirements-test.in
     #   sphinx
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
-s3transfer==0.10.4
+s3transfer==0.17.0
     # via boto3
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via
     #   pydocstyle
     #   sphinx
@@ -131,7 +139,7 @@ standard-imghdr==3.13.0
     # via -r requirements-dev.in
 stevedore==5.7.0
     # via doc8
-tomli==2.1.0
+tomli==2.4.1
     # via
     #   coverage
     #   doc8
@@ -139,23 +147,24 @@ tomli==2.1.0
     #   pylint
     #   pytest
     #   sphinx
-tomlkit==0.13.2
+tomlkit==0.14.0
     # via pylint
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20260408
     # via -r requirements-dev.in
-types-pyyaml==6.0.12.20240917
+types-pyyaml==6.0.12.20260408
     # via -r requirements-dev.in
-types-six==1.16.21.20241105
+types-six==1.17.0.20260408
     # via -r requirements-dev.in
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   astroid
+    #   exceptiongroup
     #   mypy
-urllib3==1.26.20
+urllib3==2.6.3
     # via
     #   botocore
     #   requests
-websocket-client==1.8.0
+websocket-client==1.9.0
     # via -r requirements-test.in
-wheel==0.45.0
+wheel==0.47.0
     # via -r requirements-dev.in

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,63 +4,67 @@
 #
 #    pip-compile --output-file=requirements-test.txt requirements-test.in
 #
-attrs==23.1.0
-    # via hypothesis
-boto3==1.33.13
+boto3==1.43.5
     # via -r requirements-test.in
-botocore==1.33.13
+botocore==1.43.5
     # via
     #   boto3
     #   s3transfer
-certifi==2023.11.17
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.7
     # via requests
-coverage[toml]==7.2.7
+coverage[toml]==7.13.5
     # via
     #   -r requirements-test.in
     #   pytest-cov
-exceptiongroup==1.2.0
+exceptiongroup==1.3.1
     # via
     #   hypothesis
     #   pytest
-hypothesis==6.79.4
+hypothesis==6.152.4
     # via -r requirements-test.in
-idna==3.6
+idna==3.13
     # via requests
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-packaging==23.2
+packaging==26.2
     # via pytest
-pluggy==1.2.0
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+pygments==2.20.0
     # via pytest
-pytest==7.4.3
+pytest==9.0.3
     # via
     #   -r requirements-test.in
     #   pytest-cov
-pytest-cov==4.1.0
+pytest-cov==7.1.0
     # via -r requirements-test.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via botocore
-requests==2.31.0
+requests==2.33.1
     # via -r requirements-test.in
-s3transfer==0.8.2
+s3transfer==0.17.0
     # via boto3
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-tomli==2.0.1
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.18
+typing-extensions==4.15.0
+    # via exceptiongroup
+urllib3==2.6.3
     # via
     #   botocore
     #   requests
-websocket-client==1.6.1
+websocket-client==1.9.0
     # via -r requirements-test.in


### PR DESCRIPTION
## Overview
This PR refreshes the test and dev dependency lockfiles, including updating `coverage` and `pytest-cov`, to address Python 3.14 `make prcheck` runs being OOM-killed during coverage collection.

## Summary
- Updates `requirements-dev.txt` and `requirements-test.txt` to current resolved test dependencies.
- Bumps `coverage` to `7.13.5`, which includes Python 3.14 support and memory-related fixes.
- Updates type annotations needed for the newer `mypy` release.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
